### PR TITLE
chore(python): run every Python command from a project virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
             exit 0
           fi
 
-          python scripts/detect_changed_surfaces.py \
+          make venv PYTHON_BASE=python
+          .venv/bin/python scripts/detect_changed_surfaces.py \
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
             --github-output "$GITHUB_OUTPUT"
@@ -116,7 +117,7 @@ jobs:
           python-version: '3.11'
 
       - name: Validate env contract
-        run: make env-contract-check PYTHON=python
+        run: make env-contract-check PYTHON_BASE=python
 
   script-tests:
     name: Script Guardrail Tests
@@ -133,7 +134,7 @@ jobs:
           python-version: '3.11'
 
       - name: Run script tests
-        run: make test-scripts PYTHON=python
+        run: make test-scripts PYTHON_BASE=python
 
   docs-ci:
     name: Documentation and Agent Doc Checks
@@ -150,7 +151,7 @@ jobs:
           python-version: '3.11'
 
       - name: Verify docs links and AGENTS.md pointers
-        run: make docs-check PYTHON=python
+        run: make docs-check PYTHON_BASE=python
 
   web-ci:
     name: Web App CI
@@ -174,7 +175,7 @@ jobs:
           python-version: '3.11'
 
       - name: Toolchain preflight
-        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON=python
+        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON_BASE=python
 
       - name: Install dependencies
         env:
@@ -211,19 +212,17 @@ jobs:
             services/chat/constraints.txt
 
       - name: Toolchain preflight
-        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON=python
+        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON_BASE=python
 
       - name: Install dependencies
-        run: make -C services/chat setup PYTHON=python
+        run: make -C services/chat setup PYTHON_BASE=python
 
       - name: Generate Prisma Client (Python)
-        run: |
-          prisma-client-py generate --schema=${{ github.workspace }}/apps/web/prisma/schema.prisma
+        run: make prisma-generate-chat PYTHON_BASE=python
 
       - name: Run unit tests
         run: npm run ci:chat
         env:
-          PYTHON: python
           PROJECT_ID: local-project
           REGION: us-central1
 
@@ -286,7 +285,7 @@ jobs:
         run: |
           start_epoch="$(date +%s)"
           make e2e-smoke-lite \
-            PYTHON=python \
+            PYTHON_BASE=python \
             KEEP_STACK=1 \
             E2E_SMOKE_TIMEOUT="${E2E_SMOKE_TIMEOUT}" \
             CHAT_INSTALL_LOCAL_STACK=0 \
@@ -515,7 +514,7 @@ jobs:
         run: |
           start_epoch="$(date +%s)"
           make e2e-smoke-full \
-            PYTHON=python \
+            PYTHON_BASE=python \
             KEEP_STACK=1 \
             E2E_SMOKE_TIMEOUT="${E2E_SMOKE_TIMEOUT}" \
             E2E_COMPOSE_UP_FLAGS="-d --force-recreate --quiet-pull"
@@ -962,7 +961,7 @@ jobs:
         env:
           TOOLCHAIN_CHECK_ALLOW_NON_MISE: '1'
           HUSKY: '0'
-        run: make bootstrap PYTHON=python
+        run: make bootstrap PYTHON_BASE=python
 
   full-ci-main:
     name: Full CI (Main Branch)
@@ -994,7 +993,7 @@ jobs:
             services/chat/constraints.txt
 
       - name: Toolchain preflight
-        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON=python
+        run: TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 make toolchain-doctor PYTHON_BASE=python
 
       - name: Install web dependencies
         env:
@@ -1002,10 +1001,10 @@ jobs:
         run: make -C apps/web setup
 
       - name: Install chat dependencies
-        run: make -C services/chat setup PYTHON=python
+        run: make -C services/chat setup PYTHON_BASE=python
 
       - name: Generate Prisma Client (Python)
-        run: prisma-client-py generate --schema=${{ github.workspace }}/apps/web/prisma/schema.prisma
+        run: make prisma-generate-chat PYTHON_BASE=python
 
       - name: Run full CI checks
         env:
@@ -1013,4 +1012,4 @@ jobs:
           HUSKY: '0'
           PROJECT_ID: local-project
           REGION: us-central1
-        run: make ci PYTHON=python
+        run: make ci PYTHON_BASE=python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           TOOLCHAIN_CHECK_ALLOW_NON_MISE: "1"
           HUSKY: "0"
