### PR TITLE
chore(deps): group dependabot updates and keep versions in one place

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,16 @@
+# Grouping notes:
+#
+# Package families must version in lockstep. Ungrouped, Dependabot bumps one
+# member at a time and the install fails -- e.g. opentelemetry-sdk moving
+# without opentelemetry-api leaves `pip install -c constraints.txt` unsolvable.
+#
+# Minor and patch updates are grouped per ecosystem so routine upgrades arrive
+# as one reviewable PR. Major updates stay ungrouped: they need reading
+# individually, and burying one in a group of twelve is how it gets rubber
+# stamped.
+#
+# Groups are repeated per pip directory rather than shared via a YAML anchor,
+# because Dependabot's config parser does not reliably support aliases.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -11,6 +24,13 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/apps/web"
@@ -23,6 +43,38 @@ updates:
     labels:
       - "dependencies"
       - "web"
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+      next:
+        patterns:
+          - "next"
+          - "@next/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jsdom"
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "/services/chat"
@@ -35,6 +87,25 @@ updates:
     labels:
       - "dependencies"
       - "chat"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
+      google-cloud:
+        patterns:
+          - "google-cloud-*"
+          - "google-auth*"
+          - "vertexai"
+      pytest:
+        patterns:
+          - "pytest"
+          - "pytest-*"
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "/services/chat/src/api"
@@ -47,6 +118,25 @@ updates:
     labels:
       - "dependencies"
       - "chat"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
+      google-cloud:
+        patterns:
+          - "google-cloud-*"
+          - "google-auth*"
+          - "vertexai"
+      pytest:
+        patterns:
+          - "pytest"
+          - "pytest-*"
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "/services/chat/tests"
@@ -59,3 +149,22 @@ updates:
     labels:
       - "dependencies"
       - "chat"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
+      google-cloud:
+        patterns:
+          - "google-cloud-*"
+          - "google-auth*"
+          - "vertexai"
+      pytest:
+        patterns:
+          - "pytest"
+          - "pytest-*"
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/services/chat/scripts/check_dependency_policy.py
+++ b/services/chat/scripts/check_dependency_policy.py
@@ -4,8 +4,12 @@
 Policy:
 - `constraints.txt` must pin packages with exact `==` versions.
 - Every package referenced in requirement manifests must exist in `constraints.txt`.
