### PR TITLE
refactor(chat): replace prisma-client-py with asyncpg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,6 @@ jobs:
       - name: Install dependencies
         run: make -C services/chat setup PYTHON_BASE=python
 
-      - name: Generate Prisma Client (Python)
-        run: make prisma-generate-chat PYTHON_BASE=python
 
       - name: Run unit tests
         run: npm run ci:chat
@@ -1003,8 +1001,6 @@ jobs:
       - name: Install chat dependencies
         run: make -C services/chat setup PYTHON_BASE=python
 
-      - name: Generate Prisma Client (Python)
-        run: make prisma-generate-chat PYTHON_BASE=python
 
       - name: Run full CI checks
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,6 @@ make local-provider-check
 make diagnose-chat-local
 make docker-init-fresh
 make prisma-generate
-make prisma-generate-chat
 make dev
 make test
 make test-scripts
@@ -201,7 +200,6 @@ Copy templates to `.env` before local development.
 - Full-profile smoke failure in CI: inspect `e2e-full-compose.log`, `e2e-full-metrics.txt`, `e2e-full-metrics-summary.md`, `e2e-full-dependencies-health.json`, and `e2e-full-alert-state.md` artifacts.
 - Scheduled full-profile smoke alerts keep one open issue per alert class and auto-close when scheduled runs recover; include run URL and summary when triaging.
 - Missing env files: run `make env-init`, then update `.env` and `services/chat/.env`.
-- Python Prisma client missing: run `make prisma-generate-chat`.
 - Sandbox-only build failure (`listen EPERM`): run `make ci` outside restricted sandbox.
 
 ## Building and running

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,6 @@ Refer to:
 - All Python runs from the `.venv` virtualenv created by `make venv`/`make bootstrap`; if a dependency looks missing, re-run the command through `make` rather than a system `python`.
 - If env contract drift check fails, run `make env-contract-check` and align `config/env_contract.json`, env templates, and `docs/ENV_CONTRACT.md`.
 - If env checks fail, run `make env-init` and fill required values in `.env` files.
-- If chat Prisma client checks fail, run `make prisma-generate-chat`.
 - If `make agent-docs-check` fails, move the flagged pointer-file content into the matching `AGENTS.md`, then run `make agent-docs-check FIX=1`.
 - If release preflight fails, run `make release-dry-run RELEASE_TAG=vX.Y.Z` and fix missing guardrail files.
 - If integration smoke fails, run `make e2e-smoke KEEP_STACK=1` and inspect compose logs.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PYTHON ?= $(VENV_PYTHON)
 PIP ?= $(PYTHON) -m pip
 
 # Put the venv's bin dir first so console scripts installed into it resolve
-# without activation (prisma-client-py, ruff, mypy, pytest, uvicorn).
+# without activation (ruff, mypy, pytest, uvicorn).
 export PATH := $(abspath $(VENV_DIR))/bin:$(PATH)
 TOOLCHAIN_CHECK_SCRIPT := scripts/check_toolchain.py
 AGENT_DOCTOR_SCRIPT := scripts/agent_doctor.py
@@ -31,7 +31,6 @@ WEB_DIR := apps/web
 WEB_MAKE := $(MAKE) -C $(WEB_DIR)
 CHAT_DIR := services/chat
 CHAT_MAKE := $(MAKE) -C $(CHAT_DIR)
-WEB_PRISMA_SCHEMA := $(WEB_DIR)/prisma/schema.prisma
 
 ENV_FILE := .env
 ENV_TEMPLATE := .env.example
@@ -40,7 +39,7 @@ CHAT_ENV_TEMPLATE := $(CHAT_DIR)/.env.example
 
 .DEFAULT_GOAL := help
 
-.PHONY: help venv toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate prisma-generate-chat lint typecheck test test-scripts test-web test-chat test-chat-integration build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
+.PHONY: help venv toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate lint typecheck test test-scripts test-web test-chat test-chat-integration build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
 
 help: ## Show available tasks
 	@awk 'BEGIN {FS = ":.*##"; printf "\nAvailable tasks:\n\n"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-24s %s\n", $$1, $$2} END {print ""}' $(MAKEFILE_LIST)