-        run: make release-dry-run PYTHON=python RELEASE_TAG="${RELEASE_TAG}"
+        run: make release-dry-run PYTHON_BASE=python RELEASE_TAG="${RELEASE_TAG}"
 
   draft:
     name: Draft GitHub Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,24 @@ Use `mise` at repo root before running setup/CI commands:
 mise install
 ```
 
+### Python virtualenv
+
+All Python runs from a single project virtualenv at `.venv` (git-ignored). Make
+targets create it on demand and invoke `.venv/bin/python` directly, so there is
+nothing to activate — `make test-scripts`, `make quick-ci-chat`, and friends all
+work from a clean shell.
+
+```bash
+make venv
+```
+
+Never install project Python dependencies into a system or mise interpreter. If
+you run Python by hand, use `.venv/bin/python`, not `python`/`python3`.
+
+`PYTHON_BASE` is the interpreter used to *create* the venv (default
+`mise exec python@3.11 -- python`); CI overrides it with `PYTHON_BASE=python`.
+Do not override `PYTHON` itself — that bypasses the venv.
+
 ## Canonical commands
 
 Run from repository root:
@@ -69,6 +87,7 @@ Run from repository root:
 ```bash
 make help
 make bootstrap
+make venv
 make toolchain-doctor
 make env-contract-check
 make agent-doctor
@@ -166,6 +185,8 @@ Copy templates to `.env` before local development.
 ## Troubleshooting
 
 - Toolchain mismatch: run `mise install`, then `make toolchain-doctor`.
+- Virtualenv missing, broken, or on the wrong Python: run `rm -rf .venv && make venv`.
+- `ModuleNotFoundError` for a chat dependency: you are probably outside the venv — re-run through `make`, or use `.venv/bin/python`.
 - Env contract drift: run `make env-contract-check` and update contract/templates/docs together.
 - Docs link drift (including root runbooks): run `make docs-check`.
 - Agent doc drift (a `CLAUDE.md`, `GEMINI.md`, or `.github/copilot-instructions.md` gained content): move the flagged lines into the matching `AGENTS.md`, then run `make agent-docs-check FIX=1`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ Refer to:
 ### Quick Troubleshooting
 
 - If runtime checks fail, run `mise install` then `make toolchain-doctor`.
+- All Python runs from the `.venv` virtualenv created by `make venv`/`make bootstrap`; if a dependency looks missing, re-run the command through `make` rather than a system `python`.
 - If env contract drift check fails, run `make env-contract-check` and align `config/env_contract.json`, env templates, and `docs/ENV_CONTRACT.md`.
 - If env checks fail, run `make env-init` and fill required values in `.env` files.
 - If chat Prisma client checks fail, run `make prisma-generate-chat`.

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,18 @@ SHELL := /bin/bash
 
 DOCKER_COMPOSE ?= docker compose
 NPM ?= npm
-PYTHON ?= mise exec python@3.11 -- python
-PIP ?= pip3
+
+# All Python runs from the project virtualenv. PYTHON_BASE is only used to
+# create it (override to `python` where mise is unavailable, e.g. CI).
+VENV_DIR ?= .venv
+VENV_PYTHON := $(VENV_DIR)/bin/python
+PYTHON_BASE ?= mise exec python@3.11 -- python
+PYTHON ?= $(VENV_PYTHON)
+PIP ?= $(PYTHON) -m pip
+
+# Put the venv's bin dir first so console scripts installed into it resolve
+# without activation (prisma-client-py, ruff, mypy, pytest, uvicorn).
+export PATH := $(abspath $(VENV_DIR))/bin:$(PATH)
 TOOLCHAIN_CHECK_SCRIPT := scripts/check_toolchain.py
 AGENT_DOCTOR_SCRIPT := scripts/agent_doctor.py
 ENV_CONTRACT_CHECK_SCRIPT := scripts/check_env_contract.py
@@ -30,18 +40,26 @@ CHAT_ENV_TEMPLATE := $(CHAT_DIR)/.env.example
 
 .DEFAULT_GOAL := help
 
-.PHONY: help toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate prisma-generate-chat lint typecheck test test-scripts test-web test-chat test-chat-integration build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
+.PHONY: help venv toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate prisma-generate-chat lint typecheck test test-scripts test-web test-chat test-chat-integration build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
 
 help: ## Show available tasks
 	@awk 'BEGIN {FS = ":.*##"; printf "\nAvailable tasks:\n\n"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-24s %s\n", $$1, $$2} END {print ""}' $(MAKEFILE_LIST)
 
