### PR TITLE
fix(smoke): reject chat replies that are not evidence chat works

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -29,7 +29,8 @@ What it does:
 3. verifies chat database dependency health (`/health/dependencies`)
    and fails immediately if `local_provider.enabled=true` with `local_provider.ready=false`
 4. sends a web proxy request to `/api/chat/service`
-5. validates the response contract (`answer` or `response` string)
+5. validates the response contract (`answer` or `response` string) and rejects
+   the chat service's degraded replies (see below)
 6. tears down the stack (unless `KEEP_STACK=1`)
 
 Keep the stack running for manual debugging:
@@ -37,6 +38,29 @@ Keep the stack running for manual debugging:
 ```bash
 make e2e-smoke KEEP_STACK=1
 ```
+
+### Degraded chat replies
+
+Chat answers `200` with a populated `answer` on both of its failure paths, so a
+non-empty answer is not evidence that chat works. The service labels them, and
+the smoke treats the two differently:
+
+- `mock: true` means `contoso_chat` failed to import. Detecting it needs no
+  credentials, so it **always fails** the smoke — this is what catches a broken
+  image or an undeclared dependency.
+- `fallback: true` means chat raised. That is the expected outcome wherever the
+  datastore is unconfigured, including CI, so it passes with a warning in the
+  job summary rather than failing.
+
+Where chat is expected to answer for real, make the second case fail too:
+
+```bash
+make e2e-smoke E2E_REQUIRE_REAL_CHAT=1
+```
+
+Pass it on the command line as above, or export it. Putting it in `.env` has no
+effect: `.env` is read by Docker Compose for the containers, and the smoke
+script runs outside them.
 
 Enable local LLM/vector stack in chat image when needed:
 

--- a/scripts/e2e_smoke.py
+++ b/scripts/e2e_smoke.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from html import escape
 from typing import Any
 
@@ -60,6 +62,64 @@ def response_has_answer(payload: dict[str, Any] | None) -> bool:
         return False
     answer = payload.get("answer") or payload.get("response")
     return isinstance(answer, str) and bool(answer.strip())
+
+
+def report_notice(message: str) -> None:
+    """Surface a caveat where a reader will actually see it.
+
+    A bare print scrolls past in the raw step log, and this job only dumps
+    compose logs when it fails — so on a green run the caveat is invisible,
+    which is the state this check exists to end. The job already writes to
+    $GITHUB_STEP_SUMMARY elsewhere.
+    """
+    print(f"NOTICE: {message}")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    # A newline in `message` would end the blockquote and render the rest as
+    # body text; the detail is an exception string, so it can contain one.
+    single_line = " ".join(message.split())
+    try:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(f"> [!WARNING]\n> {single_line}\n\n")
+    except OSError as error:  # pragma: no cover - summary is best-effort
+        print(f"(could not write step summary: {error})")
+
+
+def degraded_reason(payload: dict[str, Any] | None) -> tuple[str, str] | None:
+    """Classify a reply that is not evidence chat works, or None if it is.
+
+    Returns (kind, detail). Both of the chat service's failure paths return
+    HTTP 200 with a populated `answer` — `mock` when the chat module could not
+    be imported at all, `fallback` when any exception was raised — so checking
+    for a non-empty answer passes identically whether chat works or is dead.
+    The service labels both, so read the label.
+
+    The two kinds need different treatment, which is the whole reason this
+    returns a kind rather than a bare string. `mock` means an import failed and
+    needs no credentials to detect; `fallback` can mean nothing worse than an
+    unconfigured datastore.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("mock"):
+        return ("mock", "chat module could not be imported; served the mock response")
+    if payload.get("fallback"):
+        detail = payload.get("error") or "unspecified error"
+        return ("fallback", f"chat backend raised and served the fallback: {detail}")
+    return None
+
+
+def require_real_answer(env: Mapping[str, str] | None = None) -> bool:
+    """Whether a credential-dependent degradation should fail the run.
+
+    Explicit, because it cannot be inferred: the smoke process never holds
+    chat's configuration. PROJECT_ID and DISCOVERY_ENGINE_DATASTORE_ID reach
+    chat through compose substitution from .env, which the e2e-smoke target
+    does not export — and under LLM_PROVIDER=local chat needs neither.
+    """
+    env = os.environ if env is None else env
+    return env.get("E2E_REQUIRE_REAL_CHAT", "").strip().lower() in {"1", "true", "yes"}
 
 
 def dependencies_db_connected(payload: dict[str, Any] | None) -> bool:
@@ -152,6 +212,30 @@ def check_web_chat_proxy(web_url: str) -> None:
         raise RuntimeError(f"Web chat proxy returned {status}: {raw}")
     if not response_has_answer(response_payload):
         raise RuntimeError(f"Web chat proxy response missing answer/response field: {response_payload}")
+
+    degraded = degraded_reason(response_payload)
+    if degraded is None:
+        return
+    kind, detail = degraded
+
+    if kind == "mock":
+        # REAL_CHAT_AVAILABLE is decided by an import at module load, so this
+        # cannot recover and needs no credentials to detect. It is exactly the
+        # regression an undeclared dependency produces, and it is fatal
+        # everywhere including CI.
+        raise NonRetryableSmokeError(f"Chat served a mock response: {detail}")
+
+    if require_real_answer():
+        raise NonRetryableSmokeError(f"Chat failed to answer: {detail}")
+
+    # Credential-dependent, and this environment has none. Not a failure — but
+    # the run must not read as "chat works", which is what it did when the only
+    # check was a non-empty answer string.
+    report_notice(
+        f"chat did not answer for real — {detail}. This run verified transport "
+        "and status codes only. Set E2E_REQUIRE_REAL_CHAT=1 wherever chat is "
+        "expected to answer to make this a failure."
+    )
 
 
 def check_web_dynamic_page(web_url: str) -> None:

--- a/tests/scripts/test_e2e_smoke.py
+++ b/tests/scripts/test_e2e_smoke.py
@@ -1,4 +1,6 @@
+import contextlib
 import importlib.util
+import io
 import os
 import tempfile
 import unittest
@@ -97,8 +99,12 @@ class DegradedChatProxyBehaviourTests(unittest.TestCase):
     """
 
     def _run(self, payload, env):