@@ -73,7 +72,6 @@ bootstrap: ## One-command bootstrap for local and coding-agent development
 	$(MAKE) env-init
 	$(MAKE) setup
 	$(MAKE) setup-chat
-	$(MAKE) prisma-generate-chat
 	$(MAKE) sync-web-env
 	$(MAKE) agent-doctor
 
@@ -142,9 +140,6 @@ migrate: ## Run Prisma migrations using DATABASE_URL
 
 prisma-generate: ## Generate Prisma client for the web app
 	$(WEB_MAKE) prisma-generate
-
-prisma-generate-chat: | $(VENV_PYTHON) ## Generate Prisma client for the chat Python runtime
-	$(PYTHON) -m prisma py generate --schema=$(WEB_PRISMA_SCHEMA) --generator pyclient
 
 lint: ## Lint web app
 	$(WEB_MAKE) lint

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ make setup-chat-full
 make local-provider-check
 make diagnose-chat-local
 make docker-init-fresh
-make prisma-generate-chat
 make dev
 make test
 make test-scripts
@@ -255,8 +254,6 @@ Ensure all of the following:
 `ollama serve`, and `ollama pull <LOCAL_MODEL_NAME>`.
 - Full-profile smoke failure in CI:
 Inspect `e2e-full-compose.log`, `e2e-full-metrics.txt`, `e2e-full-metrics-summary.md`, `e2e-full-dependencies-health.json`, and `e2e-full-alert-state.md` artifacts (see `docs/INTEGRATION.md`).