-toolchain-doctor: ## Verify local toolchain matches project baseline
+$(VENV_PYTHON):
+	@echo "Creating Python virtualenv in $(VENV_DIR)..."
+	$(PYTHON_BASE) -m venv $(VENV_DIR)
+	$(VENV_PYTHON) -m pip install --quiet --upgrade pip
+
+venv: $(VENV_PYTHON) ## Create the project Python virtualenv (.venv)
+	@$(VENV_PYTHON) -c "import sys; print(f'Virtualenv ready: {sys.executable} ({sys.version.split()[0]})')"
+
+toolchain-doctor: | $(VENV_PYTHON) ## Verify local toolchain matches project baseline
 	$(PYTHON) $(TOOLCHAIN_CHECK_SCRIPT)
 
-env-contract-check: ## Verify env contract matches templates and docs
+env-contract-check: | $(VENV_PYTHON) ## Verify env contract matches templates and docs
 	$(PYTHON) $(ENV_CONTRACT_CHECK_SCRIPT)
 
-agent-doctor: ## Verify agent-local environment is fully ready
+agent-doctor: | $(VENV_PYTHON) ## Verify agent-local environment is fully ready
 	$(PYTHON) $(AGENT_DOCTOR_SCRIPT)
 
 env-init: ## Create local .env files from templates when missing
@@ -49,6 +67,7 @@ env-init: ## Create local .env files from templates when missing
 	@if [ ! -f "$(CHAT_ENV_FILE)" ]; then cp "$(CHAT_ENV_TEMPLATE)" "$(CHAT_ENV_FILE)"; echo "Created $(CHAT_ENV_FILE) from $(CHAT_ENV_TEMPLATE)."; else echo "$(CHAT_ENV_FILE) already exists."; fi
 
 bootstrap: ## One-command bootstrap for local and coding-agent development
+	$(MAKE) venv
 	$(MAKE) toolchain-doctor
 	$(MAKE) env-contract-check
 	$(MAKE) env-init
@@ -124,7 +143,7 @@ migrate: ## Run Prisma migrations using DATABASE_URL
 prisma-generate: ## Generate Prisma client for the web app
 	$(WEB_MAKE) prisma-generate
 
-prisma-generate-chat: ## Generate Prisma client for the chat Python runtime
+prisma-generate-chat: | $(VENV_PYTHON) ## Generate Prisma client for the chat Python runtime
 	$(PYTHON) -m prisma py generate --schema=$(WEB_PRISMA_SCHEMA) --generator pyclient
 
 lint: ## Lint web app
@@ -137,7 +156,7 @@ test: ## Run web tests and chat unit tests
 	$(MAKE) test-web
 	$(MAKE) test-chat
 
-test-scripts: ## Run root script guardrail tests
+test-scripts: | $(VENV_PYTHON) ## Run root script guardrail tests
 	$(PYTHON) -m unittest discover -s tests/scripts -p "test_*.py" -v
 
 test-web: ## Run web tests
@@ -164,7 +183,7 @@ quick-ci: ## Fast local checks for web + chat (no web build)
 	$(MAKE) quick-ci-web
 	$(MAKE) quick-ci-chat
 
-quick-ci-changed: ## Fast local checks scoped to changed files (set CHANGED_BASE/CHANGED_HEAD for git range)
+quick-ci-changed: | $(VENV_PYTHON) ## Fast local checks scoped to changed files (set CHANGED_BASE/CHANGED_HEAD for git range)
 	@set -euo pipefail; \
 	TARGETS="$$(CHANGED_BASE="$(CHANGED_BASE)" CHANGED_HEAD="$(CHANGED_HEAD)" $(PYTHON) $(CHANGED_SURFACES_SCRIPT) --print-targets)"; \
 	if [ -z "$$TARGETS" ]; then \
@@ -176,7 +195,7 @@ quick-ci-changed: ## Fast local checks scoped to changed files (set CHANGED_BASE
 		$(MAKE) $$target; \
 	done
 
