### PR TITLE
fix(chat): declare pydantic and drop the exporter that never ran

### DIFF
--- a/services/chat/constraints.txt
+++ b/services/chat/constraints.txt
@@ -13,6 +13,7 @@ opentelemetry-instrumentation-fastapi==0.65b0
 opentelemetry-sdk==1.44.0
 pandas==3.0.5
 prompty==0.1.50
+pydantic==2.13.4
 pytest-cov==7.1.0
 pytest==9.1.1
 python-dotenv==1.2.2

--- a/services/chat/src/api/requirements-core.txt
+++ b/services/chat/src/api/requirements-core.txt
@@ -10,7 +10,12 @@ requests
 # unpinned-by-default and floated 0.47 -> 1.3 on its own, breaking CI when the
 # new major changed its test-client HTTP dependency. No module imports it
 # directly.
+# pydantic is imported directly by main.py for the request/response models. It
+# arrives transitively via fastapi, but a transitive dependency is not a
+# guarantee: httpx was likewise imported-but-undeclared, came only from
+# prisma-client-py, and vanished when that package was removed.
 fastapi
+pydantic
 starlette
 uvicorn[standard]
 

--- a/services/chat/src/api/tracing.py
+++ b/services/chat/src/api/tracing.py
@@ -2,13 +2,7 @@ import contextlib
 
 from opentelemetry import trace as oteltrace
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from prompty.tracer import PromptyTracer, Tracer
-
-try:
-    from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
-except ImportError:  # pragma: no cover - optional dependency in local/test envs
-    CloudTraceSpanExporter = None
 
 _tracer = "prompty"
 
@@ -42,11 +36,9 @@ def init_tracing(local_tracing: bool = False):
     else:
         Tracer.add("OpenTelemetry", trace_span)
 
+        # No span exporter is attached: nothing in this repo collects traces.
+        # Add one here when there is somewhere to send spans.
         tracer_provider = TracerProvider()
         oteltrace.set_tracer_provider(tracer_provider)
-        if CloudTraceSpanExporter is not None:
-            tracer_provider.add_span_processor(
-                BatchSpanProcessor(CloudTraceSpanExporter())
-            )
 
         return oteltrace.get_tracer(_tracer)

--- a/services/chat/tests/unit/test_tracing.py
+++ b/services/chat/tests/unit/test_tracing.py
@@ -1,3 +1,5 @@
+import ast
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 from tracing import init_tracing, trace_span
@@ -36,22 +38,14 @@ def test_init_tracing_local_registers_prompty_tracer():
     mock_tracer_add.assert_called_once_with("PromptyTracer", "local-prompty-tracer")
 
 
-def test_init_tracing_remote_registers_otel_exporter():
+def test_init_tracing_remote_registers_otel_tracer():
     tracer_provider = MagicMock()
