### PR TITLE
fix(compose): wait for Postgres to accept connections before dependents start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/contoso-db
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
@@ -14,6 +15,20 @@ services:
   db:
     image: postgres:15
     restart: always
+    # Postgres reports "started" well before it accepts connections. Without
+    # this, dependents race the socket and fail with P1001.
+    #
+    # -h forces the probe onto TCP. Without it pg_isready checks the Unix
+    # socket, and the entrypoint runs a temporary socket-only server during
+    # first-boot initialisation to create the database. A probe landing in that
+    # window reports healthy while port 5432 is still closed, which leaves the
+    # exact race this healthcheck exists to close.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres -d contoso-db"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 5s
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -28,6 +43,9 @@ services:
       dockerfile: services/chat/Dockerfile
       args:
         INSTALL_LOCAL_STACK: ${CHAT_INSTALL_LOCAL_STACK:-0}
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - "8000:8000"
     environment:

--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -39,6 +39,10 @@ RUNTIME_PATTERNS = (
     # Agent definitions are repo tooling. Without this they classify as
     # "unknown", which forces runtime by accident rather than by intent.
     ".claude/agents/**",
+    # Compose is web+chat, but the guard that protects its startup ordering
+    # lives in tests/scripts. Without this, a change dropping the healthcheck
+    # would never run that guard.
+    "docker-compose.yml",
     "apps/web/package-lock.json",
     "apps/web/package.json",
     "services/chat/constraints.txt",

--- a/tests/scripts/test_compose_startup_ordering.py
+++ b/tests/scripts/test_compose_startup_ordering.py
@@ -1,0 +1,176 @@
+"""Guard the database startup ordering in docker-compose.yml.
+
+Postgres reports "started" well before it accepts connections. With a bare
+`depends_on`, dependents race the socket: web's entrypoint runs
+`prisma migrate deploy` immediately and dies with P1001. That race caused two
+false CI failures before it was diagnosed, on PRs whose changes had nothing to
+do with it.
+
+e2e-smoke cannot protect this. It passes whenever Postgres happens to win the
+race, which is most of the time, so a regression here would show up as an
+intermittent failure on somebody else's pull request rather than as a clear
+signal on the change that caused it.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+# Services that talk to the database and therefore must wait for it.
+DB_DEPENDENTS = ("web", "chat")
+
+
+def compose_text() -> str:
+    return COMPOSE.read_text(encoding="utf-8")
+
+
+def service_names() -> list[str]:
+    """Every top-level service, discovered rather than hardcoded.
+
+    Hardcoding would make the "future service" guard below vacuous: a service
+    added tomorrow would not be in the list, so it could not fail.
+    """
+    names = []
+    in_services = False
+    for line in compose_text().splitlines():
+        if line.startswith("services:"):
+            in_services = True
+            continue
+        # any other top-level key ends the block
+        if line and not line[0].isspace():
+            in_services = False
+            continue
+        if in_services and line.startswith("  ") and not line.startswith("   "):
+            if line.rstrip().endswith(":"):
+                names.append(line.strip().rstrip(":"))
+    return names
+
+
+def service_block(name: str) -> str:
+    """The YAML block for one service, up to the next top-level service key."""
+    text = compose_text()
+    start = text.index(f"\n  {name}:")
+    rest = text[start + 1 :]
+    lines = rest.splitlines()
+    body = [lines[0]]
+    for line in lines[1:]:
+        # a new service starts at exactly two spaces of indent
+        if line.startswith("  ") and not line.startswith("   ") and line.rstrip().endswith(":"):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+# start_period + retries * interval. Postgres init on a cold CI runner has
+# been observed near 28s with a deliberately slowed initdb, so the budget
+# needs real headroom above that.
+MIN_HEALTH_BUDGET_SECONDS = 30
+
+
+class ComposeStartupOrderingTests(unittest.TestCase):
+    def test_db_declares_a_healthcheck(self):
+        block = service_block("db")
+        self.assertIn(
+            "healthcheck:",
+            block,
+            "db needs a healthcheck; without one, dependents can only wait for "
+            "'started', which Postgres reports before it accepts connections",
+        )
+
+    def test_healthcheck_probes_tcp_not_the_unix_socket(self):
+        """The probe must target TCP, which is what dependents actually use.
+
+        Asserted against the `test:` line rather than the service block: the
+        comment above the healthcheck mentions pg_isready, so a block-level
+        substring check passes on prose even if the command is gutted.
+
+        Without -h, pg_isready checks the Unix socket. The postgres entrypoint
+        serves that socket from a temporary server during first-boot init, so
+        the probe reports healthy while port 5432 is still closed — measured at
+        5s versus 28s with a slowed initdb, which is the whole race.
+        """
+        block = service_block("db")
+        match = re.search(r"^\s*test:\s*(.+)$", block, re.M)
+        self.assertIsNotNone(match, "db healthcheck must declare a test command")
+        command = match.group(1)
+
+        self.assertIn(
+            "pg_isready",
+            command,
+            f"healthcheck should probe readiness with pg_isready; got: {command}",
+        )
+        self.assertIn(
+            "-h ",
+            command,
+            "pg_isready must be given -h so it probes TCP; without it the check "
+            "passes against the socket-only bootstrap server while 5432 is "
+            f"still closed. Got: {command}",
+        )
+
+    def test_health_budget_leaves_room_for_a_slow_cold_start(self):
+        """The budget is implicit in three YAML numbers, so tightening any one
+        of them would shrink it silently. Exceeding it is not a hang — compose
+        exits 1 with "dependency failed to start" — but that turns a slow
+        runner into a hard failure, so the floor is worth pinning."""
+        block = service_block("db")
+        values = {}
+        for key in ("start_period", "interval", "retries"):
+            match = re.search(rf"^\s*{key}:\s*(\d+)s?\s*$", block, re.M)
+            self.assertIsNotNone(match, f"db healthcheck should declare {key}")
+            values[key] = int(match.group(1))
+
+        budget = values["start_period"] + values["retries"] * values["interval"]
+        self.assertGreaterEqual(
+            budget,
+            MIN_HEALTH_BUDGET_SECONDS,
+            f"health budget is {budget}s (start_period {values['start_period']}s "
+            f"+ {values['retries']} x {values['interval']}s); a cold Postgres init "
+            "can approach 30s, and falling short turns that into a build failure",
+        )
+
+    def test_database_dependents_wait_for_healthy(self):
+        for name in DB_DEPENDENTS:
+            with self.subTest(service=name):
+                block = service_block(name)
+                self.assertIn(
+                    "depends_on:",
+                    block,
+                    f"{name} uses DATABASE_URL, so it must declare depends_on",
+                )
+                self.assertIn(
+                    "condition: service_healthy",
+                    block,
+                    f"{name} must wait for db to be healthy; a bare depends_on "
+                    "resolves to service_started and races the socket",
+                )
+
+    def test_every_service_with_a_database_url_waits_for_the_database(self):
+        """Catches a service added later with a DATABASE_URL and no dependency."""
+        checked = []
+        for name in service_names():
+            if name == "db":
+                continue
+            block = service_block(name)
+            if "DATABASE_URL" not in block:
+                continue
+            checked.append(name)
+            self.assertIn(
+                "condition: service_healthy",
+                block,
+                f"{name} references DATABASE_URL but does not wait for db",
+            )
+        # Guard the guard: if discovery breaks, this loop would silently
+        # check nothing and still report success.
+        self.assertEqual(
+            sorted(checked),
+            sorted(DB_DEPENDENTS),
+            "service discovery found a different set of database consumers "
+            "than expected; update DB_DEPENDENTS deliberately",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -91,6 +91,15 @@ class DetectChangedSurfacesTests(unittest.TestCase):
                 flags = detect_changed.classify([path])
                 self.assertTrue(flags["runtime"])
 
+    def test_compose_changes_are_runtime(self):
+        """docker-compose.yml already matched web and chat, so it never reached
+        the unknown fallback. Without an explicit runtime pattern, a
+        compose-only change would skip test-scripts and the startup-ordering
+        guard that protects it."""
+        flags = detect_changed.classify(["docker-compose.yml"])
+        self.assertTrue(flags["runtime"])
+        self.assertIn("test-scripts", detect_changed.recommended_targets(flags))
+
     def test_agent_definitions_are_runtime(self):
         """Agent definitions are repo tooling, not an unclassified path.
 


### PR DESCRIPTION
Closes #109.

The E2E smoke failed intermittently with `P1001: Can't reach database server at db:5432` — **twice in one session, both times on PRs unrelated to the failure** (#79 and #108).

Three things lined up: `db` declared no healthcheck, `web` used a bare `depends_on` (which resolves to `service_started`), and `web`'s entrypoint runs `prisma migrate deploy` under `set -e` as its first action. `chat` had no `depends_on` at all despite holding a `DATABASE_URL`.

## The probe uses `-h 127.0.0.1` deliberately

**My first version of this fix was wrong**, and review caught it.

Without `-h`, `pg_isready` checks the **Unix socket** — and the postgres entrypoint serves that socket from a *temporary socket-only server* while it initialises the database. Measured with a slowed `initdb`:

| probe | declared healthy | dependent's TCP check |
| --- | --- | --- |
| socket (original) | **5s** | **"no response"** |
| TCP (`-h 127.0.0.1`) | 28s | accepting connections |

The socket probe marks Postgres healthy 23 seconds early. That is worse than no healthcheck: it leaves the race open behind something that looks like it closed it, and sends the next person debugging a `P1001` down a false path.

## Why tests, not just the smoke

`e2e-smoke` passes whenever Postgres happens to win the race — which is most of the time. It would report green on a regression here. Four tests guard it deterministically, each confirmed to fail against a mutation:

| mutation | fails |
| --- | --- |
| probe loses `-h` | TCP probe test |
| test command → `true` | TCP probe test |
| `service_healthy` → `service_started` | dependents test |
| `retries: 15` → `5` | budget test |
| healthcheck removed | healthcheck test |
| runtime pattern removed | routing test |

**Two of those guards exist because review found the first versions vacuous.** The healthcheck assertion originally searched the whole service block — which my own explanatory comment satisfied, since it mentions `pg_isready`. The command could be replaced with `true` and the suite stayed green. It now extracts the `test:` line.

And `docker-compose.yml` is added to `RUNTIME_PATTERNS` so a compose-only change reaches `test-scripts` at all. It already matched `WEB_PATTERNS` and `CHAT_PATTERNS`, so it never hit the `unknown` fallback — the guard would not have run on the very change class it protects.

## Budget

`start_period 5s + 15 × 2s = 35s`, with a 30s floor asserted so tightening any one value cannot shrink it silently. Exceeding it fails cleanly rather than hanging: compose exits 1 with `dependency failed to start ... is unhealthy` and no dependent starts.

Script suite 74 → **80 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)