-e2e-smoke: ## Run dockerized end-to-end smoke check (web -> chat -> db)
+e2e-smoke: | $(VENV_PYTHON) ## Run dockerized end-to-end smoke check (web -> chat -> db)
 	@set -euo pipefail; \
 	keep_stack="$(KEEP_STACK)"; \
 	cleanup() { \
@@ -201,17 +220,17 @@ e2e-smoke-lite: ## Run dockerized contract smoke with minimal chat dependency pr
 e2e-smoke-full: ## Run dockerized smoke with full chat dependency profile
 	$(MAKE) e2e-smoke CHAT_INSTALL_LOCAL_STACK=1
 
-release-dry-run: ## Validate release prerequisites without publishing
+release-dry-run: | $(VENV_PYTHON) ## Validate release prerequisites without publishing
 	$(PYTHON) $(RELEASE_DRY_RUN_SCRIPT) $(if $(RELEASE_TAG),--tag "$(RELEASE_TAG)",)
 	TOOLCHAIN_CHECK_ALLOW_NON_MISE=1 $(MAKE) quick-ci
 	$(MAKE) test-scripts
 	$(MAKE) docs-check
 
-docs-check: ## Validate docs links and agent doc pointers
+docs-check: | $(VENV_PYTHON) ## Validate docs links and agent doc pointers
 	$(PYTHON) scripts/verify_docs.py
 	$(MAKE) agent-docs-check
 
-agent-docs-check: ## Verify CLAUDE.md/GEMINI.md/copilot-instructions.md stay pointers to AGENTS.md (set FIX=1 to restore)
+agent-docs-check: | $(VENV_PYTHON) ## Verify CLAUDE.md/GEMINI.md/copilot-instructions.md stay pointers to AGENTS.md (set FIX=1 to restore)
 	$(PYTHON) scripts/check_agent_docs.py $(if $(FIX),--fix,)
 
 ci: ## Run local CI checks

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ This repo uses `mise` for local runtime pinning:
 mise install
 ```
 
+All Python runs from a project virtualenv at `.venv` (git-ignored). `make bootstrap`
+creates it, and every Make target invokes `.venv/bin/python` directly — there is
+nothing to activate. To create it on its own:
+
+```bash
+make venv
+```
+
 ### Option 1: Run Everything Locally (Docker)
 **Best for:** Trying out the application quickly without installing dependencies.
 
@@ -120,6 +128,7 @@ The repository now includes a root `Makefile` for a consistent command surface:
 ```bash
 make help
 make bootstrap
+make venv
 make toolchain-doctor
 make env-contract-check
 make agent-doctor
@@ -217,6 +226,8 @@ PR CI uses changed-scope checks (same detector logic as `make quick-ci-changed`)
 
 - `make toolchain-doctor` fails:
 Run `mise install`, then retry `make bootstrap`.
+- Python dependency missing or `.venv` is on the wrong version:
+Run `rm -rf .venv && make venv`, then `make setup-chat`. If you invoke Python directly, use `.venv/bin/python`.
 - `make env-contract-check` fails:
 Update `config/env_contract.json`, env templates, and `docs/ENV_CONTRACT.md` so they match.
 - `make docs-check` fails:

--- a/scripts/agent_doctor.py
+++ b/scripts/agent_doctor.py
@@ -12,6 +12,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parent.parent
 
 TOOLCHAIN_CHECK = ROOT / "scripts/check_toolchain.py"
+VENV_DIR = ROOT / ".venv"
+VENV_PYTHON = VENV_DIR / "bin/python"
 ENV_CONTRACT = ROOT / "config/env_contract.json"
 ROOT_ENV = ROOT / ".env"
 CHAT_ENV = ROOT / "services/chat/.env"
@@ -81,6 +83,31 @@ def main() -> int:
     passes: list[str] = []
     warnings: list[str] = []
     failures: list[tuple[str, str]] = []
+
+    # Project virtualenv: every Python command must run from .venv
+    if not VENV_PYTHON.exists():
+        failures.append(
+            (
+                "Project virtualenv is missing (.venv).",
+                "Run `make venv` (or `make bootstrap`).",
+            ),
+        )
+    elif Path(sys.executable).resolve() != VENV_PYTHON.resolve():
+        failures.append(
+            (
+                f"Running outside the project virtualenv: {sys.executable}",
+                "Run agent-doctor via `make agent-doctor` so it uses .venv/bin/python.",
+            ),
+        )
+    elif sys.prefix == sys.base_prefix:
+        failures.append(
+            (
+                ".venv/bin/python is not an isolated virtualenv.",
+                "Delete .venv and run `make venv`.",
+            ),
+        )
+    else:
+        passes.append("Running inside the project virtualenv (.venv).")
 
     # Runtime parity
     toolchain = run([sys.executable, str(TOOLCHAIN_CHECK)])

--- a/scripts/check_toolchain.py
+++ b/scripts/check_toolchain.py
@@ -7,9 +7,13 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 EXPECTED_NODE_MAJOR = 22
 EXPECTED_PYTHON_MAJOR_MINOR = (3, 11)
+
+ROOT = Path(__file__).resolve().parent.parent
+VENV_PYTHON = ROOT / ".venv/bin/python"
 
 
 def run(cmd: list[str]) -> str:
@@ -76,6 +80,25 @@ def main() -> int:
         except Exception as exc:  # noqa: BLE001
             errors.append(str(exc))
 
+    venv_status = "not created"
+    if VENV_PYTHON.exists():
+        try:
+            venv_version = run([str(VENV_PYTHON), "--version"])
+            venv_major_minor = parse_python_major_minor(venv_version)
+            if venv_major_minor != EXPECTED_PYTHON_MAJOR_MINOR:
+                errors.append(
+                    "Project virtualenv runs "
+                    f"{venv_version}, expected Python "
+                    f"{EXPECTED_PYTHON_MAJOR_MINOR[0]}.{EXPECTED_PYTHON_MAJOR_MINOR[1]}.x. "
+                    "Delete .venv and run `make venv`."
+                )
+                venv_status = f"{venv_version} (wrong version)"
+            else:
+                venv_status = venv_version
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"Unable to inspect project virtualenv: {exc}")
+            venv_status = "unusable"
+
     if errors:
         print("Toolchain check failed:")
         for err in errors:
