### PR TITLE
chore(deps): bump google-cloud-aiplatform and discoveryengine

### DIFF
--- a/services/chat/constraints.txt
+++ b/services/chat/constraints.txt
@@ -2,8 +2,8 @@ asyncpg==0.30.0
 chromadb==1.5.9
 fastapi==0.140.13
 google-auth==2.56.2
-google-cloud-aiplatform==1.71.1
-google-cloud-discoveryengine==0.13.11
+google-cloud-aiplatform==1.163.0
+google-cloud-discoveryengine==0.20.2
 httpx==0.28.1
 jsonlines==4.0.0
 litellm==1.94.0
@@ -22,4 +22,3 @@ sentence-transformers==5.6.1
 tabulate==0.10.0
 torch==2.13.0
 uvicorn==0.51.0
-vertexai==1.71.1

--- a/services/chat/src/api/contoso_chat/chat_request.py
+++ b/services/chat/src/api/contoso_chat/chat_request.py
@@ -55,12 +55,12 @@ async def generate_llm_response(prompt: str, context: str, user_name: str, provi
         return response.choices[0].message.content
     else:
         import vertexai
-        from vertexai.generative_models import GenerativeModel, Part
+        from vertexai.generative_models import GenerativeModel
         vertexai.init(project=project_id, location=location)
         model = GenerativeModel(model_name)
-        
+
         full_prompt = f"{system_instruction}\n\nCatalog Context:\n{context}\n\nUser Question: {prompt}"
-        response = model.generate_content([Part.from_text(full_prompt)])
+        response = model.generate_content(full_prompt)
         return response.text
 
 async def get_response(customer_id, question, chat_history):

--- a/services/chat/src/api/requirements-core.txt
+++ b/services/chat/src/api/requirements-core.txt
@@ -10,10 +10,12 @@ fastapi
 uvicorn[standard]
 
 # Google Cloud Services
+# The standalone `vertexai` package is deliberately absent: it pins
+# google-cloud-aiplatform to an exact version, which blocks every aiplatform
+# bump. google-cloud-aiplatform ships the `vertexai` module itself.
 google-cloud-aiplatform
 google-cloud-discoveryengine
 google-auth
-vertexai
 
 # OpenTelemetry and tracing
 opentelemetry-api

--- a/services/chat/tests/unit/test_chat_request.py
+++ b/services/chat/tests/unit/test_chat_request.py
@@ -105,7 +105,6 @@ async def test_generate_llm_response_local_provider_requires_optional_dependenci
 @pytest.mark.anyio
 async def test_generate_llm_response_gcp_provider():
     mock_init = MagicMock()
-    mock_part = MagicMock(return_value="prompt-part")
     mock_model_instance = MagicMock()
     mock_model_instance.generate_content.return_value = SimpleNamespace(text="gcp answer")
     mock_model_class = MagicMock(return_value=mock_model_instance)
@@ -116,7 +115,6 @@ async def test_generate_llm_response_gcp_provider():
             "vertexai": SimpleNamespace(init=mock_init),
             "vertexai.generative_models": SimpleNamespace(
                 GenerativeModel=mock_model_class,
-                Part=SimpleNamespace(from_text=mock_part),
             ),
         },
     ):
@@ -133,8 +131,12 @@ async def test_generate_llm_response_gcp_provider():
     assert result == "gcp answer"
     mock_init.assert_called_once_with(project="project-1", location="us-central1")
     mock_model_class.assert_called_once_with("gemini-2.5-flash")
-    mock_part.assert_called_once()
-    mock_model_instance.generate_content.assert_called_once_with(["prompt-part"])
+    mock_model_instance.generate_content.assert_called_once()
+    sent_prompt = mock_model_instance.generate_content.call_args.args[0]
+    assert isinstance(sent_prompt, str)
+    assert "Best tent?" in sent_prompt
+    assert "abc123" in sent_prompt
+    assert "Taylor" in sent_prompt
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Supersedes #40, which could not resolve on its own.

## Why #40 failed

The standalone `vertexai` package pins `google-cloud-aiplatform` to an **exact** version, so every aiplatform bump is unsatisfiable:

```
vertexai 1.71.1 depends on google-cloud-aiplatform==1.71.1
The user requested (constraint) google-cloud-aiplatform==1.163.0
ERROR: ResolutionImpossible
```

Dependabot could not have fixed this — no version pairing exists that satisfies both.

## What changed

- `google-cloud-aiplatform` 1.71.1 → **1.163.0**
- `google-cloud-discoveryengine` 0.13.11 → **0.20.2**
- **dropped** the standalone `vertexai` requirement and its pin

`google-cloud-aiplatform` ships the `vertexai` module itself, so the standalone package was redundant — it only added the exact-pin constraint. The five modules that `import vertexai` are unchanged. A comment in `requirements-core.txt` records why it must not come back.

### Fallout the bump surfaced

**Typecheck.** The newer SDK types `generate_content` as accepting `list[str | Image | Part]`; `list[Part]` no longer matches because `list` is invariant. A plain `str` is accepted directly and is equivalent for a text-only prompt, so the prompt is passed straight through and the now-unused `Part` import is dropped.

**A unit test** asserted the old `generate_content(["prompt-part"])` shape and correctly failed. It now asserts the prompt string contains the question, the catalog context, and the user name — meaningful without being coupled to the prompt template.

## Verification

- Clean venv: `import vertexai` and `from vertexai.generative_models import GenerativeModel, Part` both resolve under 1.163.0, and the full requirement set installs with no conflict
- `make -C services/chat quick-ci` — lint, typecheck, 56 tests
- Dockerized E2E smoke passed (the chat image installs these deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)