### PR TITLE
test(e2e): assert a dynamic [slug] page renders

### DIFF
--- a/scripts/e2e_smoke.py
+++ b/scripts/e2e_smoke.py
@@ -8,6 +8,7 @@ import json
 import time
 import urllib.error
 import urllib.request
+from html import escape
 from typing import Any
 
 
@@ -153,6 +154,39 @@ def check_web_chat_proxy(web_url: str) -> None:
         raise RuntimeError(f"Web chat proxy response missing answer/response field: {response_payload}")
 
 
+def check_web_dynamic_page(web_url: str) -> None:
+    """Render a page with a dynamic [slug] segment.
+
+    Every other check here targets a route handler, and route handlers receive
+    no route params. That blind spot let a Next 16 upgrade ship pages that
+    404'd on every product because `params` became a Promise and was not
+    awaited, while the whole suite stayed green.
+
+    The slug is read from the API rather than hard-coded so this does not need
+    updating when seed data changes.
+    """
+    status, payload, raw = request_json("GET", f"{web_url}/api/products")
+    if status != 200:
+        raise RuntimeError(f"/api/products returned {status}: {raw[:200]}")
+    if not isinstance(payload, list) or not payload:
+        raise RuntimeError("No products returned; cannot exercise a dynamic page.")
+
+    product = payload[0]
+    slug = product.get("slug") if isinstance(product, dict) else None
+    name = product.get("name") if isinstance(product, dict) else None
+    if not slug:
+        raise RuntimeError(f"First product has no slug to request: {product}")
+
+    status, _payload, html = request_json("GET", f"{web_url}/products/{slug}", timeout=20.0)
+    if status != 200:
+        raise RuntimeError(
+            f"/products/{slug} returned {status}. A dynamic segment failed to "
+            "resolve (unawaited params render every slug as not-found)."
+        )
+    if name and name not in html and escape(name) not in html:
+        raise RuntimeError(f"/products/{slug} rendered without product name {name!r}.")
+
+
 def main() -> int:
     args = parse_args()
 
@@ -173,6 +207,12 @@ def main() -> int:
         timeout_seconds=args.timeout,
         interval_seconds=args.interval,
         check=lambda: check_web_chat_proxy(args.web_url),
+    )
+    wait_for(
+        label="web dynamic [slug] page",
+        timeout_seconds=args.timeout,
+        interval_seconds=args.interval,
+        check=lambda: check_web_dynamic_page(args.web_url),
     )
 
     print("E2E smoke passed.")


### PR DESCRIPTION
Closes the coverage gap that let #60's regression reach `main`.

## The gap

Every existing smoke check targets a **route handler** — `/health`, `/health/dependencies`, `/api/chat/service`. Route handlers receive no route params, so nothing in the suite ever rendered a page with a dynamic segment.

That is exactly how #60 shipped a Next 16 upgrade where **every product page returned 404**: `params` became a Promise in Next 15 and was not awaited. The whole suite stayed green. It was caught in #61 only because unrelated `marked` work happened to load a product page.

## The check

Reads a slug from `/api/products` rather than hard-coding one, so it survives seed-data changes, then asserts the page returns 200 and contains the product name.

## Verified both directions

Against the built image, not just unit-mocked:

**On current main** — passes:
```
[PASS] chat health
[PASS] chat dependency health (db)
[PASS] web -> chat proxy call
[PASS] web dynamic [slug] page
E2E smoke passed.
```

**With the unawaited-params bug deliberately reintroduced** — the three pre-existing checks still pass, and only the new one fails:
```
[PASS] chat health
[PASS] chat dependency health (db)
[PASS] web -> chat proxy call
RuntimeError: web dynamic [slug] page failed before timeout. Last error:
  /products/trailmaster-x4-tent returned 404. A dynamic segment failed to
  resolve (unawaited params render every slug as not-found).
```
exit 1.

The negative case is the point: a guard that cannot fail on the bug it was written for is not a guard. Those three passing lines are the old suite going green on broken code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)