### PR TITLE
fix(web): stop profile routes writing arbitrary user columns

### DIFF
--- a/apps/web/src/app/api/profile/address/route.test.ts
+++ b/apps/web/src/app/api/profile/address/route.test.ts
@@ -54,4 +54,27 @@ describe('Shipping Address API', () => {
     expect(response.status).toBe(200)
     expect(updateUser).toHaveBeenCalledWith('user_1', expect.objectContaining({ addressLine1: '123 St', city: 'City' }))
   })
+
+  it('drops password and non-profile fields from the address payload', async () => {
+    // This route took the same unfiltered body as /api/profile, and its own
+    // comment acknowledged nothing validated the fields.
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user_1' } } as any)
+    vi.mocked(updateUser).mockResolvedValue({ id: 'user_1' } as any)
+
+    const request = new Request('http://localhost/api/profile/address', {
+      method: 'PUT',
+      body: JSON.stringify({
+        addressLine1: '123 St',
+        password: 'plaintext-secret',
+        email: 'attacker@example.com',
+      }),
+    })
+
+    await PUT(request)
+
+    const written = vi.mocked(updateUser).mock.calls[0][1]
+    expect(written).not.toHaveProperty('password')
+    expect(written).not.toHaveProperty('email')
+    expect(written).toEqual({ addressLine1: '123 St' })
+  })
 })

