### PR TITLE
fix(chat): detect constraint pins no manifest requires

### DIFF
--- a/services/chat/scripts/check_dependency_policy.py
+++ b/services/chat/scripts/check_dependency_policy.py
@@ -4,12 +4,21 @@
 Policy:
 - `constraints.txt` must pin packages with exact `==` versions.
 - Every package referenced in requirement manifests must exist in `constraints.txt`.
+- Every pin in `constraints.txt` must be required by some requirement manifest.
 - Requirement manifests must use bare package names only.
 
 Versions live in exactly one place. A package pinned in both a requirement
 manifest and `constraints.txt` gives Dependabot two places to edit; it updates
 one, and `pip install -c` then fails with ResolutionImpossible before any
 check in this repo gets a chance to run.
+
+The pins and the manifests are kept in exact correspondence, in both
+directions. A pin nothing requires is inert: it constrains a version that may
+not be installed at all, while looking like the dependency is managed. That is
+how `httpx` disappeared — it was pinned here but declared in no manifest,
+arriving only as a transitive dependency of `prisma-client-py`. Removing that
+package silently dropped `httpx`, and the failure surfaced later and elsewhere,
+as `starlette` failing at test collection over `httpx2`.
 """
 
 from __future__ import annotations
@@ -81,6 +90,30 @@ def load_constraints(path: Path) -> tuple[dict[str, str], list[str]]:
     return pins, errors
 
 
+def check_unused_constraints(
+    requirement_files: tuple[Path, ...], constraints: dict[str, str]
+) -> list[str]:
+    """Flag pins that no manifest requires.
+
+    Every pin here corresponds to a directly declared package; there are no
+    transitive-only pins to allow for. A pin without a manifest entry means
+    either the manifest entry was dropped and the pin left behind, or the pin
+    was added speculatively — both make the pin inert.
+    """
+    required: set[str] = set()
+    for req_file in requirement_files:
+        for idx, raw in enumerate(req_file.read_text(encoding="utf-8").splitlines(), start=1):
+            parsed = parse_line(raw, req_file, idx)
+            if parsed is not None:
+                required.add(parsed[0])
+
+    return [
+        f"{CONSTRAINTS_FILE}: '{name}' is pinned but required by no manifest; "
+        f"add it to a requirements file or drop the pin"
+        for name in sorted(set(constraints) - required)
+    ]
+
+
 def check_requirements(requirement_files: tuple[Path, ...], constraints: dict[str, str]) -> list[str]:
     errors: list[str] = []
 
@@ -119,6 +152,7 @@ def main() -> int:
 
         constraints, errors = load_constraints(CONSTRAINTS_FILE)
         errors.extend(check_requirements(REQUIREMENT_FILES, constraints))
+        errors.extend(check_unused_constraints(REQUIREMENT_FILES, constraints))
 
         if errors:
             print("Dependency policy check failed:")


### PR DESCRIPTION
Closes #65.

## Problem

The policy check enforced one direction — every package a manifest requires must be pinned in `constraints.txt` — but not the reverse. A pin nothing requires is **inert**: it constrains a version that may not be installed at all, while looking like the dependency is managed.

Before this change, appending a package nothing requires passed, and was even counted as valid:

```
$ printf 'zzz-not-required==1.0.0\n' >> services/chat/constraints.txt
$ make -C services/chat deps-check
Dependency policy check passed: 25 pinned packages validated across 4 requirement files.
```

## Why it matters

This is exactly how #57's CI break hid. `httpx` was pinned but declared in **no manifest** — it only ever arrived transitively via `prisma-client-py`. Removing that package silently dropped `httpx`, and the failure surfaced later and elsewhere, as `starlette` failing at test collection over `httpx2`, where it read as an unrelated PR's fault.

## Approach

Constraints and manifests are an exact 1:1 set in this repo — 24 pins, 24 manifest packages, **zero transitive-only pins**. So this checks direct correspondence rather than approximating a resolver, which keeps it accurate instead of heuristic. If a transitive-only pin is ever genuinely needed, this check will say so and the decision becomes explicit.

## Verification

Three cases:

1. **Clean repo passes** — `24 pinned packages validated across 4 requirement files`
2. **Added orphan is caught** —
   ```
   - constraints.txt: 'zzz-not-required' is pinned but required by no manifest;
     add it to a requirements file or drop the pin
   ```
   exit 2
3. **The historical case is caught** — removing `httpx` from `tests/requirements-test.txt` while leaving its pin now fails with `'httpx' is pinned but required by no manifest`

Plus `make test-scripts` (63) and `make -C services/chat quick-ci` (56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)