### PR TITLE
chore(deps): bump marked to 18 and drop @azure/openai

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,7 +8,6 @@
       "name": "contoso-web",
       "version": "0.1.0",
       "dependencies": {
-        "@azure/openai": "^1.0.0-beta.7",
         "@heroicons/react": "^2.2.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/adapter-pg": "^7.9.1",
@@ -17,7 +16,7 @@
         "clsx": "^2.1.1",
         "eventsource-parser": "^1.1.1",
         "jose": "^6.2.4",
-        "marked": "^9.1.4",
+        "marked": "^18.0.7",
         "next": "16.2.12",
         "next-auth": "^4.24.15",
         "pg": "^8.22.0",
@@ -154,143 +153,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/@azure-rest/core-client": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.1.5.tgz",
-      "integrity": "sha512-Cvd3bR+bp1vet4H4Kmhr5QOEcTMjtzvg0WK3xlwzjHVdzpGIHcDYmjs7XC5yH5A1PmGv4ARaUGKYaTBhMRCQug==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.1.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.5.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-lro": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.4.tgz",
-      "integrity": "sha512-3GJiMVH7/10bulzOKGrrLeG/uCBH/9VtxqaMcB9lIqAeamI/xYQSHJL/KcsLDuH+yTjYpro/u6D/MuRe4dN70Q==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-util": "^1.2.0",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.2.tgz",
-      "integrity": "sha512-wLLJQdL4v1yoqYtEtjKNjf8pJ/G/BqVomAWxcKOR1KbZJyCEnCv04yks7Y1NhJ3JzxbDs307W67uX0JzklFdCg==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@azure/core-sse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-sse/-/core-sse-1.0.0.tgz",
-      "integrity": "sha512-UhsxgWrQaIh6rJynDCNHYDbJ1b3bmqaOex4so8+h0UL4mxyb/og2FHoDJPzgLlvtM4b6/d/klBpwltsxHaZgNA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-      "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/openai": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@azure/openai/-/openai-1.0.0-beta.7.tgz",
-      "integrity": "sha512-LhZXgEGOoDBYyLDnSe5XwkLM5OUC8RppVW1X6+IrmmGnonsaa0POQ2BYr45YAqlpggtATYRVUbmyLi5SxMzhLg==",
-      "dependencies": {
-        "@azure-rest/core-client": "^1.1.4",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-lro": "^2.5.3",
-        "@azure/core-rest-pipeline": "^1.12.2",
-        "@azure/core-sse": "^1.0.0",
-        "@azure/logger": "^1.0.3",
-        "form-data-encoder": "^3.0.0",
-        "formdata-node": "^5.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -3271,14 +3133,6 @@
         }
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -4647,17 +4501,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4963,11 +4806,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.5.4",
@@ -5504,17 +5342,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
@@ -5927,14 +5754,6 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -7146,39 +6965,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-3.0.1.tgz",
-      "integrity": "sha512-f8HPYqVUtZcpe+eg0xxDXryMxfFMZdNQZVXs3KOY3nSeLUDQBaz3w3UUVXJSgR266pgW4ruwnvV5JR+cJJD6dw==",
-      "engines": {
-        "node": ">= 16.5"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-5.0.1.tgz",
-      "integrity": "sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -7612,31 +7398,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -8844,14 +8605,15 @@
       "license": "ISC"
     },
     "node_modules/marked": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
-      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9078,25 +8840,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-function": {
@@ -9868,24 +9611,6 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-exports-info": {
@@ -13450,14 +13175,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,6 @@
     "prepare": "cd ../.. && husky || true"
   },
   "dependencies": {
-    "@azure/openai": "^1.0.0-beta.7",
     "@heroicons/react": "^2.2.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/adapter-pg": "^7.9.1",
@@ -20,7 +19,7 @@
     "clsx": "^2.1.1",
     "eventsource-parser": "^1.1.1",
     "jose": "^6.2.4",
-    "marked": "^9.1.4",
+    "marked": "^18.0.7",
     "next": "16.2.12",
     "next-auth": "^4.24.15",
     "pg": "^8.22.0",

--- a/apps/web/src/app/api/chat/grounded/route.ts
+++ b/apps/web/src/app/api/chat/grounded/route.ts
@@ -1,6 +1,5 @@
-import { Citation, Product } from "@/lib/types";
+import { ChatMessage, Citation, Product } from "@/lib/types";
 import { type NextRequest } from "next/server";
-import { ChatMessage } from "@azure/openai/rest";
 import { promises as fs } from "fs";
 
 const searchendpoint = process.env.CONTOSO_SEARCH_ENDPOINT!;

--- a/apps/web/src/app/products/[slug]/page.tsx
+++ b/apps/web/src/app/products/[slug]/page.tsx
@@ -40,7 +40,9 @@ function getRange(header1:string, header2:string, markdown: string[]): string {
   const start = markdown.findIndex((m) => m.startsWith(header1));
   const end = header2.length > 0 ? markdown.findIndex((m) => m.startsWith(header2)) : markdown.length - 1;
   const range = markdown.slice(start, end);
-  return marked.parse(range.join("\n"));
+  // marked >=9 types parse as string | Promise<string>; async: false selects
+  // the synchronous overload, which is what this synchronous helper returns.
+  return marked.parse(range.join("\n"), { async: false });
 }
 
 export default async function Page({

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -46,3 +46,11 @@ export interface GroundedMessage {
   message: string;
   citations: Citation[];
 };
+
+// Chat messages forwarded verbatim to the Azure OpenAI extensions endpoint.
+// Declared here rather than imported from @azure/openai: that package was a
+// dependency solely for this type, and the route calls Azure over fetch.
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+};


### PR DESCRIPTION
Supersedes **#56** (marked 9→18) and **#21** (@azure/openai 1.0.0-beta.7→2.0.0). Combined because both touch `package.json`, so landing them separately would just serialize a lockfile conflict.

## marked 9 → 18 (#56)

marked >=9 types `parse()` as `string | Promise<string>`, which broke the synchronous `getRange` helper:

```
src/app/products/[slug]/page.tsx(43,3): error TS2322:
  Type 'string | Promise<string>' is not assignable to type 'string'.
```

The typings carry an explicit synchronous overload:

```ts
(src: string, options: MarkedOptions & { async: false }): ParserOutput;
```

so passing `{ async: false }` selects it. One call site.

## Drop @azure/openai (#21)

The package was a dependency **solely for the `ChatMessage` type**, used once:

```ts
const messages: ChatMessage[] = await request.json();
```

The route calls Azure over `fetch` and never touches the SDK, so upgrading to 2.0.0 — a rewritten client surface — would buy nothing. The type is declared in `@/lib/types` instead, matching what the client actually sends (`role`, `content`).

This also removes **24 packages** and resolves the merge conflict that left #21 `DIRTY`/unmergeable.

## Verification

- `tsc --noEmit`, eslint, 29 test files / 67 tests
- In the built image, the product detail page renders **8 `<h2>` elements** from the manual markdown — matching the 8 in `manual_tents.md`, confirming marked 18 still emits HTML rather than a stringified Promise
- Category pages and `?type=` still resolve; `/api/products` returns 210 products

Rebased onto #61, so the async-params fix is not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)