### PR TITLE
docs(agents): point the workflow at the sub-agents now that they exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,17 @@ Follow these steps in order for every change.
 
 ### Sub-agents this workflow depends on
 
-Steps 6 through 8 require `ui-review`, `verifier`, and `code-review`. These are
-not yet defined in this repository. Until they exist, carry out each step's
-intent directly and say which agent was unavailable, rather than skipping the
-step or reporting it as done.
+Steps 6 through 8 use `ui-review`, `verifier`, and `code-review`, defined in
+`.claude/agents/`. All three run unattended: they cannot ask a question and
+cannot modify the repository they assess.
+
+If one is unavailable — a different assistant, or a session started before the
+definitions landed — carry out that step's intent directly and say which agent
+was unavailable, rather than skipping the step or reporting it as done.
+
+`ui-review` needs a browser to satisfy step 6's rendered-journey requirement.
+Where none is installed it falls back to reviewing source and must say so; a
+review that claims viewports it never rendered is worse than none.
 
 ## Repo map
 


### PR DESCRIPTION
#98 added `ui-review`, `verifier`, and `code-review` under `.claude/agents/`. That left the note from #97 stating they were undefined.

The stale note is not cosmetic: an agent reading it would take the fallback path — "carry out the step's intent directly" — instead of invoking the real sub-agents, silently bypassing the gates the workflow exists to enforce.

## Changes

- says where the three agents live
- records that all three run unattended: no ability to ask a question, no ability to modify the repository they assess
- **keeps** the fallback guidance, now scoped to the case where an agent genuinely is unavailable — a different assistant, or a session started before the definitions landed
- carries forward the one real constraint: `ui-review` needs a browser for step 6's rendered-journey requirement, and must say so when none is installed rather than claiming viewports it never rendered

`AGENTS.md` is the only file changed. `make docs-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)