### PR TITLE
fix(ci): run the guardrail suite for every change, not just runtime ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
   script-tests:
     name: Script Guardrail Tests
     needs: changes
-    if: ${{ github.event_name != 'push' && needs.changes.outputs.runtime == 'true' }}
+    # This suite asserts on files across every surface, so any surface gate lets
+    # a guarded file change while the guard sits out. `none` is the only flag
+    # that is not a surface.
+    if: ${{ github.event_name != 'push' && needs.changes.outputs.none != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -188,6 +188,12 @@ def recommended_targets(flags: dict[str, bool]) -> list[str]:
             ]
         )
     else:
+        # Mirrors the script-tests gate in ci.yml. The guardrail suite asserts
+        # on files across every surface, so it runs for any change rather than
+        # for one surface. Without this the local pre-push loop skips the guard
+        # for exactly the chat-only changes CI now runs it for.
+        if not flags["none"]:
+            ordered.append("test-scripts")
         if flags["web"]:
             ordered.append("quick-ci-web")
         if flags["chat"]:

--- a/tests/scripts/test_ci_workflow_wiring.py
+++ b/tests/scripts/test_ci_workflow_wiring.py
@@ -1,8 +1,184 @@
+import importlib.util
+import re
 import unittest
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_detector():
+    spec = importlib.util.spec_from_file_location(
+        "detect_changed_surfaces", REPO_ROOT / "scripts/detect_changed_surfaces.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def job_condition(job_id: str) -> str:
+    """Read a job's `if:` from ci.yml as text.
+
+    Deliberately not PyYAML. The job that runs this suite creates a bare venv
+    and installs nothing, so a third-party import here is not a failing test —
+    it is a collection error that reddens the whole suite. Every other script
+    and script test in this repo is stdlib-only for the same reason.
+    """
+    content = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    # `\Z` terminates the block for the last job in the file. Without it the
+    # helper reports "not found" for a job that is present, which would turn
+    # this guard into a misleading error the moment jobs are reordered.
+    match = re.search(
+        rf"^  {re.escape(job_id)}:$(.*?)(?:^  \S|\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"job '{job_id}' not found in ci.yml")
+    condition = re.search(r"^    if:\s*(.+)$", match.group(1), re.MULTILINE)
+    if condition is None:
+        raise AssertionError(f"job '{job_id}' has no `if:` condition")
+    return " ".join(condition.group(1).split())
+
+
+def evaluate_gate(condition: str, flags: dict, event_name: str) -> bool:
+    """Evaluate the narrow subset of GitHub expression syntax used by CI gates.
+
+    Only `&&` over `needs.changes.outputs.X <op> 'v'` and
+    `github.event_name <op> 'v'` comparisons. Anything else raises rather than
+    guessing, so an unsupported gate fails loudly instead of silently
+    evaluating to True and making the caller's assertion vacuous.
+
+    Outputs are strings in Actions, so the booleans are rendered as
+    'true'/'false' before comparing.
+    """
+    body = condition.strip()
+    if not (body.startswith("${{") and body.endswith("}}")):
+        raise AssertionError(f"unsupported gate: {condition}")
+    body = body[3:-2].strip()
+
+    if "||" in body:
+        raise AssertionError(f"gate evaluator does not handle `||`: {condition}")
+
+    context = {f"needs.changes.outputs.{k}": str(v).lower() for k, v in flags.items()}
+    context["github.event_name"] = event_name
+
+    for clause in body.split("&&"):
+        match = re.fullmatch(r"\s*([\w.]+)\s*(==|!=)\s*'([^']*)'\s*", clause)
+        if match is None:
+            raise AssertionError(f"unsupported clause {clause!r} in {condition}")
+        left, operator, expected = match.groups()
+        if left not in context:
+            raise AssertionError(f"unknown context reference {left!r}")
+        actual = context[left]
+        if (operator == "==" and actual != expected) or (
+            operator == "!=" and actual == expected
+        ):
+            return False
+    return True
+
+
+class ScriptGuardrailGatingTests(unittest.TestCase):
+    """The guardrail suite must run for the changes it guards.
+
+    It asserts on files across every surface — chat entrypoints and Dockerfiles,
+    web config, agent docs. Gating it on `runtime` meant a chat-only change
+    could edit a guarded file while the guard sat out, and a job skipped by an
+    `if:` counts as *satisfying* a required status check, so branch protection
+    did not compensate.
+    """
+
+    GUARDED_BY_CHAT_PROFILE_WIRING = (
+        "services/chat/src/api/chat-entrypoint.sh",
+        "services/chat/scripts/check_dependency_policy.py",
+        "services/chat/Dockerfile",
+    )
+
+    def test_guarded_files_exist(self):
+        """Without this the two tests below pass on typo'd paths."""
+        for path in self.GUARDED_BY_CHAT_PROFILE_WIRING:
+            with self.subTest(path=path):
+                self.assertTrue((REPO_ROOT / path).exists())
+
+    # Whitespace-normalised. Asserting the whole expression rather than probing
+    # for substrings is what rejects a gate that merely *contains* the right
+    # clause: `none != 'true' && docs == 'true'` reintroduces the original bug
+    # while satisfying any `assertIn` check.
+    EXPECTED_CONDITION = (
+        "${{ github.event_name != 'push' "
+        "&& needs.changes.outputs.none != 'true' }}"
+    )
+
+    def test_guarded_files_classify_as_chat(self):
+        """The premise of the bug, not proof of the fix.
+
+        Deliberately does not assert `runtime` is False. Adding these paths to
+        RUNTIME_PATTERNS is a strictly safer change that this suite must not
+        forbid — the gate below is correct either way.
+        """
+        detector = load_detector()
+        for path in self.GUARDED_BY_CHAT_PROFILE_WIRING:
+            with self.subTest(path=path):
+                self.assertTrue(detector.classify([path])["chat"])
+
+    def test_job_condition_resolves_the_last_job_in_the_file(self):
+        """Job order must not silently break this guard.
+
+        The block regex needs an end-of-file terminator; without one the last
+        job reports "not found", so reordering ci.yml would replace a real
+        assertion with a misleading error.
+        """
+        last_job = re.findall(
+            r"^  ([\w-]+):$",
+            (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )[-1]
+        self.assertIn("${{", job_condition(last_job))
+
+    def test_script_tests_gate_is_exactly_the_expected_expression(self):
+        self.assertEqual(job_condition("script-tests"), self.EXPECTED_CONDITION)
+
+    def test_script_tests_still_skips_on_push(self):
+        """`full-ci-main` already runs the suite via `make ci` on push.
+
+        Asserted separately because the equality test above would let this
+        clause be dropped silently if someone rewrote the expected string.
+        """
+        self.assertIn("github.event_name != 'push'", job_condition("script-tests"))
+
+    def test_guarded_files_reach_the_script_tests_job(self):
+        """The end-to-end claim: detector output must satisfy the job's gate.
+
+        Evaluates the gate against real classifier output rather than checking
+        the two halves independently — a gate ANDed with an extra surface flag
+        passes both halves separately while still skipping these files.
+        """
+        detector = load_detector()
+        condition = job_condition("script-tests")
+        for path in self.GUARDED_BY_CHAT_PROFILE_WIRING:
+            with self.subTest(path=path):
+                flags = detector.classify([path])
+                self.assertTrue(
+                    evaluate_gate(condition, flags, event_name="pull_request"),
+                    f"{path} classifies as {flags} but the gate skips it",
+                )
+
+    def test_gate_evaluator_rejects_a_gate_that_skips_guarded_files(self):
+        """Guards the evaluator itself.
+
+        Without this, a helper that returned True unconditionally would make
+        the test above pass against any gate at all.
+        """
+        detector = load_detector()
+        flags = detector.classify(["services/chat/Dockerfile"])
+        broken = (
+            "${{ github.event_name != 'push' "
+            "&& needs.changes.outputs.runtime == 'true' }}"
+        )
+        self.assertFalse(evaluate_gate(broken, flags, event_name="pull_request"))
+        self.assertTrue(
+            evaluate_gate(self.EXPECTED_CONDITION, flags, event_name="pull_request")
+        )
 
 
 class CiWorkflowWiringTests(unittest.TestCase):

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -142,7 +142,42 @@ class DetectChangedSurfacesTests(unittest.TestCase):
             "unknown": False,
             "none": False,
         }
-        self.assertEqual(detect_changed.recommended_targets(flags), ["docs-check"])
+        self.assertEqual(
+            detect_changed.recommended_targets(flags), ["test-scripts", "docs-check"]
+        )
+
+    def test_recommended_targets_includes_script_tests_for_any_change(self):
+        """The local mirror of the script-tests CI gate.
+
+        The guardrail suite asserts on files across every surface, so a
+        surface-scoped local run must still include it — otherwise the
+        pre-push loop skips the guard that CI runs.
+        """
+        for surface in ("web", "chat", "docs"):
+            with self.subTest(surface=surface):
+                flags = {
+                    "runtime": False,
+                    "web": surface == "web",
+                    "chat": surface == "chat",
+                    "docs": surface == "docs",
+                    "unknown": False,
+                    "none": False,
+                }
+                self.assertIn(
+                    "test-scripts", detect_changed.recommended_targets(flags)
+                )
+
+    def test_recommended_targets_is_empty_when_nothing_changed(self):
+        """`none` must not pick up test-scripts from the clause above."""
+        flags = {
+            "runtime": False,
+            "web": False,
+            "chat": False,
+            "docs": False,
+            "unknown": False,
+            "none": True,
+        }
+        self.assertEqual(detect_changed.recommended_targets(flags), [])
 
     def test_agent_doc_paths_route_to_docs_check(self):
         for path in (


### PR DESCRIPTION
Closes #105.

`tests/scripts` asserts on files across every surface. The `script-tests` job was gated on `runtime`, so a chat-only PR touching `chat-entrypoint.sh`, `check_dependency_policy.py`, or `services/chat/Dockerfile` **skipped the guardrail written specifically for those files**.

A job skipped by an `if:` counts as *satisfying* a required status check, so branch protection read the skipped guard as a passing one.

## Why not the fixes the issue suggested

#105 proposed adding those three paths to `RUNTIME_PATTERNS`, or gating on `runtime || chat`. Measuring first showed why neither holds: `tests/scripts` asserts on **19 tracked files that do not classify as runtime**, spanning docs, web *and* chat. Any enumeration re-opens the hole with the next guard someone adds.

Gate on `none` instead — the only flag that is not a surface. The suite takes ~25s, and 85% of PRs already set `runtime=true`, so the old gate was buying almost nothing while costing a correctness hole.

This does not erode change-surface routing generally. `web-ci`, `chat-ci` and `docs-ci` each assert on one surface; `script-tests` asserts on the wiring *between* surfaces, so its input set is the union of everything by construction. A gate is only meaningful when the guarded set is a proper subset of the repo.

`Env Contract Drift Check` and `Onboarding Smoke` were checked and are correctly scoped — every file they read is already in `RUNTIME_PATTERNS`.

## The same bug in the local path

`recommended_targets()` also gated `test-scripts` on `runtime`, so `make quick-ci-changed` skipped the guard locally for exactly the chat-only changes CI now runs it for. Fixed alongside — closing #105 with the pre-push loop and CI disagreeing would close half a bug, and that drift is the same class as #89 and #105 themselves.

## Tests evaluate the gate, they do not pattern-match it

A mirrored string constant proves nothing by itself: edit the gate and the expected value together and it still passes while the bug returns. `evaluate_gate()` applies the condition to **real classifier output**, and raises on syntax it does not understand rather than defaulting to `True`. `test_gate_evaluator_rejects_a_gate_that_skips_guarded_files` closes the "helper returns True unconditionally" hole.

Confirmed to kill: the original `runtime == 'true'` gate, a dropped `event_name != 'push'` clause, and gates ANDed with `docs`/`chat`/`unknown` flags. The paired gate-and-constant edit is caught by the evaluator alone.

## No third-party imports

The `script-tests` job's only setup is `make test-scripts`, whose venv recipe is `python -m venv` plus a pip upgrade — it installs nothing, and there is no root Python manifest. An earlier revision of this PR imported PyYAML, which is present locally only as a transitive dependency of `prompty` via `make setup-chat`. In CI that would have been a *collection* error, reddening the entire suite on every PR.

Verified under a venv containing only `pip` and `setuptools`: **98 tests, OK**.

## Follow-up filed

- #123 — `docs-check` still carries a comment asserting the routing condition this PR removes, and `test_venv_wiring.py` encodes the same stale premise

🤖 Generated with [Claude Code](https://claude.com/claude-code)