### PR TITLE
fix(ci): require a separator when matching dir/** patterns

### DIFF
--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -61,6 +61,15 @@ WEB_PATTERNS = (
 CHAT_PATTERNS = (
     "services/chat/**",
     "apps/web/prisma/**",
+    # A sibling of prisma/, not a child, so the pattern above never covered it
+    # on purpose — it matched only through the missing separator in
+    # path_matches. Dockerfile.migrate below COPYs this exact file, so editing
+    # it changes the migration image and must run the chat suite.
+    #
+    # Any future prisma.* sibling needs its own entry for the same reason:
+    # apps/web/** still matches it, so `unknown` stays False and the runtime
+    # fallback will not cover the omission.
+    "apps/web/prisma.config.ts",
     "docker-compose.yml",
     "Dockerfile.migrate",
 )
@@ -96,7 +105,12 @@ def run_git(args: list[str]) -> str:
 
 def path_matches(pattern: str, path: str) -> bool:
     if pattern.endswith("/**"):
-        return path.startswith(pattern[:-3])
+        # Keep the trailing separator. Dropping it matches any sibling whose
+        # name merely starts with the directory's, so "docs-archive/x.md" hits
+        # "docs/**". That is not the harmless direction: a spurious match keeps
+        # `unknown` False, which suppresses the fallback that would otherwise
+        # force the full runtime suite, and CI silently narrows to one job.
+        return path.startswith(pattern[:-2])
     return Path(path).match(pattern)
 
 

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -27,6 +27,87 @@ class DetectChangedSurfacesTests(unittest.TestCase):
             detect_changed.path_matches("apps/web/**", "apps/web/src/app/page.tsx"),
         )
 
+    def test_directory_glob_does_not_match_a_sibling_with_the_same_prefix(self):
+        """`dir/**` must require a separator, not just a string prefix.
+
+        Without one, any neighbour whose name starts with the pattern's
+        directory matches it.
+        """
+        for pattern, sibling in (
+            ("apps/web/**", "apps/web-e2e/spec.ts"),
+            ("docs/**", "docs-archive/notes.md"),
+            ("services/chat/**", "services/chat-legacy/old.py"),
+            (".claude/agents/**", ".claude/agents-extra/foo.md"),
+        ):
+            with self.subTest(pattern=pattern, path=sibling):
+                self.assertFalse(detect_changed.path_matches(pattern, sibling))
+
+    def test_directory_glob_anchors_at_the_start_of_the_path(self):
+        """`startswith`, not "contains".
+
+        Every sibling case above puts the pattern's directory at position 0, so
+        a substring check is indistinguishable from a prefix check under them —
+        a mutation to `pattern[:-2] in path` passes all of them. These paths
+        embed the directory deeper, where the two disagree.
+        """
+        for pattern, path in (
+            ("docs/**", "vendor/docs/notes.md"),
+            ("apps/web/**", "backup/apps/web/page.tsx"),
+            ("services/chat/**", "archive/services/chat/main.py"),
+        ):
+            with self.subTest(pattern=pattern, path=path):
+                self.assertFalse(detect_changed.path_matches(pattern, path))
+
+    def test_prisma_config_stays_in_the_chat_surface(self):
+        """It is a sibling of `apps/web/prisma/`, not a child.
+
+        Before the separator fix it reached the chat surface only through the
+        bug. `Dockerfile.migrate` COPYs this file, so losing that coverage would
+        let a migration-image change ship without the chat suite ever running —
+        and `apps/web/**` still matches it, so `unknown` stays False and the
+        runtime fallback does not cover the loss.
+        """
+        flags = detect_changed.classify(["apps/web/prisma.config.ts"])
+        self.assertTrue(flags["web"])
+        self.assertTrue(flags["chat"])
+        self.assertIn("quick-ci-chat", detect_changed.recommended_targets(flags))
+
+    def test_directory_glob_still_matches_real_children(self):
+        """The other half of the guard above.
+
+        A fix that required the separator but broke genuine children would
+        route everything to `unknown`, which passes the negative test alone.
+        """
+        for pattern, child in (
+            ("apps/web/**", "apps/web/src/app/page.tsx"),
+            ("docs/**", "docs/ENV_CONTRACT.md"),
+            ("services/chat/**", "services/chat/src/api/main.py"),
+            (".claude/agents/**", ".claude/agents/verifier.md"),
+        ):
+            with self.subTest(pattern=pattern, path=child):
+                self.assertTrue(detect_changed.path_matches(pattern, child))
+
+    def test_sibling_directory_does_not_narrow_ci_to_a_single_job(self):
+        """The consequence the separator bug actually had.
+
+        A spurious match keeps `unknown` False, and `unknown` is what forces
+        the full runtime suite. So over-matching does not fail safe — it
+        suppresses the fallback and silently narrows CI to one job. Asserting
+        on `path_matches` alone would not have shown that.
+        """
+        for sibling in (
+            "docs-archive/notes.md",
+            "apps/web-e2e/spec.ts",
+            "services/chat-legacy/old.py",
+        ):
+            with self.subTest(path=sibling):
+                flags = detect_changed.classify([sibling])
+                self.assertTrue(flags["unknown"])
+                self.assertTrue(flags["runtime"])
+                self.assertIn(
+                    "test-scripts", detect_changed.recommended_targets(flags)
+                )
+
     def test_unknown_paths_force_runtime(self):
         flags = detect_changed.classify(["some/new/area/file.txt"])
         self.assertTrue(flags["unknown"])


### PR DESCRIPTION
Closes #107.

`path_matches` stripped three characters from a `dir/**` pattern and compared with `startswith`, dropping the separator. Any sibling whose name merely began with the pattern's directory matched it.

## The issue's impact analysis is wrong

#107 says the bug is "currently benign" and "over-matches into the safe direction". It is the opposite, and this is the reason the fix matters.

`unknown` is what forces the full runtime suite (`classify()`: `if unknown: runtime = True`). A spurious match is precisely what keeps `unknown` False — so over-matching **suppresses the safety fallback** and narrows CI to a single job:

| path | before | correct |
| --- | --- | --- |
| `docs-archive/notes.md` | `['docs-check']` | full runtime suite |
| `apps/web-e2e/spec.ts` | `['quick-ci-web']` | full runtime suite |
| `services/chat-legacy/old.py` | `['quick-ci-chat']` | full runtime suite |

The issue is also factually wrong that "every affected pattern is in `RUNTIME_PATTERNS` or `WEB_PATTERNS`" — `docs/**` is in `DOC_PATTERNS`, and `services/chat/**` and `apps/web/prisma/**` are in `CHAT_PATTERNS`. The "benign" reading holds only for the subset where the spurious match lands in `RUNTIME_PATTERNS`, where the target list genuinely coincides.

## A second bug the fix exposed

Keeping the separator revealed that `apps/web/prisma.config.ts` was in the chat surface **only through the same bug** — it is a sibling of `apps/web/prisma/`, not a child. `Dockerfile.migrate:11` COPYs that exact file into the migration image, and `apps/web/**` still matches it, so `unknown` stays False and the runtime fallback would not have covered the loss. Editing it would have run `quick-ci-web` alone.

It is now declared in `CHAT_PATTERNS` explicitly, with a note that any future `prisma.*` sibling needs the same treatment.

**Across all 1344 tracked files, old and new classification agree exactly** — the fix removes the phantom matches without dropping any real coverage.

## Tests

Five cases covering both directions and the actual consequence:

- siblings must not match (`docs-archive/`, `apps/web-e2e/`, `services/chat-legacy/`, `.claude/agents-extra/`)
- real children must still match — this one also rejects `Path.match`, which cannot do recursive `**` on the Python 3.11 that CI pins
- a sibling must produce the **full target list**, not just a `path_matches` boolean — asserting on the matcher alone would not have shown the CI-narrowing consequence
- `prisma.config.ts` must stay in the chat surface
- matches must anchor at position 0

That last one exists because without it a substring implementation (`pattern[:-2] in path`) passes the entire suite — every other case puts the directory at the start, where prefix and containment are indistinguishable. Mutation testing across 16 wrong implementations now kills every non-equivalent mutant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)