-    cloud_exporter = MagicMock()
-    batch_processor = MagicMock()
     tracer_instance = MagicMock()
 
     with patch("tracing.Tracer.add") as mock_tracer_add, patch(
         "tracing.TracerProvider",
         return_value=tracer_provider,
     ), patch(
-        "tracing.CloudTraceSpanExporter",
-        return_value=cloud_exporter,
-    ), patch(
-        "tracing.BatchSpanProcessor",
-        return_value=batch_processor,
-    ) as mock_batch_span_processor, patch(
         "tracing.oteltrace.set_tracer_provider"
     ) as mock_set_tracer_provider, patch(
         "tracing.oteltrace.get_tracer",
@@ -62,6 +56,50 @@ def test_init_tracing_remote_registers_otel_exporter():
     assert result is tracer_instance
     mock_tracer_add.assert_called_once_with("OpenTelemetry", trace_span)
     mock_set_tracer_provider.assert_called_once_with(tracer_provider)
-    mock_batch_span_processor.assert_called_once_with(cloud_exporter)
-    tracer_provider.add_span_processor.assert_called_once_with(batch_processor)
     mock_get_tracer.assert_called_once_with("prompty")
+
+    # No exporter is configured, so no span processor is attached.
+    tracer_provider.add_span_processor.assert_not_called()
+
+
+def test_tracing_declares_no_optional_import_that_falls_back_to_none():
+    """Guard the failure mode, not just the one instance of it.
+
+    An `except ImportError: X = None` fallback turns an undeclared dependency
+    into a silent no-op: the feature never runs, nothing raises, and the gap
+    surfaces only when someone asks why the data is missing. If a future import
+    here is genuinely optional, the absent case has to be observable — log it,
+    or fail — rather than bound to None.
+    """
+    source = (
+        Path(__file__).resolve().parents[2] / "src" / "api" / "tracing.py"
+    ).read_text(encoding="utf-8")
+
+    tree = ast.parse(source)
+    offenders = [
+        target.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        for handler in node.handlers
+        if _handles_import_error(handler)
+        for statement in handler.body
+        if isinstance(statement, ast.Assign)
+        and isinstance(statement.value, ast.Constant)
+        and statement.value.value is None
+        for target in statement.targets
+        if isinstance(target, ast.Name)
+    ]
+
+    assert offenders == [], (
+        f"{offenders} fall back to None on ImportError, which hides a missing "
+        f"dependency as a silently disabled feature"
+    )
+
+
+def _handles_import_error(handler: ast.ExceptHandler) -> bool:
+    names = (
+        handler.type.elts
+        if isinstance(handler.type, ast.Tuple)
+        else [handler.type] if handler.type is not None else []
+    )
+    return any(isinstance(name, ast.Name) and name.id == "ImportError" for name in names)


### PR DESCRIPTION
Closes #104.

Two imports in the chat service resolved to no manifest entry. `check_dependency_policy.py` cannot catch this class: all three of its rules start from a *declaration*, so a package that source imports but nothing declares is invisible to it.

## `pydantic` — declared and pinned

Imported directly by `src/api/main.py` for the request/response models, but present only transitively via `fastapi`, `google-cloud-aiplatform`, and `google-genai`.

This is the `httpx` pattern that broke CI in #57 — imported, undeclared, present only because something else happened to pull it in, and gone the moment that something else was removed.

Pinned at `2.13.4` (current latest, and what is installed). Verified against the optional local stack, which is not installed in the dev venv: `chromadb` wants `pydantic>=2.0`, `litellm` wants `>=2.10.0,<3.0.0`, and `torch`/`sentence-transformers` don't constrain it. `pip install --dry-run -c constraints.txt` resolves clean.

## Cloud Trace exporter — deleted

`opentelemetry-exporter-gcp-trace` was declared in no manifest either, so `CloudTraceSpanExporter` fell back to `None` in **every** environment and the `BatchSpanProcessor` branch has never executed — not locally, not in CI, not in the image. The failure mode was a silent no-op, so nothing surfaced it.

Deleted rather than declared, because:

- Nothing in this repo configures or collects Cloud Trace — no project setting, no exporter env var, no deployment infrastructure.
- The branch was unreachable regardless: `init_tracing`'s only caller is `evaluate.py:117`, which passes `local_tracing=True`.

Declaring a GCP-only wheel to feed a path nothing invokes and no backend collects is worse than removing it. Wire up a real exporter when there is somewhere to send spans.

## The test that hid it

`test_init_tracing_remote_registers_otel_exporter` patched `tracing.CloudTraceSpanExporter`, turning the `None` into a `MagicMock`. **It manufactured the capability it claimed to verify** — it would have passed identically had the feature never existed. That is how a permanently dead exporter survived.

Replaced with an assertion that no span processor is attached, plus a new AST guard rejecting `except ImportError: X = None` in this module, since that shape is what converts a missing dependency into a silently disabled feature. The guard was confirmed to fail against the pre-change file (`offenders: ['CloudTraceSpanExporter']`) rather than assumed to work.

## Verification

60 chat unit tests, 84 script guardrail tests, `ruff`, `mypy`, and the dependency policy check (26 pins, 4 manifests) all pass. The chat image was rebuilt from scratch and a live container confirmed `pydantic-2.13.4` installs cleanly, `/health` reports `real_chat: true`, and `init_tracing(local_tracing=False)` runs with no `NameError`.

## Follow-ups filed

- #118 — teach the policy check a third rule that starts from imports rather than declarations
- #119 — `services/chat/scripts/` is outside the `make lint` scope, so the guardrail script itself is never linted

🤖 Generated with [Claude Code](https://claude.com/claude-code)