--- a/apps/web/src/app/api/profile/address/route.ts
+++ b/apps/web/src/app/api/profile/address/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { updateUser } from '@/lib/user'
+import { pickProfileFields } from '@/lib/profile-fields'
 
 export async function PUT(request: Request) {
   const session = await getServerSession(authOptions)
@@ -13,11 +14,13 @@ export async function PUT(request: Request) {
   const userId = (session.user as any).id
   const data = await request.json()
 
-  // In a real app, I might validate that only address fields are being updated here.
   
   try {
-    const updatedUser = await updateUser(userId, data)
-    return NextResponse.json(updatedUser)
+    const updatedUser = await updateUser(userId, pickProfileFields(data))
+    // Strip the hash, as GET already does. Returning it would hand the
+    // credential back to the client on every profile save.
+    const { password, ...userProfile } = updatedUser
+    return NextResponse.json(userProfile)
   } catch (error) {
     console.error('Address update error:', error)
     return NextResponse.json({ message: 'Internal server error' }, { status: 500 })

--- a/apps/web/src/app/api/profile/password/route.test.ts
+++ b/apps/web/src/app/api/profile/password/route.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PUT } from './route'
-import { updateUser, getUserById } from '@/lib/user'
+import { updateUserPassword, getUserById } from '@/lib/user'
 import { getServerSession } from 'next-auth'
 import { compare, hash } from 'bcryptjs'
 
 vi.mock('@/lib/user', () => ({
-  updateUser: vi.fn(),
+  updateUserPassword: vi.fn(),
   getUserById: vi.fn(),
 }))
 
@@ -67,7 +67,7 @@ describe('Password API', () => {
     vi.mocked(getUserById).mockResolvedValue({ password: 'hashed_old' } as any)
     vi.mocked(compare).mockResolvedValue(true as any)
     vi.mocked(hash).mockResolvedValue('hashed_new' as any)
-    vi.mocked(updateUser).mockResolvedValue({ id: 'user_1' } as any)
+    vi.mocked(updateUserPassword).mockResolvedValue({ id: 'user_1' } as any)
 
     const request = new Request('http://localhost/api/profile/password', {
       method: 'PUT',
@@ -76,6 +76,6 @@ describe('Password API', () => {
 
     const response = await PUT(request)
     expect(response.status).toBe(200)
-    expect(updateUser).toHaveBeenCalledWith('user_1', { password: 'hashed_new' })
+    expect(updateUserPassword).toHaveBeenCalledWith('user_1', 'hashed_new')
   })
 })

--- a/apps/web/src/app/api/profile/password/route.ts
+++ b/apps/web/src/app/api/profile/password/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import { updateUser, getUserById } from '@/lib/user'
+import { updateUserPassword, getUserById } from '@/lib/user'
 import { compare, hash } from 'bcryptjs'
 
 export async function PUT(request: Request) {
@@ -30,7 +30,7 @@ export async function PUT(request: Request) {
     }
 
     const hashedPassword = await hash(newPassword, 12)
-    await updateUser(userId, { password: hashedPassword })
+    await updateUserPassword(userId, hashedPassword)
 
     return NextResponse.json({ message: 'Password updated' })
   } catch (error) {

--- a/apps/web/src/app/api/profile/route.test.ts
+++ b/apps/web/src/app/api/profile/route.test.ts
@@ -55,4 +55,58 @@ describe('Profile API', () => {
     expect(response.status).toBe(200)
     expect(updateUser).toHaveBeenCalledWith('user_1', { name: 'New Name' })
   })
+
+  it('does not let the client write a password through the profile route', async () => {
+    // updateUser does not hash. Only the dedicated password route does. A
+    // password arriving here would be stored in plaintext, bypassing it.
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user_1' } } as any)
+    vi.mocked(updateUser).mockResolvedValue({ id: 'user_1' } as any)
+
+    const request = new Request('http://localhost/api/profile', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'New Name', password: 'plaintext-secret' }),
+    })
+
+    await PUT(request)
+
+    const written = vi.mocked(updateUser).mock.calls[0][1]
+    expect(written).not.toHaveProperty('password')
+  })
+
+  it('does not return the password hash in the response', async () => {
+    // GET already strips it; the PUTs did not, so every profile save handed
+    // the credential back to the client.
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user_1' } } as any)
+    vi.mocked(updateUser).mockResolvedValue({
+      id: 'user_1',
+      name: 'New Name',
+      password: '$2a$12$hashedvalue',
+    } as any)
+
+    const request = new Request('http://localhost/api/profile', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'New Name' }),
+    })
+
+    const response = await PUT(request)
+    const payload = await response.json()
+    expect(payload).not.toHaveProperty('password')
+  })
+
+  it('ignores fields outside the profile allowlist', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user_1' } } as any)
+    vi.mocked(updateUser).mockResolvedValue({ id: 'user_1' } as any)
+
+    const request = new Request('http://localhost/api/profile', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'New Name', email: 'attacker@example.com', membership: 'gold' }),
+    })
+
+    await PUT(request)
+
+    const written = vi.mocked(updateUser).mock.calls[0][1]
+    expect(written).not.toHaveProperty('email')
+    expect(written).not.toHaveProperty('membership')
+    expect(written).toEqual({ name: 'New Name' })
+  })
 })

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { updateUser, getUserById } from '@/lib/user'
+import { pickProfileFields } from '@/lib/profile-fields'
 
 export async function GET(_request: Request) {
   const session = await getServerSession(authOptions)
@@ -33,8 +34,11 @@ export async function PUT(request: Request) {
   const data = await request.json()
 
   try {
-    const updatedUser = await updateUser(userId, data)
-    return NextResponse.json(updatedUser)
+    const updatedUser = await updateUser(userId, pickProfileFields(data))
+    // Strip the hash, as GET already does. Returning it would hand the
+    // credential back to the client on every profile save.
+    const { password, ...userProfile } = updatedUser
+    return NextResponse.json(userProfile)
   } catch (error) {
     console.error('Profile update error:', error)
     return NextResponse.json({ message: 'Internal server error' }, { status: 500 })

--- a/apps/web/src/lib/profile-fields.test.ts
+++ b/apps/web/src/lib/profile-fields.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { pickProfileFields, PROFILE_FIELDS } from './profile-fields'
+
+describe('pickProfileFields', () => {
+  it('keeps allowlisted profile fields', () => {
+    expect(
+      pickProfileFields({ name: 'Ada', city: 'London', phoneNumber: '123' }),
+    ).toEqual({ name: 'Ada', city: 'London', phoneNumber: '123' })
+  })
+
+  it('drops password, so it cannot reach an update that does not hash', () => {
+    expect(pickProfileFields({ name: 'Ada', password: 'plaintext' })).toEqual({
+      name: 'Ada',
+    })
+  })
+
+  it('drops columns the profile forms never send', () => {
+    expect(
+      pickProfileFields({ name: 'Ada', email: 'x@y.z', membership: 'gold', age: 30 }),
+    ).toEqual({ name: 'Ada' })
+  })
+
+  it('keeps empty strings, which is how a field is cleared', () => {
+    expect(pickProfileFields({ addressLine2: '' })).toEqual({ addressLine2: '' })
+  })
+
+  it('drops non-string values rather than forwarding them', () => {
+    expect(
+      pickProfileFields({ name: { toString: () => 'x' }, city: ['a'], state: 42, country: null }),
+    ).toEqual({})
+  })
+
+  it('returns nothing for a non-object body', () => {
+    for (const body of [null, undefined, 'string', 42, []]) {
+      expect(pickProfileFields(body)).toEqual({})
+    }
+  })
+
+  // The function reads a fixed field list rather than enumerating the caller's
+  // keys, so injected prototype keys are never consulted. These pin that.
+  it('ignores __proto__ injection and does not pollute Object.prototype', () => {
+    const malicious = JSON.parse('{"name":"Ada","__proto__":{"password":"pwned"}}')
+    expect(pickProfileFields(malicious)).toEqual({ name: 'Ada' })
+    expect(({} as Record<string, unknown>).password).toBeUndefined()
+  })
+
+  it('ignores constructor.prototype injection', () => {
+    const malicious = JSON.parse('{"constructor":{"prototype":{"password":"pwned"}}}')
+    expect(pickProfileFields(malicious)).toEqual({})
+    expect(({} as Record<string, unknown>).password).toBeUndefined()
+  })
+
+  it('does not match on differently cased keys', () => {
+    expect(pickProfileFields({ Password: 'x', NAME: 'y', City: 'z' })).toEqual({})
+  })
+
+  it('never allowlists a credential field', () => {
+    // Guards the allowlist itself: re-adding password here would otherwise
+    // reopen the plaintext-write path without any test failing.
+    for (const forbidden of ['password', 'email', 'id']) {
+      expect(PROFILE_FIELDS).not.toContain(forbidden)
+    }
+  })
+})

--- a/apps/web/src/lib/profile-fields.ts
+++ b/apps/web/src/lib/profile-fields.ts
@@ -1,0 +1,39 @@
+import type { UpdateUserInput } from '@/lib/user'
+
+// Fields a user may set through the profile routes. Everything else in the
+// request body is dropped.
+//
+// This is an allowlist rather than a denylist because `await request.json()`
+// is `any` at runtime: the UpdateUserInput type constrains the call site, not
+// the payload, so without this every column on User is client-writable.
+//
+// `password` is deliberately absent. updateUser does not hash, so a password
+// arriving here would be stored in plaintext and bypass the dedicated route
+// that does hash it.
+export const PROFILE_FIELDS = [
+  'name',
+  'avatar',
+  'addressLine1',
+  'addressLine2',
+  'city',
+  'state',
+  'zipCode',
+  'country',
+  'phoneNumber',
+] as const satisfies readonly (keyof UpdateUserInput)[]
+
+export function pickProfileFields(body: unknown): UpdateUserInput {
+  if (typeof body !== 'object' || body === null) return {}
+
+  const source = body as Record<string, unknown>
+  const picked: Record<string, unknown> = {}
+
+  // Only strings are accepted, so clearing a field means sending an empty
+  // string rather than null. A null would be dropped silently.
+  for (const field of PROFILE_FIELDS) {
+    const value = source[field]
+    if (typeof value === 'string') picked[field] = value
+  }
+
+  return picked as UpdateUserInput
+}

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -17,7 +17,6 @@ export interface UpdateUserInput {
   zipCode?: string
   country?: string
   phoneNumber?: string
-  password?: string // Added password here
 }
 
 export async function createUser(data: CreateUserInput) {
@@ -48,5 +47,14 @@ export async function updateUser(id: string, data: UpdateUserInput) {
   return prisma.user.update({
     where: { id },
     data,
+  })
+}
+
+// Separate from updateUser so a password can only be written through a call
+// that names it. The caller is responsible for hashing.
+export async function updateUserPassword(id: string, hashedPassword: string) {
+  return prisma.user.update({
+    where: { id },
+    data: { password: hashedPassword },
   })
 }


### PR DESCRIPTION
Closes #101.

`PUT /api/profile` and `PUT /api/profile/address` forwarded the parsed request body straight into `prisma.user.update`. `UpdateUserInput` is a TypeScript interface and `request.json()` returns `any`, so the type constrained the call site, not the payload — **every column on `User` was client-writable**.

## The sharper half

`updateUser` does not hash. Only `createUser` did, and the dedicated password route hashed *before* calling `updateUser`. So:

```
PUT /api/profile  {"password": "hunter2"}   →  stored in plaintext
```

That bypasses the one path that hashes, locks the user out (login compares against a bcrypt hash), and leaves a plaintext credential in the database.

## Changes

- **`pickProfileFields()`** allowlists the nine profile fields. It reads a **fixed list** rather than enumerating caller keys, so injected prototype keys are never consulted.
- **`password` removed from `UpdateUserInput`.** `updateUserPassword()` is now the only write path for that column and names it explicitly.
- **Both PUTs strip the hash from their responses**, matching what `GET` already did. `prisma.user.update` returns the column regardless of what was written, so every profile save had been handing the credential back to the client.

## What the gates contributed

**`ui-review`** traced all three client callers and confirmed no field either form sends is dropped by the allowlist — the real risk of an allowlist fix. It then found the response leak, which was outside the stated scope but squarely on-topic for a branch about keeping credentials out of client-controlled paths.

**`verifier`** exploited the fix end to end against a built container: signed up a real user, authenticated, sent `password` and `email` in a profile update, and confirmed **via `psql`** that the bcrypt hash was unchanged. It then probed nine bypass vectors — `__proto__`, `constructor.prototype`, casing, nesting — and established the filter is structurally immune rather than incidentally safe.

Those manual probes are now permanent tests, including a guard asserting the allowlist never contains a credential field, so re-adding `password` there fails loudly instead of silently reopening the path.

**`code-review`** confirmed the response strip is not redundant with the input filter, and that no other code in the repo consumes these response shapes.

## Suite

Web 67 → **81 tests** (30 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)