### PR TITLE
fix(web): await async params on dynamic pages

### DIFF
--- a/apps/web/src/app/products/[slug]/page.tsx
+++ b/apps/web/src/app/products/[slug]/page.tsx
@@ -46,9 +46,10 @@ function getRange(header1:string, header2:string, markdown: string[]): string {
 export default async function Page({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const product = await getData(params.slug);
+  const { slug } = await params;
+  const product = await getData(slug);
 
   if (!product) {
     notFound();

--- a/apps/web/src/app/products/category/[slug]/page.test.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.test.tsx
@@ -44,7 +44,7 @@ describe('Category Page', () => {
 
     vi.mocked(getProductsByCategory).mockResolvedValue(mockCategory as any)
 
-    const result = await CategoryPage({ params: { slug: 'hiking' } })
+    const result = await CategoryPage({ params: Promise.resolve({ slug: 'hiking' }) })
     render(result)
 
     expect(screen.getByText('Hiking')).toBeDefined()
@@ -55,7 +55,7 @@ describe('Category Page', () => {
   it('calls notFound if category does not exist', async () => {
     vi.mocked(getProductsByCategory).mockResolvedValue(null)
 
-    await expect(CategoryPage({ params: { slug: 'invalid' } })).rejects.toThrow('NEXT_NOT_FOUND')
+    await expect(CategoryPage({ params: Promise.resolve({ slug: 'invalid' }) })).rejects.toThrow('NEXT_NOT_FOUND')
     expect(notFound).toHaveBeenCalled()
   })
 })

--- a/apps/web/src/app/products/category/[slug]/page.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.tsx
@@ -16,10 +16,12 @@ export default async function CategoryPage({
   params,
   searchParams,
 }: {
-  params: { slug: string };
-  searchParams?: { [key: string]: string | string[] | undefined };
+  params: Promise<{ slug: string }>;
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
-  const category = await getProductsByCategory(params.slug);
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+  const category = await getProductsByCategory(slug);
 
   if (!category) {
     notFound();
@@ -43,7 +45,9 @@ export default async function CategoryPage({
             <a
               key={product.id}
               href={`/products/${product.slug}${
-                searchParams?.type ? "?type=" + searchParams.type : ""
+                resolvedSearchParams?.type
+                  ? "?type=" + resolvedSearchParams.type
+                  : ""
               }`}
               className="group"
             >


### PR DESCRIPTION
**Product detail pages are returning 404 on `main` right now.** This is a regression from #60 (Next 16), which I merged. Fix is three files.

## Cause

Next 15 made `params` and `searchParams` **Promises**. #60 upgraded to Next 16 without awaiting them, so `params.slug` reads `undefined` off a Promise object:

```ts
const product = await getData(params.slug);  // params is a Promise -> undefined
if (!product) notFound();                    // every product page 404s
```

- `/products/[slug]` → **404 for every product**
- `/products/category/[slug]` → still rendered, but silently lost the slug and `?type=` handling

## Why nothing caught it

**TypeScript didn't**, because the hand-written annotation asserts the pre-15 shape:

```ts
}: { params: { slug: string } })   // tsc believes this over Next's generated types
```

**CI didn't**, because the E2E smoke only exercises route handlers — `/api/chat/service`, `/health`, `/health/dependencies` — which take no params. No check in the suite loads a `[slug]` page. My own verification of #60 hit `/api/products` and `/api/brands` for the same reason, and the one category-page check I ran was on the Prisma 7 branch, still Next 14.

## Verification

Built the image and compared against `dc25e22` (the commit before #60):

| Page | before #60 (Next 14) | on `main` now | with this fix |
| --- | --- | --- | --- |
| `/products/trailmaster-x4-tent` | 200, 55,823 B | **404** | 200, 57,543 B, 8 `<h2>` |
| `/products/category/tents` | 200 | 200 (slug lost) | 200, resolves slug |
| `/products/category/tents?type=visual` | 200 | `?type` dropped | 200, `type=visual` present |

Plus `tsc`, eslint, and 67 tests.

## Follow-up

The smoke should load a `[slug]` page so this class of break can't reach `main` again. Not in this PR — it should land as a fix first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)