+        # Swallow the NOTICE. Without this it lands in the Script Guardrail
+        # Tests log, a job that never runs chat, reading as though chat were
+        # degraded there.
         with patch.object(e2e_smoke, "request_json", return_value=(200, payload, "")), \
-             patch.dict(os.environ, env, clear=True):
+             patch.dict(os.environ, env, clear=True), \
+             contextlib.redirect_stdout(io.StringIO()):
             e2e_smoke.check_web_chat_proxy("http://web")
 
     def test_mock_reply_fails_even_without_credentials(self):

--- a/tests/scripts/test_e2e_smoke.py
+++ b/tests/scripts/test_e2e_smoke.py
@@ -1,4 +1,6 @@
 import importlib.util
+import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -19,6 +21,145 @@ e2e_smoke = load_script_module(
     "e2e_smoke",
     REPO_ROOT / "scripts/e2e_smoke.py",
 )
+
+
+class DegradedChatDetectionTests(unittest.TestCase):
+    """The smoke must not report success for a chat backend that is dead.
+
+    Both failure paths in services/chat/src/api/main.py return HTTP 200 with a
+    populated `answer`, so the previous non-empty-string check passed
+    identically whether chat worked or had failed entirely.
+    """
+
+    MOCK_REPLY = {
+        "answer": "Mock response: You asked about 'x'. ...",
+        "customer_id": "1",
+        "mock": True,
+    }
+    FALLBACK_REPLY = {
+        "answer": "I'm having trouble processing your request about 'x' right now.",
+        "customer_id": "1",
+        "error": "PROJECT_ID, REGION, and DISCOVERY_ENGINE_DATASTORE_ID must be set",
+        "fallback": True,
+    }
+    REAL_REPLY = {"answer": "A four-season tent suits that trip.", "context": []}
+
+    def test_degraded_replies_still_satisfy_the_old_check(self):
+        """Establishes the bug the rest of this class exists to fix.
+
+        If these failed `response_has_answer`, the old check would already have
+        caught a dead backend and nothing here would be needed.
+        """
+        for label, reply in (("mock", self.MOCK_REPLY), ("fallback", self.FALLBACK_REPLY)):
+            with self.subTest(reply=label):
+                self.assertTrue(e2e_smoke.response_has_answer(reply))
+
+    def test_degraded_replies_are_classified_by_kind(self):
+        """Kind, not prose. The two need different treatment."""
+        self.assertEqual(e2e_smoke.degraded_reason(self.MOCK_REPLY)[0], "mock")
+        self.assertEqual(e2e_smoke.degraded_reason(self.FALLBACK_REPLY)[0], "fallback")
+
+    def test_degraded_reason_names_the_underlying_error(self):
+        """A bare "degraded" verdict sends the reader back to the logs."""
+        self.assertIn(
+            "DISCOVERY_ENGINE_DATASTORE_ID",
+            e2e_smoke.degraded_reason(self.FALLBACK_REPLY)[1],
+        )
+
+    def test_a_real_reply_is_not_flagged(self):
+        self.assertIsNone(e2e_smoke.degraded_reason(self.REAL_REPLY))
+
+    def test_require_real_answer_is_explicit_only(self):
+        """No inference from the environment.
+
+        The smoke process never holds chat's configuration — PROJECT_ID and the
+        datastore id reach chat through compose substitution from .env, which
+        the e2e-smoke target does not export. Inferring from them here would
+        read False no matter how chat is actually configured.
+        """
+        self.assertFalse(e2e_smoke.require_real_answer({}))
+        self.assertFalse(
+            e2e_smoke.require_real_answer(
+                {
+                    "PROJECT_ID": "contoso-prod-1234",
+                    "DISCOVERY_ENGINE_DATASTORE_ID": "contoso-datastore",
+                }
+            )
+        )
+        self.assertTrue(e2e_smoke.require_real_answer({"E2E_REQUIRE_REAL_CHAT": "1"}))
+
+
+class DegradedChatProxyBehaviourTests(unittest.TestCase):
+    """Covers `check_web_chat_proxy` itself, not just its helpers.
+
+    The branch below is the entire point of the change, and asserting only on
+    the pure helpers would leave it untested.
+    """
+
+    def _run(self, payload, env):
+        with patch.object(e2e_smoke, "request_json", return_value=(200, payload, "")), \
+             patch.dict(os.environ, env, clear=True):
+            e2e_smoke.check_web_chat_proxy("http://web")
+
+    def test_mock_reply_fails_even_without_credentials(self):
+        """An import failure needs no credentials to detect.
+
+        This is what gives CI real regression detection: `mock` means
+        contoso_chat failed to import, which is exactly what an undeclared
+        dependency produces.
+        """
+        with self.assertRaises(e2e_smoke.NonRetryableSmokeError) as caught:
+            self._run(DegradedChatDetectionTests.MOCK_REPLY, {})
+        self.assertIn("mock", str(caught.exception))
+
+    def test_mock_failure_is_not_retried(self):
+        """Drives the real retry loop rather than asserting a class hierarchy.
+
+        REAL_CHAT_AVAILABLE is fixed at module import, so a mock reply cannot
+        change between polls. Retrying it would re-POST every interval for the
+        whole timeout (300s in CI) before reporting a verdict that was knowable
+        on the first attempt, with the reason buried in the last-error text.
+        """
+        attempts = 0
+
+        def check():
+            nonlocal attempts
+            attempts += 1
+            self._run(DegradedChatDetectionTests.MOCK_REPLY, {})
+
+        with self.assertRaises(e2e_smoke.NonRetryableSmokeError):
+            e2e_smoke.wait_for("chat proxy", 60, 0.01, check)
+        self.assertEqual(attempts, 1)
+
+    def test_fallback_reply_passes_without_credentials(self):
+        """CI has no secrets; failing here would make the smoke permanently
+        red rather than more honest."""
+        self._run(DegradedChatDetectionTests.FALLBACK_REPLY, {})
+
+    def test_fallback_reply_fails_when_a_real_answer_is_required(self):
+        with self.assertRaises(e2e_smoke.NonRetryableSmokeError):
+            self._run(
+                DegradedChatDetectionTests.FALLBACK_REPLY,
+                {"E2E_REQUIRE_REAL_CHAT": "1"},
+            )
+
+    def test_a_real_reply_passes_in_both_modes(self):
+        for env in ({}, {"E2E_REQUIRE_REAL_CHAT": "1"}):
+            with self.subTest(env=env):
+                self._run(DegradedChatDetectionTests.REAL_REPLY, env)
+
+    def test_notice_reaches_the_step_summary(self):
+        """A bare print is invisible on a green run — this job only dumps
+        logs when it fails."""
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = Path(tmp) / "summary.md"
+            summary.touch()
+            self._run(
+                DegradedChatDetectionTests.FALLBACK_REPLY,
+                {"GITHUB_STEP_SUMMARY": str(summary)},
+            )
+            written = summary.read_text(encoding="utf-8")
+        self.assertIn("DISCOVERY_ENGINE_DATASTORE_ID", written)
 
 
 class E2ESmokeTests(unittest.TestCase):


