### PR TITLE
fix(web): drop chat replies whose thread was reset while in flight

### DIFF
--- a/apps/web/src/components/chat.test.tsx
+++ b/apps/web/src/components/chat.test.tsx
@@ -16,6 +16,15 @@ vi.mock('@/lib/messaging', () => ({
   sendChatMessage: (...args: unknown[]) => sendChatMessage(...args),
 }))
 
+function clickReset() {
+  // The reset control is an unlabelled svg with an onClick, so it cannot be
+  // selected by role or accessible name — which is also why a keyboard user
+  // cannot reach it. Tracked in #112; this selector goes away with that fix.
+  const reset = document.querySelector('.w-5.stroke-zinc-500')
+  if (!reset) throw new Error('reset control not found')
+  fireEvent.click(reset)
+}
+
 function openChatAndSend(text: string) {
   // The launcher is the first button; opening it reveals the input.
   fireEvent.click(screen.getAllByRole('button')[0])
@@ -138,6 +147,147 @@ describe('Chat placeholder timing', () => {
       { timeout: 2000 },
     )
     expect(screen.queryByText('Let me see what I can find...')).toBeNull()
+  })
+
+  it('drops a reply that arrives after the thread was reset', async () => {
+    // Send, reset within the 400ms placeholder delay, then let the reply land.
+    // Nothing told the in-flight request its conversation was gone, so the
+    // answer appended into the cleared thread — an assistant reply to nothing.
+    let resolveReply: (turn: unknown) => void = () => {}
+    sendChatMessage.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReply = resolve
+      }),
+    )
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<Chat />)
+      openChatAndSend('recommend a tent')
+
+      // Reset before the placeholder timer fires.
+      clickReset()
+      expect(screen.queryByText('recommend a tent')).toBeNull()
+
+      await act(async () => {
+        vi.advanceTimersByTime(500)
+      })
+      // The placeholder must not fire into the cleared thread either.
+      expect(screen.queryByText('Let me see what I can find...')).toBeNull()
+
+      await act(async () => {
+        resolveReply({
+          name: 'Jane Doe', message: 'ORPHANED ANSWER', status: 'done',
+          type: 'assistant', avatar: '',
+        })
+      })
+
+      expect(screen.queryByText('ORPHANED ANSWER')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('abandons every send in flight when reset runs, not just the last', async () => {
+    // reset clears the whole set, so this generalises trivially — but a fix
+    // that tracked a single pending id instead of a set would pass the
+    // one-send test above and drop only one of these.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const replies: Array<(turn: unknown) => void> = []
+      sendChatMessage.mockImplementation(
+        () => new Promise((resolve) => replies.push(resolve)),
+      )
+
+      render(<Chat />)
+      openChatAndSend('FIRST question')
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'SECOND question' } })
+      fireEvent.keyUp(input, { code: 'Enter' })
+
+      await act(async () => {
+        vi.advanceTimersByTime(500)
+      })
+      expect(screen.getAllByText('Let me see what I can find...')).toHaveLength(2)
+
+      clickReset()
+      expect(screen.queryByText('Let me see what I can find...')).toBeNull()
+
+      await act(async () => {
+        replies[0]({
+          name: 'Jane Doe', message: 'ANSWER ONE', status: 'done',
+          type: 'assistant', avatar: '',
+        })
+        replies[1]({
+          name: 'Jane Doe', message: 'ANSWER TWO', status: 'done',
+          type: 'assistant', avatar: '',
+        })
+      })
+
+      expect(screen.queryByText('ANSWER ONE')).toBeNull()
+      expect(screen.queryByText('ANSWER TWO')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('sends nothing for an empty message and stays usable', async () => {
+    // Note what this does NOT cover: sendMessage also returns early before
+    // minting a pending id, so an empty Enter leaves no orphan in the pending
+    // set. That ordering is unobservable from outside the component — this
+    // test passes either way — so it is an invariant argued in the source, not
+    // one pinned here.
+    sendChatMessage.mockClear()
+
+    render(<Chat />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+    const input = screen.getByRole('textbox')
+    fireEvent.keyUp(input, { code: 'Enter' })
+
+    expect(sendChatMessage).not.toHaveBeenCalled()
+
+    // And the panel still works afterwards.
+    sendChatMessage.mockResolvedValue({
+      name: 'Jane Doe', message: 'A REAL ANSWER', status: 'done',
+      type: 'assistant', avatar: '',
+    })
+    fireEvent.change(input, { target: { value: 'a real question' } })
+    fireEvent.keyUp(input, { code: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('A REAL ANSWER')).toBeDefined())
+  })
+
+  it('still delivers a reply sent after a reset', async () => {
+    // The other half: reset must abandon only what was in flight when it ran.
+    // Clearing the pending set without re-registering later sends would make
+    // the panel permanently dead after one reset, which the test above would
+    // not catch.
+    const replies: Array<(turn: unknown) => void> = []
+    sendChatMessage.mockImplementation(
+      () => new Promise((resolve) => replies.push(resolve)),
+    )
+
+    render(<Chat />)
+    openChatAndSend('first question')
+    clickReset()
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'second question' } })
+    fireEvent.keyUp(input, { code: 'Enter' })
+
+    // Resolve the abandoned send first, then the live one.
+    replies[0]({
+      name: 'Jane Doe', message: 'STALE ANSWER', status: 'done',
+      type: 'assistant', avatar: '',
+    })
+    replies[1]({
+      name: 'Jane Doe', message: 'LIVE ANSWER', status: 'done',
+      type: 'assistant', avatar: '',
+    })
+
+    await waitFor(() => expect(screen.getByText('LIVE ANSWER')).toBeDefined())
+    expect(screen.queryByText('STALE ANSWER')).toBeNull()
+    expect(screen.getByText('second question')).toBeDefined()
   })
 
   it('resolves each reply into its own placeholder when two are on screen', async () => {

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -67,12 +67,23 @@ export const Chat = () => {
     scrollChat();
   }, [state.turns.length]);
 
+  // Ids of sends whose replies this thread still wants. A reset empties it, so
+  // anything already in flight is abandoned rather than landing in a
+  // conversation the user cleared.
+  const pendingIds = useRef<Set<string>>(new Set());
+
   const reset = () => {
     setMessage("");
+    pendingIds.current.clear();
     dispatch({ type: "clear" });
   };
 
   const sendMessage = () => {
+    // Before anything is minted. Registering a pending id for a send that never
+    // happens leaves an entry nothing can remove, so the set stops meaning
+    // "replies this thread is still waiting for".
+    if (message === "") return;
+
     const userName = session?.user?.name || "Guest";
     const userAvatar = (session?.user as any)?.image || "";
     const customerId = (session?.user as any)?.id;
@@ -90,11 +101,13 @@ export const Chat = () => {
     // to the other request — the reply then overwrites a turn it does not own
     // and the other placeholder spins forever.
     const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    let settled = false;
+    pendingIds.current.add(pendingId);
 
     const showPlaceholder = () =>
       setTimeout(() => {
-        if (settled) return;
+        // Membership covers both cases: the reply already settled, or the
+        // thread was reset. Either way this placeholder has no owner.
+        if (!pendingIds.current.has(pendingId)) return;
         dispatch({
           type: "add",
           payload: {
@@ -109,8 +122,14 @@ export const Chat = () => {
       }, 400);
 
     const settle = (timer: ReturnType<typeof setTimeout>) => (responseTurn: ChatTurn) => {
-      settled = true;
       clearTimeout(timer);
+      // Two jobs in one call. The return value is the guard: a reset between
+      // the request and its reply removed the id, so the reply is dropped
+      // rather than appended into the cleared thread as an answer to nothing.
+      // The removal itself is hygiene — ids are unique, so a settled one left
+      // behind changes no behaviour, it just accumulates for the lifetime of
+      // the panel, which is mounted once in the root layout.
+      if (!pendingIds.current.delete(pendingId)) return;
       dispatch({ type: "resolve", id: pendingId, payload: responseTurn });
     };
 
@@ -134,7 +153,6 @@ export const Chat = () => {
       request.then(settle(timer)).catch(settleWithError(timer));
     };
 
-    if (message === "") return;
     dispatch({ type: "add", payload: newTurn });
     send(sendChatMessage(newTurn, customerId));
 


### PR DESCRIPTION
Closes #113.

Send a message, then reset within the 400ms placeholder delay. The thread clears, but nothing tells the in-flight request its conversation is gone — the placeholder fires into the empty thread and the reply appends, leaving an assistant answer with no question above it.

#114 made replies resolve by id, so a reset no longer causes a reply to *overwrite* an unrelated turn. It did not stop the orphan from appearing.

## The fix

A ref-held `Set` of ids the thread still wants. `reset()` empties it; `settle` uses `delete`'s return value as its guard and drops a reply whose id is gone.

Set membership also subsumes the old `settled` boolean — it covers both "already settled" and "thread was reset" — so there is one mechanism instead of two.

**Second bug fixed incidentally:** `settleWithError` routes through `settle`, so a *rejected* request after a reset no longer plants "Sorry, something went wrong" into a cleared thread either.

**Ordering bug found in review:** the empty-message guard ran *after* the pending id was minted, so pressing Enter on an empty input registered an id with no request behind it. `settle` never runs for it and only `reset` removes it, which quietly breaks the set's meaning for anything that later asks whether a reply is outstanding. The guard now runs first.

## Tests

Three added: a reset mid-flight, a send *after* a reset still landing, and a reset while **two** sends are in flight. The second stops a fix that clears the pending set from leaving the panel permanently dead; the third would catch a fix that tracked a single pending id rather than a set. All verified to fail against the pre-change component.

## What is deliberately not pinned by a test

Stated plainly rather than papered over, because both are unobservable from outside the component:

- **The empty-message ordering.** Moving the guard back below the id mint still passes all 10 tests — `sendChatMessage` is uncalled either way. The included test's name and comment say only what it verifies.
- **That `settle` removes settled ids rather than only checking them.** Mutating `delete` to `has` survives the suite. Ids never collide, so a settled id left behind changes no behaviour; it only accumulates in a panel the root layout mounts once. Testing it would mean reaching into component internals.

## Deferred

`AbortController` — this ignores the response rather than cancelling the request, so the network call still completes. Doing it properly means plumbing a signal through `messaging.ts` and teaching its unconditional `catch` about `AbortError`, or every reset logs an error and resolves a user-facing error turn. Its own slice.

The reset control is an unlabelled svg with an `onClick`, so the test helper selects it by Tailwind class. That is #112's scope; the helper's comment says so and will need updating with that fix.

93 web tests pass, `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)