@@ -85,7 +108,8 @@ def main() -> int:
 
     print(
         "Toolchain check passed: "
-        f"Node {node_version}, Python {python_version} (via {python_source})."
+        f"Node {node_version}, Python {python_version} (via {python_source}), "
+        f"venv {venv_status}."
     )
     return 0
 

--- a/services/chat/AGENTS.md
+++ b/services/chat/AGENTS.md
@@ -19,7 +19,13 @@ From repository root:
 
 ```bash
 mise install
+make venv
 ```
+
+All chat Python runs from the shared repo-root virtualenv at `.venv`. The Make
+targets here create it on demand and call `.venv/bin/python` directly, so no
+activation step is needed. Do not `pip install` chat dependencies into a system
+or mise interpreter.
 
 ## Local commands
 

--- a/services/chat/Makefile
+++ b/services/chat/Makefile
@@ -1,7 +1,16 @@
 SHELL := /bin/bash
 
-PYTHON ?= mise exec python@3.11 -- python
+# All Python runs from the shared project virtualenv at the repository root.
+# PYTHON_BASE is only used to create it (override to `python` in CI).
+REPO_ROOT := $(abspath $(CURDIR)/../..)
+VENV_DIR ?= $(REPO_ROOT)/.venv
+VENV_PYTHON := $(VENV_DIR)/bin/python
+PYTHON_BASE ?= mise exec python@3.11 -- python
+PYTHON ?= $(VENV_PYTHON)
 PIP ?= $(PYTHON) -m pip
+
+# Put the venv's bin dir first so console scripts resolve without activation.
+export PATH := $(VENV_DIR)/bin:$(PATH)
 PYTEST ?= $(PYTHON) -m pytest
 UVICORN ?= $(PYTHON) -m uvicorn
 RUFF ?= $(PYTHON) -m ruff
@@ -21,15 +30,22 @@ export PIP_DISABLE_PIP_VERSION_CHECK := 1
 
 .DEFAULT_GOAL := help
 
-.PHONY: help check-python setup setup-core setup-full local-provider-check diagnose-chat-local dev deps-check lint typecheck test test-integration quick-ci ci
+.PHONY: help venv check-python setup setup-core setup-full local-provider-check diagnose-chat-local dev deps-check lint typecheck test test-integration quick-ci ci
 
 help: ## Show available chat-service tasks
 	@awk 'BEGIN {FS = ":.*##"; printf "\nChat service tasks:\n\n"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-20s %s\n", $$1, $$2} END {print ""}' $(MAKEFILE_LIST)
 
-check-python: ## Ensure chat commands run on Python 3.11
-	@$(PYTHON) -c "import sys; assert sys.version_info[:2] == (3, 11), f'Expected Python 3.11, got {sys.version.split()[0]}'"
+# Delegate creation to the root Makefile so there is exactly one venv recipe.
+$(VENV_PYTHON):
+	$(MAKE) -C $(REPO_ROOT) venv
 