-- `make prisma-generate-chat` fails in a sandbox with permission errors:
-Run the command in a normal local shell (outside restricted sandboxing).
 - `make agent-doctor` reports missing env files/keys:
 Run `make env-init`, then fill required values in `.env` and `services/chat/.env`.
 - `next build` fails in restricted sandbox with `listen EPERM`:

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -6,11 +6,6 @@ generator client {
   binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
-generator pyclient {
-  provider  = "prisma-client-py"
-  interface = "asyncio"
-}
-
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")

--- a/scripts/agent_doctor.py
+++ b/scripts/agent_doctor.py
@@ -189,31 +189,13 @@ def main() -> int:
     else:
         failures.append(("Web Prisma client is missing.", "Run `make prisma-generate`."))
 
-    # Chat Python dependencies and generated Prisma client
-    deps_check = run([sys.executable, "-c", "import fastapi, pytest"])
+    # Chat Python dependencies. The chat service talks to Postgres through
+    # asyncpg; there is no generated Python client to check for.
+    deps_check = run([sys.executable, "-c", "import asyncpg, fastapi, pytest"])
     if deps_check.returncode == 0:
         passes.append("Chat Python dependencies are available.")
     else:
         failures.append(("Chat Python dependencies are incomplete.", "Run `make setup-chat`."))
-
-    chat_prisma = run([sys.executable, "-c", "from prisma import Prisma; print(Prisma.__name__)"])
-    if chat_prisma.returncode == 0:
-        passes.append("Chat Prisma client is generated.")
-    else:
-        output = normalize_output(chat_prisma)
-        if "No module named 'prisma'" in output:
-            failures.append(("Python prisma package is missing.", "Run `make setup-chat`."))
-        elif "Client hasn't been generated yet" in output:
-            failures.append(
-                ("Chat Prisma client has not been generated.", "Run `make prisma-generate-chat`."),
-            )
-        else:
-            failures.append(
-                (
-                    f"Unable to validate chat Prisma client: {output}",
-                    "Run `make prisma-generate-chat` and retry.",
-                ),
-            )
 
     for line in passes:
         print(f"[PASS] {line}")

--- a/services/chat/AGENTS.md
+++ b/services/chat/AGENTS.md
@@ -35,7 +35,6 @@ From repository root:
 make bootstrap
 make agent-doctor
 make setup-chat
-make prisma-generate-chat
 make local-provider-check
 make diagnose-chat-local
 make dev-chat
@@ -81,6 +80,22 @@ Most common local values:
 - `LLM_PROVIDER=local`
 - `OLLAMA_BASE_URL=http://localhost:11434`
 - `ALLOWED_ORIGINS=http://localhost:3000`
+
+## Database access
+
+The chat service reads Postgres directly through `asyncpg` in
+`services/chat/src/api/db.py`. There is no generated Python ORM client and no
+code generation step.
+
+`prisma-client-py` was removed: it pinned Prisma 5.17.0 and required a `url` in
+the shared schema's `datasource` block, which Prisma 7 removes. Generating both
+a JS and a Python client from `apps/web/prisma/schema.prisma` meant the Python
+client dictated which Prisma versions the web app could adopt.
+
+`apps/web/prisma/schema.prisma` remains the source of truth for the data model
+and migrations. When it changes, update the SQL in `db.py` to match — the
+queries name tables and columns explicitly and nothing verifies them at build
+time.
 
 ## Guardrails
 

--- a/services/chat/Dockerfile
+++ b/services/chat/Dockerfile
@@ -9,11 +9,6 @@ ENV PYTHONUNBUFFERED=1 \
 
 ARG INSTALL_LOCAL_STACK=0
 
-# Prisma Python's nodeenv runtime requires libatomic at generation time.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libatomic1 \
-    && rm -rf /var/lib/apt/lists/*
-
 # Create non-root user for security
 RUN groupadd -r appuser && useradd -r -m -g appuser appuser
 
@@ -40,12 +35,9 @@ RUN pip install --no-cache-dir --default-timeout=300 --retries 5 -r requirements
 
 # Copy application code
 
-# Copy Prisma schema and generate client
-COPY --chown=appuser:appuser apps/web/prisma/schema.prisma schema.prisma
-RUN python -m prisma py generate --schema=schema.prisma --generator pyclient
-
 # Copy application code
 COPY --chown=appuser:appuser services/chat/src/api/main.py main.py
+COPY --chown=appuser:appuser services/chat/src/api/db.py db.py
 COPY --chown=appuser:appuser services/chat/src/api/local_provider_health.py local_provider_health.py
 COPY --chown=appuser:appuser services/chat/src/api/contoso_chat/ contoso_chat/
 COPY --chown=appuser:appuser services/chat/src/api/evaluators/ evaluators/

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -58,7 +58,6 @@ mise install
 make bootstrap
 make setup-chat
 make setup-chat-full # optional: include local LLM/vector dependencies
-make prisma-generate-chat
 npm run setup:chat
 npm run setup:chat:full # optional: include local LLM/vector dependencies
 make -C services/chat setup

--- a/services/chat/constraints.txt
+++ b/services/chat/constraints.txt
@@ -1,3 +1,4 @@
+asyncpg==0.30.0
 chromadb==1.5.9
 fastapi==0.140.13
 google-auth==2.56.2
@@ -11,10 +12,9 @@ opentelemetry-api==1.44.0
 opentelemetry-instrumentation-fastapi==0.65b0
 opentelemetry-sdk==1.44.0
 pandas==3.0.5
-prisma==0.15.0
 prompty==0.1.50
-pytest==8.4.2
 pytest-cov==7.0.0
+pytest==8.4.2
 python-dotenv==1.2.2
 requests==2.34.2
 ruff==0.16.0

--- a/services/chat/src/api/contoso_chat/chat_request.py
+++ b/services/chat/src/api/contoso_chat/chat_request.py
@@ -1,12 +1,7 @@
 import json
 import os
-from typing import Any
 
 from .search_service import get_search_service
-
-# Keep Prisma patchable in tests while avoiding import-time runtime errors
-# when the generated client is unavailable.
-Prisma: Any = None
 
 
 async def get_customer_from_postgres(customer_id: str):
@@ -14,37 +9,11 @@ async def get_customer_from_postgres(customer_id: str):
     if not customer_id:
         return None
     try:
-        global Prisma
-        if Prisma is None:
-            from prisma import Prisma as PrismaClient
+        # Imported lazily so unit tests can exercise this module without a
+        # database driver present, matching the previous client's behaviour.
+        from db import fetch_customer
 
-            Prisma = PrismaClient
-
-        db = Prisma()
-        await db.connect()
-        
-        # Try to find by ID
-        user = await db.user.find_unique(
-            where={'id': customer_id},
-            include={
-                'orders': {
-                    'include': {
-                        'items': {
-                            'include': {
-                                'product': True
-                            }
-                        }
-                    }
-                }
-            }
-        )
-        
-        await db.disconnect()
-        
-        if user:
-            return user.model_dump()
-        else:
-            return None
+        return await fetch_customer(customer_id)
     except Exception as e:
         print(f"Error retrieving customer from Postgres: {e}")
         return None

--- a/services/chat/src/api/db.py
+++ b/services/chat/src/api/db.py
@@ -1,0 +1,178 @@
+"""PostgreSQL access for the chat service.
+
+Replaces the generated `prisma-client-py` client. That client pinned Prisma
+5.17.0 and required a `url` in the schema's `datasource` block, which Prisma 7
+removes. Because the web app and the chat service generated from the same
+`schema.prisma`, the Python client held the whole repository back from
+tracking Prisma releases.
+
+The chat service only ever read from the database -- one customer lookup and a
+health probe -- so it talks to Postgres directly instead.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import asyncpg
+
+# Prisma accepts connection-string parameters that asyncpg rejects. `schema` is
+# the common one: the repo's own .env.example ships `?schema=public`.
+PRISMA_ONLY_QUERY_KEYS = frozenset(
+    {
+        "schema",
+        "connection_limit",
+        "connect_timeout",
+        "pool_timeout",
+        "pgbouncer",
+        "socket_timeout",
+        "sslcert",
+        "sslidentity",
+        "sslpassword",
+    }
+)
+
+
+def normalize_dsn(url: str) -> str:
+    """Strip Prisma-only query parameters so asyncpg can parse the DSN."""
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+
+    kept = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if key not in PRISMA_ONLY_QUERY_KEYS
+    ]
+    return urlunsplit(parts._replace(query=urlencode(kept)))
+
+
+async def connect() -> asyncpg.Connection:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL is not set.")
+    return await asyncpg.connect(normalize_dsn(dsn))
+
+
+async def check_connection() -> tuple[bool, str | None]:
+    """Return (connected, error) for the dependency health endpoint."""
+    connection = None
+    try:
+        connection = await connect()
+        await connection.fetchval("SELECT 1")
+        return True, None
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+    finally:
+        if connection is not None:
+            await connection.close()
+
+
+# Table and column identifiers are quoted: Prisma maps models to PascalCase
+# tables and fields to camelCase columns, neither of which survives Postgres
+# identifier folding unquoted.
+_USER_QUERY = """
+SELECT id, email, name, avatar, "addressLine1", "addressLine2", city, state,
+       "zipCode", country, "phoneNumber", "firstName", "lastName", age,
+       membership, "createdAt", "updatedAt"
+  FROM "User"
+ WHERE id = $1
+"""
+
+_ORDER_ITEMS_QUERY = """
+SELECT o.id            AS order_id,
+       o."userId"      AS order_user_id,
+       o.date          AS order_date,
+       o.total         AS order_total,
+       o."createdAt"   AS order_created_at,
+       o."updatedAt"   AS order_updated_at,
+       i.id            AS item_id,
+       i."orderId"     AS item_order_id,
+       i."productId"   AS item_product_id,
+       i.quantity      AS item_quantity,
+       i.price         AS item_price,
+       p.id            AS product_id,
+       p.name          AS product_name,
+       p.description   AS product_description,
+       p.price         AS product_price,
+       p.image         AS product_image,
+       p."categoryId"  AS product_category_id,
+       p."brandId"     AS product_brand_id,
+       p.slug          AS product_slug,
+       p."createdAt"   AS product_created_at,
+       p."updatedAt"   AS product_updated_at
+  FROM "Order" o
+  LEFT JOIN "OrderItem" i ON i."orderId" = o.id
+  LEFT JOIN "Product" p ON p.id = i."productId"
+ WHERE o."userId" = $1
+ ORDER BY o.date DESC, i.id
+"""
+
+
+def _build_orders(rows: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    """Fold the joined rows back into the nested shape the client returned."""
+    orders: dict[str, dict[str, Any]] = {}
+
+    for row in rows:
+        order_id = row["order_id"]
+        order = orders.get(order_id)
+        if order is None:
+            order = {
+                "id": order_id,
+                "userId": row["order_user_id"],
+                "date": row["order_date"],
+                "total": row["order_total"],
+                "createdAt": row["order_created_at"],
+                "updatedAt": row["order_updated_at"],
+                "items": [],
+            }
+            orders[order_id] = order
+
+        # LEFT JOIN: an order with no items yields a row with null item columns.
+        if row["item_id"] is None:
+            continue
+
+        order["items"].append(
+            {
+                "id": row["item_id"],
+                "orderId": row["item_order_id"],
+                "productId": row["item_product_id"],
+                "quantity": row["item_quantity"],
+                "price": row["item_price"],
+                "product": {
+                    "id": row["product_id"],
+                    "name": row["product_name"],
+                    "description": row["product_description"],
+                    "price": row["product_price"],
+                    "image": row["product_image"],
+                    "categoryId": row["product_category_id"],
+                    "brandId": row["product_brand_id"],
+                    "slug": row["product_slug"],
+                    "createdAt": row["product_created_at"],
+                    "updatedAt": row["product_updated_at"],
+                },
+            }
+        )
+
+    return list(orders.values())
+
+
+async def fetch_customer(customer_id: str) -> dict[str, Any] | None:
+    """Return a customer with nested orders/items/products, or None."""
+    connection = None
+    try:
+        connection = await connect()
+        user_row = await connection.fetchrow(_USER_QUERY, customer_id)
+        if user_row is None:
+            return None
+
+        customer = dict(user_row)
+        customer["orders"] = _build_orders(
+            await connection.fetch(_ORDER_ITEMS_QUERY, customer_id)
+        )
+        return customer
+    finally:
+        if connection is not None:
+            await connection.close()

--- a/services/chat/src/api/main.py
+++ b/services/chat/src/api/main.py
@@ -108,12 +108,9 @@ async def health():
 
 async def check_database_connection() -> tuple[bool, str | None]:
     try:
-        from prisma import Prisma
+        from db import check_connection
 
-        db = Prisma()
-        await db.connect()
-        await db.disconnect()
-        return True, None
+        return await check_connection()
     except Exception as exc:  # noqa: BLE001
         return False, str(exc)
 

--- a/services/chat/src/api/requirements-core.txt
+++ b/services/chat/src/api/requirements-core.txt
@@ -24,4 +24,4 @@ opentelemetry-instrumentation-fastapi
 prompty
 
 # Database
-prisma
+asyncpg

--- a/services/chat/tests/requirements-test.txt
+++ b/services/chat/tests/requirements-test.txt
@@ -2,3 +2,6 @@ pytest
 requests
 python-dotenv
 pytest-cov
+
+# Required by fastapi.testclient/starlette.testclient; no test imports it directly.
+httpx

--- a/services/chat/tests/unit/test_chat_request.py
+++ b/services/chat/tests/unit/test_chat_request.py
@@ -18,58 +18,36 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_get_customer_from_postgres_returns_none_for_empty_id():
-    with patch("contoso_chat.chat_request.Prisma") as mock_prisma:
+    with patch("db.fetch_customer") as mock_fetch:
         result = await get_customer_from_postgres("")
 
     assert result is None
-    mock_prisma.assert_not_called()
+    mock_fetch.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_get_customer_from_postgres_returns_customer_dump():
-    mock_db = MagicMock()
-    mock_db.connect = AsyncMock()
-    mock_db.disconnect = AsyncMock()
-    mock_user = MagicMock()
-    mock_user.model_dump.return_value = {"firstName": "Taylor"}
-    mock_db.user.find_unique = AsyncMock(return_value=mock_user)
-
-    with patch("contoso_chat.chat_request.Prisma", return_value=mock_db):
+async def test_get_customer_from_postgres_returns_customer():
+    with patch("db.fetch_customer", AsyncMock(return_value={"firstName": "Taylor"})) as mock_fetch:
         result = await get_customer_from_postgres("cust-1")
 
     assert result == {"firstName": "Taylor"}
-    mock_db.connect.assert_awaited_once()
-    mock_db.user.find_unique.assert_awaited_once()
-    mock_db.disconnect.assert_awaited_once()
+    mock_fetch.assert_awaited_once_with("cust-1")
 
 
 @pytest.mark.anyio
 async def test_get_customer_from_postgres_returns_none_when_missing():
-    mock_db = MagicMock()
-    mock_db.connect = AsyncMock()
-    mock_db.disconnect = AsyncMock()
-    mock_db.user.find_unique = AsyncMock(return_value=None)
-
-    with patch("contoso_chat.chat_request.Prisma", return_value=mock_db):
+    with patch("db.fetch_customer", AsyncMock(return_value=None)):
         result = await get_customer_from_postgres("cust-1")
 
     assert result is None
-    mock_db.connect.assert_awaited_once()
-    mock_db.user.find_unique.assert_awaited_once()
-    mock_db.disconnect.assert_awaited_once()
 
 
 @pytest.mark.anyio
 async def test_get_customer_from_postgres_returns_none_on_exception():
-    mock_db = MagicMock()
-    mock_db.connect = AsyncMock(side_effect=RuntimeError("db down"))
-    mock_db.disconnect = AsyncMock()
-
-    with patch("contoso_chat.chat_request.Prisma", return_value=mock_db):
+    with patch("db.fetch_customer", AsyncMock(side_effect=RuntimeError("db down"))):
         result = await get_customer_from_postgres("cust-1")
 
     assert result is None
-    mock_db.connect.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/services/chat/tests/unit/test_db.py
+++ b/services/chat/tests/unit/test_db.py
@@ -1,0 +1,87 @@
+import db
+import pytest
+
+
+class TestNormalizeDsn:
+    def test_leaves_plain_dsn_untouched(self):
+        dsn = "postgresql://postgres:postgres@localhost:5432/contoso-db"
+        assert db.normalize_dsn(dsn) == dsn
+
+    def test_strips_prisma_schema_parameter(self):
+        # The repo's own .env.example ships `?schema=public`, which asyncpg rejects.
+        dsn = "postgresql://postgres:postgres@localhost:5432/contoso-db?schema=public"
+        assert (
+            db.normalize_dsn(dsn)
+            == "postgresql://postgres:postgres@localhost:5432/contoso-db"
+        )
+
+    def test_strips_only_prisma_specific_parameters(self):
+        dsn = (
+            "postgresql://u:p@h:5432/d"
+            "?schema=public&connection_limit=5&application_name=chat"
+        )
+        assert db.normalize_dsn(dsn) == "postgresql://u:p@h:5432/d?application_name=chat"
+
+    def test_preserves_credentials_and_port(self):
+        dsn = "postgresql://user:s3cret@db:5432/contoso-db?schema=public"
+        assert db.normalize_dsn(dsn) == "postgresql://user:s3cret@db:5432/contoso-db"
+
+
+def _row(order_id, item_id=None, product_id=None):
+    return {
+        "order_id": order_id,
+        "order_user_id": "cust-1",
+        "order_date": "2026-01-01",
+        "order_total": 10.0,
+        "order_created_at": "2026-01-01",
+        "order_updated_at": "2026-01-01",
+        "item_id": item_id,
+        "item_order_id": order_id,
+        "item_product_id": product_id,
+        "item_quantity": 2,
+        "item_price": 5.0,
+        "product_id": product_id,
+        "product_name": "Tent",
+        "product_description": "A tent",
+        "product_price": 5.0,
+        "product_image": None,
+        "product_category_id": "cat-1",
+        "product_brand_id": "brand-1",
+        "product_slug": "tent",
+        "product_created_at": "2026-01-01",
+        "product_updated_at": "2026-01-01",
+    }
+
+
+class TestBuildOrders:
+    def test_groups_items_under_their_order(self):
+        rows = [_row("o1", "i1", "p1"), _row("o1", "i2", "p2"), _row("o2", "i3", "p3")]
+
+        orders = db._build_orders(rows)
+
+        assert [o["id"] for o in orders] == ["o1", "o2"]
+        assert [i["id"] for i in orders[0]["items"]] == ["i1", "i2"]
+        assert orders[0]["items"][0]["product"]["id"] == "p1"
+
+    def test_order_without_items_yields_empty_list(self):
+        # LEFT JOIN produces one row with null item columns.
+        orders = db._build_orders([_row("o1")])
+
+        assert len(orders) == 1
+        assert orders[0]["items"] == []
+
+    def test_no_rows_yields_no_orders(self):
+        assert db._build_orders([]) == []
+
+
+@pytest.mark.anyio
+async def test_connect_requires_database_url(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL is not set"):
+        await db.connect()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/tests/scripts/test_venv_wiring.py
+++ b/tests/scripts/test_venv_wiring.py
@@ -44,7 +44,6 @@ class VenvWiringTests(unittest.TestCase):
             "test-scripts",
             "docs-check",
             "agent-docs-check",
-            "prisma-generate-chat",
             "release-dry-run",
         ):
             with self.subTest(target=target):


### PR DESCRIPTION
## Why

`prisma-client-py` 0.15.0 pins Prisma **5.17.0** and requires a `url` in the shared schema's `datasource` block — which **Prisma 7 removes** (error P1012). Generating both a JS and a Python client from `apps/web/prisma/schema.prisma` meant the Python client dictated which Prisma versions the web app could adopt.

This unblocks #49 (Prisma 6 → 7).

## What

The chat service now reads Postgres directly through `asyncpg` in `services/chat/src/api/db.py`. There is no generated Python ORM client and no code generation step.

- **New `db.py`** — DSN normalization (strips Prisma-only query params like `?schema=public`), `connect`, `check_connection`, and `fetch_customer` with LEFT JOIN row folding into the previous nested shape.
- `chat_request.get_customer_from_postgres` and `main`'s dependency health check now call into `db.py`.
- **Removed**: the `pyclient` generator from the schema, `make prisma-generate-chat`, both CI generate steps, the `agent_doctor.py` check, and the chat image's generate step plus its `libatomic1` apt dependency.
- `constraints.txt`: `prisma==0.15.0` → `asyncpg==0.30.0`.
- Tests: new `tests/unit/test_db.py`; `test_chat_request.py` rewritten to mock `db.fetch_customer` instead of the Prisma client.

`apps/web/prisma/schema.prisma` remains the source of truth for the data model and migrations. Since the SQL names tables and columns explicitly and nothing verifies them at build time, `services/chat/AGENTS.md` now says to update `db.py` when the schema changes.

## Scope

This removes the **Python** blocker only. #49 still needs the web-side migration — moving the connection URL to `prisma.config.ts` and adding a driver adapter to `PrismaClient` in `apps/web/src/lib/prisma.ts` and `apps/web/prisma/seed.ts`.

## Verification

- `fetch_customer` against a **live seeded database**: user `1` (John) with all 3 seeded orders and nested products, `None` for a missing id, `?schema=public` DSN normalization correct.
- **Dockerized E2E smoke passes** — `/health/dependencies` reports `"database": {"connected": true, "error": null}`, and no "Error retrieving customer" in chat logs. This caught a real bug the unit tests structurally could not: `db.py` initially had no `COPY` line in the chat Dockerfile (the image copies source files individually), so the container failed with `No module named 'db'`.
- Chat unit tests 48 → 56; `make test-scripts` 63 passing; `docs-check`, `quick-ci`, and `agent-doctor` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)