### PR TITLE
docs(agents): add the development workflow to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,102 @@ moving the content across:
 make agent-docs-check FIX=1
 ```
 
+## Development workflow
+
+Follow these steps in order for every change.
+
+1. **Inspect before changing anything.** Inspect the repository, current Git
+   state, and all applicable instruction files before making changes. Preserve
+   unrelated staged, unstaged, and untracked work.
+
+2. **Create a branch first.** Create a dedicated feature, fix, refactor, chore,
+   test, or documentation branch before making code changes. Never commit
+   directly to `main`, and create the branch from the latest appropriate
+   `main` state.
+
+3. **Choose a thin vertical slice.** Before implementing a tracked issue or
+   feature, define the smallest end-to-end slice that can be reviewed, tested,
+   shipped, and merged independently. Prefer one coherent user-visible or
+   operational outcome over a broad horizontal layer. If the next issue is too
+   large for one pull request, split it into ordered slices and complete only
+   the current slice. Keep pull requests small enough for thorough review,
+   reliable verification, and quick rollback.
+
+4. **Use test-driven development when behavior or structure is testable.**
+   - Add or update a focused test before implementation.
+   - Run it and confirm it fails for the expected reason.
+   - Implement the smallest appropriate change.
+   - Run focused tests while iterating.
+   - Refactor only while the relevant tests remain green.
+
+5. **Inspect the complete diff.** Review the branch diff plus all staged,
+   unstaged, and untracked files. Remove accidental or unrelated changes while
+   preserving work that belongs to the user.
+
+6. **Run `ui-review` before verification.** After the main agent completes an
+   implementation pass, invoke the `ui-review` sub-agent. The `ui-review`
+   sub-agent must act as an expert in website design, usability,
+   responsiveness, and accessibility. Address every actionable finding before
+   running the `verifier`. For UI-affecting changes, exercise the changed
+   journey in the rendered application at representative phone, tablet, and
+   desktop viewports; inspect interaction, loading, empty, error, focus,
+   keyboard, contrast, and responsive states as applicable; and capture
+   screenshots or equivalent visual evidence. For changes with no UI impact,
+   explicitly record that rendered UI review is not applicable. If a finding
+   is not applicable, record the concrete reason rather than silently ignoring
+   it.
+
+7. **Run `verifier` before code review.** Invoke the `verifier` sub-agent to run
+   the builds, static checks, tests, and journey coverage appropriate for the
+   change. The verifier must report failures, flakes, missing coverage, and
+   environment issues. Fix or explicitly resolve every actionable finding
+   before starting code review. If a verifier finding requires a code change,
+   rerun the verifier after addressing it.
+
+8. **Run `code-review` before every commit.** Invoke the `code-review`
+   sub-agent against the current branch diff and every staged, unstaged, and
+   untracked file. The reviewer must act as an expert in the languages and
+   frameworks used by this application. Address every actionable finding
+   before committing. If review findings cause changes, rerun the appropriate
+   tests and the `verifier`, then obtain a fresh `code-review` approval for the
+   changed state.
+
+9. **Commit after approval.** Commit only after verification and code review
+   are complete. Use Conventional Commits:
+
+   ```text
+   <type>(<scope>): <imperative summary>
+   ```
+
+   Keep the subject at 72 characters or fewer, describe why in the body when
+   useful, and do not combine unrelated work.
+
+10. **Create pull requests from the reviewed state.**
+    - Confirm that local verification remains valid.
+    - Rerun `code-review` only if the reviewed state changed after the
+      pre-commit review.
+    - A changed state includes code, tests, documentation, generated files,
+      conflict resolution, or any other staged, unstaged, or untracked content.
+    - Do not repeat code review when the already-reviewed diff and worktree
+      remain unchanged.
+    - Push and create the pull request only after local verification and any
+      required code review are complete.
+    - Open a normal, ready-for-review pull request by default. Do not open
+      draft pull requests unless the user explicitly asks for a draft.
+
+11. **Merge only clean, passing pull requests.** Merge only after GitHub
+    reports a clean merge state and every configured check passes. Never bypass
+    a failing or pending required check. Self-merges are allowed when these
+    conditions are met. Use squash merge for short-lived development branches
+    to keep `main` linear, then delete the merged branch.
+
+### Sub-agents this workflow depends on
+
+Steps 6 through 8 require `ui-review`, `verifier`, and `code-review`. These are
+not yet defined in this repository. Until they exist, carry out each step's
+intent directly and say which agent was unavailable, rather than skipping the
+step or reporting it as done.
+
 ## Repo map
 
 - `apps/web/src/app/`: Next.js pages and API routes.


### PR DESCRIPTION
Adds an eleven-step development workflow to `AGENTS.md`.

## Scope

**`AGENTS.md` is the only file changed.** `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` already point at it and must stay pure pointers — `make agent-docs-check` fails if any gains content — so all four assistants pick this up without duplicating it.

## Contents

Inspection before changing → branch first → thin vertical slice → TDD → full diff review → `ui-review` → `verifier` → `code-review` → Conventional Commits → PR from the reviewed state → merge only clean and passing.

## One thing to be aware of

**Steps 6–8 reference sub-agents that do not exist in this repository.** `.claude/` currently contains only `settings.json` — there is no `ui-review`, `verifier`, or `code-review` definition anywhere.

The steps are written exactly as specified, and a short subsection records the gap:

> Steps 6 through 8 require `ui-review`, `verifier`, and `code-review`. These are not yet defined in this repository. Until they exist, carry out each step's intent directly and say which agent was unavailable, rather than skipping the step or reporting it as done.

Without that, an agent reaching an undefined sub-agent either fails outright or quietly improvises and reports the gate as satisfied — the second being worse, since it produces a false record of review.

Defining those three agents is worth doing as a follow-up; this PR does not attempt it.

## Verification

`make docs-check` passes (including `agent-docs-check`, confirming the pointer files stayed pointers), and `make test-scripts` passes at 65 tests. `git diff --name-only` shows `AGENTS.md` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)