-setup: ## Install chat runtime and test dependencies (CHAT_SETUP_PROFILE=core|full)
+venv: $(VENV_PYTHON) ## Create the shared project virtualenv (.venv at repo root)
+
+check-python: | $(VENV_PYTHON) ## Ensure chat commands run on Python 3.11 inside the project venv
+	@$(PYTHON) -c "import sys; assert sys.version_info[:2] == (3, 11), f'Expected Python 3.11, got {sys.version.split()[0]}'"
+	@$(PYTHON) -c "import sys; assert sys.prefix != sys.base_prefix, 'Expected a virtualenv; run \`make venv\`'"
+
+setup: | $(VENV_PYTHON) ## Install chat runtime and test dependencies (CHAT_SETUP_PROFILE=core|full)
 	$(MAKE) check-python
 	@if [ "$(CHAT_SETUP_PROFILE)" != "core" ] && [ "$(CHAT_SETUP_PROFILE)" != "full" ]; then \
 		echo "Unsupported CHAT_SETUP_PROFILE='$(CHAT_SETUP_PROFILE)' (expected core or full)"; \
@@ -48,7 +64,7 @@ setup-core: ## Install chat with core dependency profile
 setup-full: ## Install chat with full local-LLM/vector dependency profile
 	$(MAKE) setup CHAT_SETUP_PROFILE=full
 
-local-provider-check: ## Validate local-provider runtime prerequisites (LLM_PROVIDER=local)
+local-provider-check: | $(VENV_PYTHON) ## Validate local-provider runtime prerequisites (LLM_PROVIDER=local)
 	$(PYTHON) $(API_DIR)/local_provider_health.py --json
 
 diagnose-chat-local: ## Print local-provider diagnostics (checks + health endpoint snapshot)
@@ -68,24 +84,24 @@ diagnose-chat-local: ## Print local-provider diagnostics (checks + health endpoi
 		echo "curl not found; skipping endpoint snapshot."; \
 	fi
 
-dev: ## Run chat service with hot reload
+dev: | $(VENV_PYTHON) ## Run chat service with hot reload
 	cd $(API_DIR) && $(UVICORN) main:app --reload --host 0.0.0.0 --port 8000
 
-deps-check: ## Validate dependency pinning policy for chat service
+deps-check: | $(VENV_PYTHON) ## Validate dependency pinning policy for chat service
 	$(PYTHON) $(DEPS_CHECK_SCRIPT)
 
-lint: ## Lint chat service
+lint: | $(VENV_PYTHON) ## Lint chat service
 	$(RUFF) check src/api tests
 
-typecheck: ## Type-check chat service
+typecheck: | $(VENV_PYTHON) ## Type-check chat service
 	$(MYPY) --config-file mypy.ini src/api
 
-test: ## Run chat unit tests
+test: | $(VENV_PYTHON) ## Run chat unit tests
 	@mkdir -p $(COVERAGE_TMP_DIR)
 	@tmp_cov="$$(mktemp "$(COVERAGE_TMP_DIR)/.coverage.XXXXXX")"; \
 	COVERAGE_FILE="$$tmp_cov" $(PYTEST) tests/unit/ --cov=src/api --cov-report=term-missing -v
 
-test-integration: ## Run chat integration tests (requires SERVICE_URL)
+test-integration: | $(VENV_PYTHON) ## Run chat integration tests (requires SERVICE_URL)
 	$(PYTEST) tests/integration/ -v
 
 quick-ci: ## Fast chat checks

--- a/services/chat/run_tests.sh
+++ b/services/chat/run_tests.sh
@@ -22,9 +22,19 @@ if [ ! -f "src/api/main.py" ]; then
     exit 1
 fi
 
+# All Python runs from the shared project virtualenv at the repository root.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PY="${REPO_ROOT}/.venv/bin/python"
+if [ ! -x "${PY}" ]; then
+    log_error "Project virtualenv not found at ${REPO_ROOT}/.venv"
+    log_error "Run 'make venv' (or 'make bootstrap') from the repository root first."
+    exit 1
+fi
+log_info "Using $(${PY} -c 'import sys; print(sys.executable)')"
+
 # Install test dependencies
 log_info "Installing test dependencies..."
-pip install -r tests/requirements-test.txt
+"${PY}" -m pip install -r tests/requirements-test.txt
 
 # Install main dependencies for testing
 log_info "Installing main dependencies..."
