### PR TITLE
chore(deps): pin starlette

### DIFF
--- a/services/chat/constraints.txt
+++ b/services/chat/constraints.txt
@@ -19,6 +19,7 @@ python-dotenv==1.2.2
 requests==2.34.2
 ruff==0.16.0
 sentence-transformers==5.6.1
+starlette==1.3.1
 tabulate==0.10.0
 torch==2.13.0
 uvicorn==0.51.0

--- a/services/chat/src/api/requirements-core.txt
+++ b/services/chat/src/api/requirements-core.txt
@@ -6,7 +6,12 @@ tabulate
 requests
 
 # API server
+# starlette is fastapi's ASGI layer. It is pinned and declared because it is
+# unpinned-by-default and floated 0.47 -> 1.3 on its own, breaking CI when the
+# new major changed its test-client HTTP dependency. No module imports it
+# directly.
 fastapi
+starlette
 uvicorn[standard]
 
 # Google Cloud Services


### PR DESCRIPTION
Closes #64.

## Problem

`starlette` was the only runtime dependency left unpinned. It floated from `0.47` to **`1.3.1`** with no change on our side and broke CI during #57:

```
starlette/testclient.py:41: raise RuntimeError(
E   RuntimeError: The starlette.testclient module requires the httpx2 package to be installed.
```

Two things had to line up: starlette 1.x prefers `httpx2`, and `httpx` had silently stopped being installed because it only ever arrived transitively via `prisma-client-py`. #57 fixed the `httpx` half by declaring it explicitly, and #70 added a check so an orphaned pin cannot hide again — but **starlette itself stayed unpinned and free to move**.

It also left local and CI disagreeing about a library *major* on the same commit: this repo's `.venv` resolved `0.47.3` while CI resolved `1.3.1`. That is a bad property for reproducing failures.

## Change

Pinned at **1.3.1** — the version CI already runs and passes on — so this fixes the version in place rather than changing behaviour. The local venv now installs 1.3.1 too, so the two agree.

Declared in `requirements-core.txt` as well as pinned, because #70 now requires every pin to be required by a manifest. This follows the existing convention for `httpx`, which is likewise declared with a comment noting nothing imports it directly.

## Verification

- `make -C services/chat deps-check` — 25 pins validated, including the new orphan-pin rule from #70
- `make -C services/chat quick-ci` — lint, typecheck, 56 tests
- Local venv upgraded 0.47.3 → 1.3.1 and the suite still passes

## Follow-up, not done here

We remain on starlette's deprecated path:

```
StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is
deprecated; install `httpx2` instead.
```

The fallback works today and is not guaranteed to survive the next major. Migrating the test client to `httpx2` is the second half of #64 and deserves its own change — pinning is the urgent part, since it stops the version moving underneath us in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)