### PR TITLE
chore(deps): move the starlette test client to httpx2

### DIFF
--- a/services/chat/constraints.txt
+++ b/services/chat/constraints.txt
@@ -4,7 +4,7 @@ fastapi==0.141.1
 google-auth==2.56.2
 google-cloud-aiplatform==1.163.0
 google-cloud-discoveryengine==0.20.2
-httpx==0.28.1
+httpx2==2.9.1
 jsonlines==4.0.0
 litellm==1.94.1
 mypy==2.3.0

--- a/services/chat/tests/requirements-test.txt
+++ b/services/chat/tests/requirements-test.txt
@@ -3,5 +3,6 @@ requests
 python-dotenv
 pytest-cov
 
-# Required by fastapi.testclient/starlette.testclient; no test imports it directly.
-httpx
+# Required by fastapi.testclient/starlette.testclient; no test imports it
+# directly. starlette >=1.0 prefers httpx2 and warns when it falls back to httpx.
+httpx2


### PR DESCRIPTION
Closes #92 — the follow-up half of #64, which pinned starlette but deliberately left this.

## Why

starlette 1.x prefers `httpx2` and warns when it falls back:

```
StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is
deprecated; install `httpx2` instead.
```

The fallback works today and is not guaranteed to survive the next major. **This exact chain already broke CI once** during #57 — starlette floated to 1.x while `httpx` had quietly stopped being installed, and it surfaced as `RuntimeError: The starlette.testclient module requires the httpx2 package`.

## Change

- `tests/requirements-test.txt`: `httpx` → `httpx2`
- `constraints.txt`: `httpx==0.28.1` → `httpx2==2.9.1`

## On dropping the httpx pin

`httpx` is **still installed** — but now purely as a transitive dependency of `google-genai`, not as something our test client needs:

```
Required-by: google-genai
```

So its pin is dropped and it is left unpinned like every other transitive here (`anyio`, `certifi`, and the rest). starlette was singled out for pinning only because it broke us; pinning every transitive is not the policy, and #70's orphan check would reject a pin with no manifest entry anyway.

Worth being explicit since #64/#65 were about unpinned load-bearing packages: `httpx` is no longer load-bearing for us.

## Verification

- `from starlette.testclient import TestClient` under `-W always` — **imports clean, no warning**
- chat suite: 59 tests, no starlette deprecation in the run
- `deps-check` passes at 25 pins, including #70's orphan rule
- dockerized E2E smoke passes, including the dynamic `[slug]` page check

🤖 Generated with [Claude Code](https://claude.com/claude-code)