### PR DESCRIPTION
Closes #121.

The E2E smoke's chat assertion required only a non-empty `answer` string. **Both** of the chat service's failure paths return HTTP 200 with a populated `answer` — `mock` when `contoso_chat` fails to import, `fallback` when anything raises — so the check passed identically whether chat worked or was entirely dead.

A green Integration E2E Smoke was compatible with a non-functional chat service.

This is the shape `check_web_dynamic_page` exists to catch, and its own docstring says why: a Next 16 upgrade shipped pages that 404'd on every product "while the whole suite stayed green." Same failure mode, different surface — testing the *shape* of a response rather than evidence the thing worked.

## Split by degradation kind, not by environment

An earlier revision gated on whether the environment looked configured. Review killed it: `PROJECT_ID` and `DISCOVERY_ENGINE_DATASTORE_ID` reach chat through **compose substitution from `.env`**, which the `e2e-smoke` target never exports — so the smoke process saw neither, the inference returned False everywhere, and the strict branch was dead code. Under `LLM_PROVIDER=local` chat needs neither variable anyway.

The useful split is what *kind* of degradation it is:

| label | meaning | needs credentials to detect? | treatment |
| --- | --- | --- | --- |
| `mock: true` | `contoso_chat` failed to import | **no** | fails everywhere, including CI |
| `fallback: true` | chat raised | yes | warns; fails under `E2E_REQUIRE_REAL_CHAT` |

