### PR TITLE
fix(web): drop the dead border-zinc-40 class

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -310,7 +310,7 @@ export const Chat = () => {
           </div>
         )}
         <button
-          className="bg-white rounded-full p-2 shadow-lg border-zinc-40 hover:cursor-pointer"
+          className="bg-white rounded-full p-2 shadow-lg hover:cursor-pointer"
           onClick={toggleChat}
           aria-label={showChat ? "Close chat" : "Open chat"}
         >

--- a/apps/web/src/components/video.tsx
+++ b/apps/web/src/components/video.tsx
@@ -109,7 +109,7 @@ const Video = ({ onVideoClick, onClose }: Props) => {
             </select>
             {showCamera && (
               <button
-                className="bg-white rounded-full p-2 shadow-md border-zinc-40 hover:cursor-pointer"
+                className="bg-white rounded-full p-2 shadow-md hover:cursor-pointer"
                 onClick={handleVideoClick}
                 aria-label="Take picture"
               >
@@ -117,7 +117,7 @@ const Video = ({ onVideoClick, onClose }: Props) => {
               </button>
             )}
             <button
-              className="bg-white rounded-full p-2 shadow-md border-zinc-40 hover:cursor-pointer"
+              className="bg-white rounded-full p-2 shadow-md hover:cursor-pointer"
               onClick={() => onClose()}
               aria-label="Close camera"
             >


### PR DESCRIPTION
Three occurrences of a misspelled `border-zinc-40` — `chat.tsx` once, `video.tsx` twice. Found while checking class coverage for the Tailwind 4 migration (#91).

No such utility exists, so Tailwind emitted no rule for it on v3 and none on v4. It was inert either way.

## Why removed, not corrected

The obvious "fix" is `border-zinc-400`. That would still render nothing:

```html
className="bg-white rounded-full p-2 shadow-lg border-zinc-40 hover:cursor-pointer"
```

None of the three elements carries a border-**width** utility, and Tailwind's preflight sets `border-width: 0`. A colour alone paints no border. Adding `border` to make it visible would be a **design change**, not a typo fix, and not one I can verify without knowing the intent.

So the dead class is removed and the decision is left explicit: if a border was wanted, these want `border border-zinc-400`.

## No visual change

The class produced no CSS before this change and none after. `tsc`, eslint, and 67 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)