-- Requirement manifests may use bare package names or exact `==` pins only.
-- If a requirement manifest uses `==`, it must match the constraint pin.
+- Requirement manifests must use bare package names only.
+
+Versions live in exactly one place. A package pinned in both a requirement
+manifest and `constraints.txt` gives Dependabot two places to edit; it updates
+one, and `pip install -c` then fails with ResolutionImpossible before any
+check in this repo gets a chance to run.
 """
 
 from __future__ import annotations
@@ -87,25 +91,16 @@ def check_requirements(requirement_files: tuple[Path, ...], constraints: dict[st
                 continue
 
             name, operator, version = parsed
-            if operator not in (None, "=="):
+            if operator is not None:
                 errors.append(
-                    f"{req_file}:{idx}: only bare names or exact '==' pins are allowed (got '{raw.strip()}')"
+                    f"{req_file}:{idx}: requirement manifests must use bare package names; "
+                    f"pin the version in {CONSTRAINTS_FILE} instead (got '{raw.strip()}')"
                 )
-                continue
-            if operator == "==" and not version:
-                errors.append(f"{req_file}:{idx}: missing version after '=='")
                 continue
 
             if name not in constraints:
                 errors.append(
                     f"{req_file}:{idx}: package '{name}' must be pinned in {CONSTRAINTS_FILE}"
-                )
-                continue
-
-            if operator == "==" and constraints[name] != version:
-                errors.append(
-                    f"{req_file}:{idx}: version '{name}=={version}' does not match "
-                    f"{CONSTRAINTS_FILE} pin '{name}=={constraints[name]}'"
                 )
 
     return errors

--- a/services/chat/src/api/requirements-core.txt
+++ b/services/chat/src/api/requirements-core.txt
@@ -1,5 +1,5 @@
 # General
-python-dotenv==1.0.1
+python-dotenv
 jsonlines
 pandas
 tabulate

--- a/tests/scripts/test_chat_profile_wiring.py
+++ b/tests/scripts/test_chat_profile_wiring.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -40,6 +42,59 @@ class ChatProfileWiringTests(unittest.TestCase):
         self.assertIn("src/api/requirements-core.txt", files)
         self.assertIn("src/api/requirements-local.txt", files)
         self.assertNotIn("src/api/requirements.txt", files)
+
+    def test_requirement_manifests_carry_no_inline_pins(self):
+        """Versions live only in constraints.txt, so Dependabot has one place to edit."""
+        chat_root = REPO_ROOT / "services/chat"
+        for relative in dependency_policy.REQUIREMENT_FILES:
+            manifest = chat_root / relative
+            with self.subTest(manifest=str(relative)):
+                for line_no, raw in enumerate(
+                    manifest.read_text(encoding="utf-8").splitlines(), start=1
+                ):
+                    line = raw.split("#", 1)[0].strip()
+                    if not line:
+                        continue
+                    self.assertNotIn(
+                        "==",
+                        line,
+                        msg=(
+                            f"{relative}:{line_no} pins a version inline; "
+                            "pin it in constraints.txt instead"
+                        ),
+                    )
+
+    def test_dependency_policy_rejects_inline_pins(self):
+        constraints = {"python-dotenv": "1.0.1"}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "requirements-core.txt"
+
+            manifest.write_text("python-dotenv\n", encoding="utf-8")
+            self.assertEqual(
+                dependency_policy.check_requirements((manifest,), constraints),
+                [],
+            )
+
+            # This is the exact shape that broke PR #33: a manifest pin that
+            # disagrees with constraints.txt, which pip cannot resolve.
+            manifest.write_text("python-dotenv==1.2.2\n", encoding="utf-8")
+            errors = dependency_policy.check_requirements((manifest,), constraints)
+
+        self.assertTrue(any("bare package names" in error for error in errors))
+
+    def test_dependabot_groups_keep_package_families_together(self):
+        # Asserted as text rather than parsed YAML: this suite runs in a bare
+        # venv without the chat dependencies, so PyYAML is not available.
+        content = (REPO_ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+
+        ecosystems = re.findall(r"^\s*- package-ecosystem:", content, re.M)
+        self.assertEqual(len(ecosystems), content.count("    groups:"))
+
+        # opentelemetry-sdk moving without opentelemetry-api is what broke #6.
+        self.assertEqual(content.count('- "opentelemetry-*"'), 3)
+        for pattern in ('- "google-cloud-*"', '- "pytest-*"', '- "eslint-*"', '- "@prisma/*"'):
+            with self.subTest(pattern=pattern):
+                self.assertIn(pattern, content)
 
     def test_chat_makefile_exposes_profile_setup_targets(self):
         content = (REPO_ROOT / "services/chat/Makefile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- What changed: versions now live only in `constraints.txt`, and `.github/dependabot.yml` groups package families so they are bumped as a unit.
- Why: two Dependabot PRs (#33, #6) fail with `ResolutionImpossible`, for two different reasons. Both fail during `pip install -c`, *before* any check in this repo runs, so `deps-check` never gets a chance to report the mismatch.

## Root causes

**#33 — double-pinned package.** `python-dotenv` was pinned in both `requirements-core.txt` and `constraints.txt`. Dependabot updated one side:

```
ERROR: Cannot install python-dotenv==1.2.2 because these package versions have conflicting dependencies.
    The user requested python-dotenv==1.2.2
    The user requested (constraint) python-dotenv==1.0.1
```

It was the only package in that manifest with an inline version; every other entry is a bare name.

**#6 — split package family.** Dependabot bumped `opentelemetry-sdk` in `constraints.txt` but left `opentelemetry-api==1.37.0` and `opentelemetry-instrumentation-fastapi==0.58b0` behind:

```
ERROR: Cannot install -r src/api/requirements-core.txt (line 20) and opentelemetry-api because these package versions have conflicting dependencies.
    The user requested opentelemetry-api
    The user requested (constraint) opentelemetry-api==1.37.0
```

## Fixes

1. **One place for versions.** The inline pin is removed from `requirements-core.txt`, and `check_dependency_policy.py` now rejects *any* `==` in a requirement manifest rather than merely requiring it to match `constraints.txt`. Dependabot gets exactly one file to edit.
2. **Grouping.** `opentelemetry-*`, `google-cloud-*`/`vertexai`, `pytest*` on the pip side; `eslint*`, `next`, `react`, `prisma`, and the test toolchain on npm. Minor/patch updates are additionally grouped per ecosystem, so routine upgrades arrive as one reviewable PR.

Major updates stay **ungrouped** deliberately — they need reading individually, and burying one in a group of twelve is how it gets rubber stamped.

## Scope
- Surface: runtime / chat / CI config
- Risk level: low (no runtime code changes; resolved versions are unchanged)
- Breaking change: no

## Verification Evidence

```
$ make deps-check
Dependency policy check passed: 25 pinned packages validated across 4 requirement files.

# regression: re-introduce the exact shape that broke #33
$ sed -i 's/^python-dotenv$/python-dotenv==1.2.2/' src/api/requirements-core.txt && make deps-check
Dependency policy check failed:
- src/api/requirements-core.txt:2: requirement manifests must use bare package names; pin the version in constraints.txt instead (got 'python-dotenv==1.2.2')

$ make quick-ci-chat
48 passed in 12.22s

# run in a bare venv, matching what the Script Guardrail Tests job actually has
$ /tmp/bare-venv/bin/python -m unittest discover -s tests/scripts
Ran 63 tests in 0.105s
OK
```

### Required
- [x] `make quick-ci-changed` (ran `quick-ci-chat` + `test-scripts`)
- [x] `make test-scripts`
- [ ] `make docs-check` (no docs changes)

## Release and Ops Impact
- Env contract change: no
- Migration required: no
- Runbook updates needed: no
- Follow-up tasks: #6 and #33 should be closed and left to regenerate under the new config; the remaining major bumps still need individual review

## Reviewer Notes
- Areas that need close review:
  - **Removing the inline pin does not change what gets installed.** `constraints.txt` already pinned `python-dotenv==1.0.1`, so resolution is identical — the manifest simply stops duplicating it.
  - **Groups are written out per pip directory rather than shared via a YAML anchor.** Dependabot's config parser does not reliably support aliases, and a config that fails to parse silently stops Dependabot rather than erroring loudly.
  - **The new tests assert against `dependabot.yml` as text, not parsed YAML.** The script guardrail suite runs in a bare venv where PyYAML is not installed — parsing would have made that CI job fail on import. Verified by running the suite in a clean venv.
- Known limitations or deferred cleanup:
  - Grouping only takes effect on the next Dependabot run; existing PRs keep their current shape until regenerated.
  - `open-pull-requests-limit` is unchanged (10 per pip ecosystem, 10 npm, 5 actions). Grouping should reduce the count enough that lowering it is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)