@@ -33,17 +43,17 @@ if [ "${CHAT_SETUP_PROFILE}" != "core" ] && [ "${CHAT_SETUP_PROFILE}" != "full" 
     log_error "Unsupported CHAT_SETUP_PROFILE='${CHAT_SETUP_PROFILE}' (expected core or full)"
     exit 2
 fi
-pip install -r src/api/requirements-core.txt
+"${PY}" -m pip install -r src/api/requirements-core.txt
 if [ "${CHAT_SETUP_PROFILE}" = "full" ]; then
-    pip install -r src/api/requirements-local.txt
+    "${PY}" -m pip install -r src/api/requirements-local.txt
 fi
 
 # Add FastAPI test client
-pip install httpx
+"${PY}" -m pip install httpx
 
 # Run unit tests
 log_info "Running unit tests..."
-pytest tests/unit/ --cov=src/api --cov-report=term-missing -v
+"${PY}" -m pytest tests/unit/ --cov=src/api --cov-report=term-missing -v
 
 if [ $? -eq 0 ]; then
     log_success "Unit tests passed!"
@@ -55,7 +65,7 @@ fi
 # Run integration tests if SERVICE_URL is provided
 if [ -n "$SERVICE_URL" ]; then
     log_info "Running integration tests against $SERVICE_URL..."
-    pytest tests/integration/ -v
+    "${PY}" -m pytest tests/integration/ -v
 
     if [ $? -eq 0 ]; then
         log_success "Integration tests passed!"
@@ -71,9 +81,9 @@ fi
 # Validate code structure
 log_info "Validating code structure..."
 cd src/api
-python -m py_compile main.py
-python -m py_compile contoso_chat/chat_request.py
-python -m py_compile evaluators/custom_evals/relevance.py
+"${PY}" -m py_compile main.py
+"${PY}" -m py_compile contoso_chat/chat_request.py
+"${PY}" -m py_compile evaluators/custom_evals/relevance.py
 cd ../..
 
 log_success "All tests completed successfully! 🎉"

--- a/tests/scripts/test_venv_wiring.py
+++ b/tests/scripts/test_venv_wiring.py
@@ -1,0 +1,81 @@
+"""Guard the rule that every Python command runs from the project virtualenv."""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github/workflows"
+
+
+def read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def workflow_files() -> list[Path]:
+    return sorted(WORKFLOW_DIR.glob("*.yml"))
+
+
+class VenvWiringTests(unittest.TestCase):
+    def test_root_makefile_defaults_python_to_venv(self):
+        content = read("Makefile")
+        self.assertIn("VENV_DIR ?= .venv", content)
+        self.assertIn("VENV_PYTHON := $(VENV_DIR)/bin/python", content)
+        self.assertIn("PYTHON ?= $(VENV_PYTHON)", content)
+        self.assertIn("PIP ?= $(PYTHON) -m pip", content)
+
+    def test_chat_makefile_uses_shared_root_venv(self):
+        content = read("services/chat/Makefile")
+        self.assertIn("REPO_ROOT := $(abspath $(CURDIR)/../..)", content)
+        self.assertIn("VENV_DIR ?= $(REPO_ROOT)/.venv", content)
+        self.assertIn("PYTHON ?= $(VENV_PYTHON)", content)
+
+    def test_bootstrap_creates_venv_first(self):
+        content = read("Makefile")
+        bootstrap = content.split("bootstrap:", 1)[1].split("\n\n", 1)[0]
+        self.assertIn("$(MAKE) venv", bootstrap)
+
+    def test_python_targets_depend_on_venv(self):
+        content = read("Makefile")
+        for target in (
+            "toolchain-doctor",
+            "env-contract-check",
+            "agent-doctor",
+            "test-scripts",
+            "docs-check",
+            "agent-docs-check",
+            "prisma-generate-chat",
+            "release-dry-run",
+        ):
+            with self.subTest(target=target):
+                pattern = rf"^{re.escape(target)}: \| \$\(VENV_PYTHON\)"
+                self.assertRegex(content, re.compile(pattern, re.M))
+
+    def test_workflows_never_override_python_directly(self):
+        """`PYTHON=...` (or a PYTHON env var) bypasses the venv; CI must set PYTHON_BASE."""
+        for workflow in workflow_files():
+            content = workflow.read_text(encoding="utf-8")
+            with self.subTest(workflow=workflow.name):
+                self.assertNotRegex(content, re.compile(r"(?<!_)\bPYTHON=", re.M))
+                self.assertNotRegex(content, re.compile(r"^\s*PYTHON:\s", re.M))
+
+    def test_workflows_do_not_call_venv_external_console_scripts(self):
+        """Console scripts installed into .venv are not on PATH in CI."""
+        for workflow in workflow_files():
+            content = workflow.read_text(encoding="utf-8")
+            with self.subTest(workflow=workflow.name):
+                self.assertNotIn("prisma-client-py generate", content)
+
+    def test_chat_test_runner_uses_venv_interpreter(self):
+        content = read("services/chat/run_tests.sh")
+        self.assertIn('PY="${REPO_ROOT}/.venv/bin/python"', content)
+        self.assertNotRegex(content, re.compile(r"^\s*pip install ", re.M))
+        self.assertNotRegex(content, re.compile(r"^\s*pytest ", re.M))
+        self.assertNotRegex(content, re.compile(r"^\s*python -m ", re.M))
+
+    def test_venv_is_git_ignored(self):
+        self.assertIn(".venv/", read(".gitignore"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- What changed: all Python now runs from a single project virtualenv at `.venv` (already git-ignored). Both Makefiles default `PYTHON` to `.venv/bin/python`, create the venv on demand, and prepend `.venv/bin` to `PATH` — no activation step anywhere.
- Why: dependencies were being installed into whatever interpreter happened to be active — the mise-managed 3.11 locally, the runner's `setup-python` in CI. That pollutes a shared interpreter and lets local and CI environments drift.

## Scope
- Surface: runtime / chat / docs
- Risk level: medium (touches how every Python command resolves, locally and in CI)
- Breaking change: no — `make bootstrap` creates the venv; existing commands keep working

## Verification Evidence

Full local run, dependencies installed into the new venv:

```
$ make bootstrap
[PASS] Running inside the project virtualenv (.venv).
[PASS] Pinned runtime toolchain detected.
[PASS] Web Prisma client is generated.
[PASS] Chat Python dependencies are available.
[PASS] Chat Prisma client is generated.
Agent doctor passed: local environment is ready.

$ make quick-ci
48 passed in 12.20s        # chat unit tests, 79% coverage, python 3.11.15
                           # web lint + typecheck + tests all pass

$ make toolchain-doctor
Toolchain check passed: Node v22.23.1, Python Python 3.11.15 (via mise python@3.11), venv Python 3.11.15.

$ make test-scripts
Ran 60 tests in 0.175s
OK
```

Also verified that `make -C services/chat check-python` creates the shared root venv from a clean tree (delegates to the root recipe), and that `rm -rf .venv && make venv` rebuilds it.

### Required
- [x] `make quick-ci-changed` (ran the superset, `make quick-ci`)
- [x] `make test-scripts`
- [x] `make docs-check`

### Optional / Contextual
- [x] `make quick-ci`
- [ ] `make ci` (not run locally; `next build` in this sandbox)
- [ ] Manual UX/API validation

## Release and Ops Impact
- Env contract change: no
- Migration required: no
- Runbook updates needed: yes — done in this PR (`AGENTS.md`, `services/chat/AGENTS.md`, `README.md`, `CONTRIBUTING.md`)
- Follow-up tasks: none

## Reviewer Notes
- Areas that need close review:
  - **`PATH` export is load-bearing, not a convenience.** `make prisma-generate-chat` failed outright without it: `python -m prisma` shells out to the `prisma-client-py` generator *binary*, which lives in `.venv/bin` and is unreachable without activation. Same class of problem would hit `ruff`, `mypy`, `pytest`, `uvicorn`.
  - **CI overrides `PYTHON_BASE`, not `PYTHON`.** `PYTHON_BASE` is only the interpreter used to *create* the venv. Overriding `PYTHON` bypasses the venv entirely, which defeats the purpose — so CI now exercises the same venv path local development does.
  - **The chat test step previously set `env: PYTHON: python`.** An environment variable beats Make's `?=`, so that would have silently bypassed the venv even after this change. Removed.
  - The CI step that ran `prisma-client-py generate` directly is now `make prisma-generate-chat`, for the PATH reason above.
  - There is exactly one venv and one recipe that builds it: `services/chat/Makefile` delegates creation to the root Makefile rather than duplicating it.
- Known limitations or deferred cleanup:
  - `services/chat/Dockerfile` already used its own `/app/venv` and is unchanged — a container is already isolated.
  - `tests/scripts/test_venv_wiring.py` guards the wiring: Makefile defaults, venv prerequisites, no `PYTHON=` override or bare console script in any workflow, no bare `pip`/`pytest` in `run_tests.sh`.
  - Expect the **Integration E2E Smoke** check to fail on the pre-existing web image size budget (2.19 GB vs 1.5 GB), unrelated to this PR — same failure PR #34 hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)