### PR TITLE
fix(chat): shrink the full-profile chat image below its budget

### DIFF
--- a/services/chat/Dockerfile
+++ b/services/chat/Dockerfile
@@ -28,9 +28,20 @@ COPY --chown=appuser:appuser services/chat/src/api/requirements-local.txt requir
 COPY --chown=appuser:appuser services/chat/constraints.txt constraints.txt
 
 # Install core dependencies first; optionally install the heavier local stack.
+#
+# The local stack resolves torch from PyTorch's CPU-only index. The default
+# PyPI wheel drags in ~2.5GB of nvidia-* CUDA runtime plus triton, none of
+# which this image can use: there is no GPU in CI, Ollama runs outside the
+# container, and torch is only here to back sentence-transformers embeddings.
+# The local stack installs with --no-compile. PYTHONDONTWRITEBYTECODE only stops
+# runtime writes, so pip still compiled it to ~560MB of __pycache__. Skipping it
+# costs ~25s of import time on first use, which is why the core stack — the one
+# the default production image ships — keeps its bytecode.
 RUN pip install --no-cache-dir --default-timeout=300 --retries 5 -r requirements-core.txt -c constraints.txt && \
     if [ "${INSTALL_LOCAL_STACK}" = "1" ]; then \
-      pip install --no-cache-dir --default-timeout=600 --retries 3 -r requirements-local.txt -c constraints.txt; \
+      pip install --no-cache-dir --no-compile --default-timeout=600 --retries 3 \
+        --extra-index-url https://download.pytorch.org/whl/cpu \
+        -r requirements-local.txt -c constraints.txt; \
     fi
 
 # Copy application code


### PR DESCRIPTION
Closes #32. The scheduled full-profile smoke has failed on image size every run since at least May; this makes it pass.

## Result (from a dispatched full-profile CI run, not a local measurement)

| | chat image | vs 2.0 GB budget |
| --- | --- | --- |
| before | **9.10 GB** | 4.5× over |
| CPU-only torch | 2.19 GB | still 190 MB over |
| **+ `--no-compile` on the local stack** | **1.86 GB** | ✅ under, 137 MB margin |

**79.5% reduction.** The dispatched run completed `success` with no `warning=` line.

## Cause 1 — CUDA runtime that cannot be used

The default PyPI `torch` wheel pulls the CUDA build plus its `nvidia-*` libraries. Resolving from PyTorch's CPU index drops **19 packages**:

```
default PyPI:    122 packages, 2.91 GB of downloads
                 torch 527MB, nvidia-cublas 423MB, nvidia-cudnn 366MB,
                 nvidia-cufft 214MB, nvidia-nccl 206MB, triton 198MB, ...
CPU-only index:  103 packages, ~0.38 GB
```

None of it is reachable in this image: CI has no GPU, Ollama runs **outside** the container, and `torch` is only present to back `sentence-transformers` embeddings, which run on CPU either way. Verified in the built image: `torch 2.13.0+cpu`, `cuda_is_available() == False`, zero `nvidia-*`/`triton` packages.

## Cause 2 — 561 MB of bytecode

`PYTHONDONTWRITEBYTECODE=1` is set, but that only suppresses *runtime* writes — pip still compiled every install, leaving 561 MB of `__pycache__`.

**This one is a trade, not free.** Without bytecode, importing the local stack goes from **26.7s → 52.1s**, since Python parses source instead of loading `.pyc`.

So it is applied to the **local stack only**:

| | image | bytecode | startup |
| --- | --- | --- | --- |
| lite (**what production ships**) | 670 MB | kept — 1122 `__pycache__` dirs | unchanged |
| full (weekly smoke + local LLM dev) | 1.86 GB | skipped | +25s first import |

Applying `--no-compile` everywhere would have reached 1.7 G instead of 1.9 G locally, but would have slowed the production image for 200 MB that isn't needed to clear the budget.

## Note on measurement

The same image measures **0.60 GB** by local `docker image inspect`, **2.3 G** by container `du`, and **2.19 GB** in CI. Local `inspect` and the CI metric disagree because the image stores differ, which is why every number quoted above comes from a CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)