**This gives CI real regression detection today.** CI has zero secrets (`grep -c "secrets\." .github/workflows/ci.yml` → `0`) and always lands on `fallback`, so it stays green — while `mock` now catches exactly the undeclared-dependency class that #104 fixed and nothing would have caught.

## Fails fast

Both failures raise `NonRetryableSmokeError`. `REAL_CHAT_AVAILABLE` is fixed at module import, so retrying re-POSTs every interval for the full timeout before reporting a verdict knowable on the first attempt. Measured: a plain `RuntimeError` retries 20× per second of timeout — ~150 pointless requests at CI's 300s.

## Visible on a green run

The notice goes to `$GITHUB_STEP_SUMMARY` as well as stdout. This job dumps compose logs only on failure, so a printed caveat on a green run is invisible — which is the state this change exists to end. Newlines in the detail are collapsed so the alert block cannot be broken by a multi-line exception message.

## What this does not do

CI still cannot prove chat produces a real answer, because it has no credentials. It now proves transport, status codes, and that the chat module imports — and says so explicitly instead of implying more. `E2E_REQUIRE_REAL_CHAT=1` makes the rest enforceable wherever chat is expected to answer.

## Verification

- 109 guardrail tests pass under a **bare venv** (`pip`/`setuptools` only), matching what the `script-tests` job builds.
- The real stack was stood up with CI's exact values and the unmodified smoke run against it: all four checks PASS, exit 0, NOTICE emitted — so Integration E2E Smoke is not broken.
- Mutation-tested: inverting the `require_real_answer` branch, deleting the `mock` branch, and deleting the summary write each fail the suite.
- `make e2e-smoke E2E_REQUIRE_REAL_CHAT=1` was verified to reach the recipe (GNU make exports command-line variables); `docs/INTEGRATION.md` notes that putting it in `.env` does **not** work, for the same reason the original inference failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)