### PR TITLE
fix(ci): treat deletions as changes in the surface detector

### DIFF
--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -98,7 +98,11 @@ def matches_any(path: str, patterns: Iterable[str]) -> bool:
 
 
 def changed_files_from_range(base: str, head: str) -> list[str]:
-    raw = run_git(["diff", "--name-only", "--diff-filter=ACMRT", f"{base}...{head}"])
+    # D is included: a deletion changes a surface just as much as an edit.
+    # Without it a deletion-only change classified as "none" and CI skipped
+    # every scoped check, so removing a referenced asset or source file would
+    # have gone green without the web or chat suites ever running.
+    raw = run_git(["diff", "--name-only", "--diff-filter=ACMRTD", f"{base}...{head}"])
     return sorted({line.strip() for line in raw.splitlines() if line.strip()})
 
 

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -91,6 +91,29 @@ class DetectChangedSurfacesTests(unittest.TestCase):
                 flags = detect_changed.classify([path])
                 self.assertTrue(flags["runtime"])
 
+    def test_changed_files_from_range_includes_deletions(self):
+        """A deletion-only change must still classify its surface.
+
+        The diff filter previously omitted D, so removing files produced an
+        empty file list, classified as "none", and CI skipped every scoped
+        check — a deleted referenced asset or source file would have gone
+        green without the web or chat suites running.
+        """
+        with patch.object(detect_changed, "run_git", return_value="") as run_git:
+            detect_changed.changed_files_from_range(base="main", head="HEAD")
+
+        args = run_git.call_args.args[0]
+        diff_filter = next(a for a in args if a.startswith("--diff-filter="))
+        self.assertIn("D", diff_filter, "deletions must be reported as changes")
+
+    def test_deleted_web_asset_routes_to_web_checks(self):
+        flags = detect_changed.classify(
+            ["apps/web/public/images/1/abc-alt-1.jpg"],
+        )
+        self.assertTrue(flags["web"])
+        self.assertFalse(flags["none"])
+        self.assertIn("quick-ci-web", detect_changed.recommended_targets(flags))
+
     def test_changed_files_from_worktree_parses_porcelain(self):
         porcelain = "\n".join(
             [


### PR DESCRIPTION
## The bug

The changed-surface detector filtered `git diff` with `--diff-filter=ACMRT`, which omits **D**. A change consisting only of deletions produced an **empty file list**, classified as `none`, and CI skipped every scoped check.

```
before:  git diff --name-only --diff-filter=ACMRT  main...HEAD  ->    0 files
after:   git diff --name-only --diff-filter=ACMRTD main...HEAD  ->  449 files
         classify -> {web: True}, targets: ['quick-ci-web']
```

## How it surfaced

#88 deletes 449 image files that ship inside the web image. Its checks:

```
pass      Analyze (javascript-typescript)
pass      Analyze (python)
pass      CodeQL
pass      Detect Changed Surfaces
skipping  Web App CI
skipping  Integration E2E Smoke
skipping  Chat Service CI
skipping  Onboarding Smoke
skipping  Script Guardrail Tests
skipping  Documentation and Agent Doc Checks
skipping  Env Contract Drift Check
```

`mergeStateStatus: CLEAN`. Nothing verified the image still built or the app still served — only the language analyzers ran, and those scan source, not assets.

**This is not limited to assets.** Deleting a referenced image, a source module, or a test file would have gone green identically, with the failure showing up in production or on somebody else's PR.

## Tests

Two regression tests, and the first one **fails against the old value** rather than merely passing against the new one:

```
AssertionError: 'D' not found in '--diff-filter=ACMRT' : deletions must be reported as changes
```

- `test_changed_files_from_range_includes_deletions` — asserts the filter includes `D`
- `test_deleted_web_asset_routes_to_web_checks` — asserts a deleted `apps/web/public/...` path classifies as `web` and routes to `quick-ci-web`

Script suite: 63 → **65**.

## Order

This should land before #88, so that PR re-runs with the web checks it never got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)