### PR TITLE
test(agents): guard AGENTS.md's sub-agent claims against their definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,9 @@ release-dry-run: | $(VENV_PYTHON) ## Validate release prerequisites without publ
 docs-check: | $(VENV_PYTHON) ## Validate docs links and agent doc pointers
 	$(PYTHON) scripts/verify_docs.py
 	$(MAKE) agent-docs-check
+	# AGENTS.md is a docs path, so a change to it never reaches test-scripts.
+	# This guard reads AGENTS.md, so it has to run here too.
+	$(PYTHON) -m unittest discover -s tests/scripts -p "test_agent_definitions.py"
 
 agent-docs-check: | $(VENV_PYTHON) ## Verify CLAUDE.md/GEMINI.md/copilot-instructions.md stay pointers to AGENTS.md (set FIX=1 to restore)
 	$(PYTHON) scripts/check_agent_docs.py $(if $(FIX),--fix,)

--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -36,6 +36,9 @@ RUNTIME_PATTERNS = (
     "scripts/verify_docs.py",
     "scripts/check_agent_docs.py",
     "tests/scripts/**",
+    # Agent definitions are repo tooling. Without this they classify as
+    # "unknown", which forces runtime by accident rather than by intent.
+    ".claude/agents/**",
     "apps/web/package-lock.json",
     "apps/web/package.json",
     "services/chat/constraints.txt",

--- a/tests/scripts/test_agent_definitions.py
+++ b/tests/scripts/test_agent_definitions.py
@@ -1,0 +1,184 @@
+"""Guard AGENTS.md's claims about the workflow sub-agents against their definitions.
+
+AGENTS.md states that `ui-review`, `verifier`, and `code-review` are defined in
+`.claude/agents/`, that all three run unattended, and that none can modify the
+repository it assesses. Those claims are load-bearing: the first is why the
+workflow can run without a human present, the second is why a review agent is
+trusted to look at uncommitted work.
+
+Nothing else checks them. `verify_docs.py` validates that links resolve and that
+pointer files stay pointers; it does not compare prose against the agent
+definitions, and the references are inline code spans rather than links. So an
+agent could gain `Write` or `AskUserQuestion` and the documentation would keep
+asserting otherwise with every check green.
+
+Same shape as the schema drift guarded in services/chat/tests/unit/test_schema_drift.py:
+two files that must agree, with nothing enforcing it.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+AGENTS_DIR = REPO_ROOT / ".claude/agents"
+
+# Tools that would contradict a claim AGENTS.md makes about these agents.
+INTERACTIVE_TOOLS = ("AskUserQuestion",)
+MUTATING_TOOLS = ("Write", "Edit", "NotebookEdit")
+
+# Step number in AGENTS.md that invokes each agent.
+EXPECTED_STEP = {"ui-review": 6, "verifier": 7, "code-review": 8}
+
+
+def defined_agents() -> set[str]:
+    """Agents that actually exist on disk."""
+    return {p.stem for p in AGENTS_DIR.glob("*.md")}
+
+
+def agent_names_claimed_by_docs() -> set[str]:
+    """Agent names AGENTS.md says live in .claude/agents/.
+
+    Deliberately unfiltered. Filtering by a known set would make this a subset
+    by construction, so it could only ever detect a missing name — never an
+    extra one.
+    """
+    text = AGENTS_MD.read_text(encoding="utf-8")
+    section = text.split("### Sub-agents this workflow depends on", 1)
+    if len(section) < 2:
+        return set()
+    body = section[1].split("\n## ", 1)[0]
+    return set(re.findall(r"`([a-z][a-z-]*[a-z])`", body))
+
+
+def frontmatter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    block = text.split("---", 2)[1]
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" in line and not line.startswith((" ", "\t")):
+            key, _, value = line.partition(":")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def tools_of(fm: dict[str, str]) -> list[str]:
+    return [t.strip() for t in fm.get("tools", "").split(",") if t.strip()]
+
+
+def step_that_invokes(agent: str) -> int | None:
+    """The workflow step number whose text names this agent.
+
+    Read from AGENTS.md rather than hardcoded, so renumbering the workflow
+    cannot leave the test agreeing with a stale number.
+    """
+    text = AGENTS_MD.read_text(encoding="utf-8")
+    for match in re.finditer(r"^(\d+)\.\s+\*\*(.+?)\*\*", text, re.M):
+        number, heading = match.group(1), match.group(2)
+        if f"`{agent}`" in heading:
+            return int(number)
+    return None
+
+
+class AgentDefinitionTests(unittest.TestCase):
+    def test_every_agent_the_docs_name_exists(self):
+        for name in sorted(EXPECTED_STEP):
+            with self.subTest(agent=name):
+                self.assertTrue(
+                    (AGENTS_DIR / f"{name}.md").is_file(),
+                    f"AGENTS.md names '{name}' but .claude/agents/{name}.md is missing",
+                )
+
+    def test_docs_reference_every_defined_agent(self):
+        self.assertEqual(
+            agent_names_claimed_by_docs(),
+            set(EXPECTED_STEP),
+            "AGENTS.md's sub-agent section should name exactly the agents the workflow uses",
+        )
+
+    def test_no_undocumented_agent_exists(self):
+        """A new definition must be a deliberate decision, not a silent addition.
+
+        Without this, someone can add .claude/agents/<name>.md granting Write
+        and AskUserQuestion, mention it nowhere, and every other test here still
+        passes — while this file claims none of them can modify the repository.
+        """
+        self.assertEqual(
+            defined_agents(),
+            set(EXPECTED_STEP),
+            "every agent in .claude/agents/ must be named in AGENTS.md and listed "
+            "in EXPECTED_STEP; add it deliberately or remove it",
+        )
+
+    def test_agents_cannot_ask_questions(self):
+        """AGENTS.md claims all three run unattended."""
+        for name in sorted(defined_agents() | set(EXPECTED_STEP)):
+            with self.subTest(agent=name):
+                tools = tools_of(frontmatter(AGENTS_DIR / f"{name}.md"))
+                # Assert parsing succeeded first. `assertNotIn(x, [])` is
+                # trivially true, so an unparseable frontmatter would let this
+                # test pass while proving nothing.
+                self.assertTrue(tools, f"{name}: could not parse a tools list")
+                for banned in INTERACTIVE_TOOLS:
+                    self.assertNotIn(
+                        banned,
+                        tools,
+                        f"{name} has {banned}, so it can block waiting for a human; "
+                        "AGENTS.md claims these agents run unattended",
+                    )
+
+    def test_agents_cannot_modify_the_repository(self):
+        """AGENTS.md claims none of them can modify what they assess."""
+        for name in sorted(defined_agents() | set(EXPECTED_STEP)):
+            with self.subTest(agent=name):
+                tools = tools_of(frontmatter(AGENTS_DIR / f"{name}.md"))
+                self.assertTrue(tools, f"{name}: could not parse a tools list")
+                for banned in MUTATING_TOOLS:
+                    self.assertNotIn(
+                        banned,
+                        tools,
+                        f"{name} has {banned}, so it can modify the repository it reviews; "
+                        "AGENTS.md claims it cannot",
+                    )
+
+    def test_agent_description_matches_the_step_that_invokes_it(self):
+        """The step number is read from AGENTS.md, not hardcoded.
+
+        Hardcoding lets the workflow renumber while the test keeps agreeing
+        with a stale value.
+        """
+        for name, expected in sorted(EXPECTED_STEP.items()):
+            with self.subTest(agent=name):
+                step = step_that_invokes(name)
+                self.assertIsNotNone(
+                    step, f"no numbered workflow step in AGENTS.md names `{name}`"
+                )
+                self.assertEqual(
+                    step,
+                    expected,
+                    f"AGENTS.md invokes {name} at step {step}, but this test expects "
+                    f"{expected}; update EXPECTED_STEP if the workflow was renumbered",
+                )
+                description = frontmatter(AGENTS_DIR / f"{name}.md").get("description", "")
+                self.assertIn(
+                    f"step {step}",
+                    description.lower(),
+                    f"{name}'s description should say it is invoked at step {step}, "
+                    "matching the workflow in AGENTS.md",
+                )
+
+    def test_every_agent_declares_tools(self):
+        """An agent with no tools list inherits everything, defeating both claims."""
+        for name in sorted(defined_agents() | set(EXPECTED_STEP)):
+            with self.subTest(agent=name):
+                self.assertTrue(
+                    tools_of(frontmatter(AGENTS_DIR / f"{name}.md")),
+                    f"{name} declares no tools, so it would inherit the full tool set",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -91,6 +91,18 @@ class DetectChangedSurfacesTests(unittest.TestCase):
                 flags = detect_changed.classify([path])
                 self.assertTrue(flags["runtime"])
 
+    def test_agent_definitions_are_runtime(self):
+        """Agent definitions are repo tooling, not an unclassified path.
+
+        They would reach runtime anyway through the unknown fallback, but by
+        accident. An explicit pattern means the routing survives a change to
+        how unknown paths are handled.
+        """
+        flags = detect_changed.classify([".claude/agents/verifier.md"])
+        self.assertTrue(flags["runtime"])
+        self.assertFalse(flags["unknown"], "should match a pattern, not fall through")
+        self.assertIn("test-scripts", detect_changed.recommended_targets(flags))
+
     def test_changed_files_from_range_includes_deletions(self):
         """A deletion-only change must still classify its surface.
 

--- a/tests/scripts/test_venv_wiring.py
+++ b/tests/scripts/test_venv_wiring.py
@@ -76,5 +76,20 @@ class VenvWiringTests(unittest.TestCase):
         self.assertIn(".venv/", read(".gitignore"))
 
 
+class DocsCheckWiringTests(unittest.TestCase):
+    def test_docs_check_runs_the_agent_definition_guard(self):
+        """AGENTS.md classifies as docs, so docs-check is the only path that
+        runs for an AGENTS.md-only change. The guard reads AGENTS.md, so it has
+        to be invoked here or that drift goes unchecked."""
+        makefile = read("Makefile")
+        recipe = makefile.split("docs-check:", 1)[1].split("\n\n", 1)[0]
+        self.assertIn(
+            "test_agent_definitions.py",
+            recipe,
+            "docs-check must run the agent-definition guard; without it, "
+            "renumbering the workflow in AGENTS.md would not be caught",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #100.

`AGENTS.md` asserts that `ui-review`, `verifier`, and `code-review` exist in `.claude/agents/`, that all three **run unattended**, and that **none can modify the repository** it assesses. Those claims are load-bearing — the first is why the workflow can run without a human present, the second is why a review agent is trusted with uncommitted work.

Nothing checked them. `verify_docs.py` validates that links resolve and pointer files stay pointers; it does not read agent frontmatter, and the references are code spans rather than links.

## Verified by breaking things, not by passing

Every guard was confirmed to fail against a deliberately broken definition:

| broken | fails |
| --- | --- |
| agent gains `AskUserQuestion` | cannot-ask-questions |
| agent gains `Write` | cannot-modify |
| agent file deleted | existence |
| `tools` list removed | declares-tools |
| **undocumented agent added** | **three tests** |
| workflow step renumbered | step-match |

## Two rounds of review changed the shape of this

**`verifier`** found the tool-membership tests asserted against a possibly-empty list — `assertNotIn(x, [])` is trivially true, so unparseable frontmatter made them **vacuous**, saved only by a sibling test happening to catch it. They now assert the parse succeeded first. It also found the step number was hardcoded, so a renumbering would leave the test agreeing with a stale value; it is now read from `AGENTS.md`.

**`code-review`** found the guard **would not have run in CI for the changes it most needs to catch**. `AGENTS.md` is in `DOC_PATTERNS`, so it reaches `docs-check` but never `test-scripts` — renumbering a step or dropping an agent from the docs would have gone green. `docs-check` now runs the guard too, and `.claude/agents/**` is an explicit runtime pattern rather than relying on the `unknown` fallback.

It also found no test enumerated `.claude/agents/`, and a filter made the docs comparison a subset by construction — detecting a *missing* name but never an *extra* one. It proved this with a mutant: a new agent granting itself `Write` and `AskUserQuestion`, mentioned nowhere, passed all six tests. The set is now derived from disk.

Both wiring fixes are locked in by regression tests confirmed to fail when the wiring is removed.

## Suite

65 → **74 tests**.

## Out of scope

A pre-existing `path_matches` prefix-boundary bug surfaced during review — `dir/**` matches sibling directories because the `/**` strip leaves no separator check. Filed as #107, deliberately not fixed here. Currently inert, since affected paths reach the same target via the `unknown` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)