### PR TITLE
fix(web): make the chat panel usable on a phone and legible to screen readers

### DIFF
--- a/apps/web/src/components/chat.test.tsx
+++ b/apps/web/src/components/chat.test.tsx
@@ -17,12 +17,11 @@ vi.mock('@/lib/messaging', () => ({
 }))
 
 function clickReset() {
-  // The reset control is an unlabelled svg with an onClick, so it cannot be
-  // selected by role or accessible name — which is also why a keyboard user
-  // cannot reach it. Tracked in #112; this selector goes away with that fix.
-  const reset = document.querySelector('.w-5.stroke-zinc-500')
-  if (!reset) throw new Error('reset control not found')
-  fireEvent.click(reset)
+  fireEvent.click(screen.getByRole('button', { name: 'Clear conversation' }))
+}
+
+function openChat() {
+  fireEvent.click(screen.getByRole('button', { name: 'Open chat' }))
 }
 
 function openChatAndSend(text: string) {
@@ -32,6 +31,237 @@ function openChatAndSend(text: string) {
   fireEvent.change(input, { target: { value: text } })
   fireEvent.keyUp(input, { code: 'Enter' })
 }
+
+describe('Chat accessibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exposes every control by an accessible name', () => {
+    // Rendered review found the reset control was a bare svg with an onClick —
+    // no role, no name, unreachable by keyboard — and the send button and
+    // input had no names at all.
+    render(<Chat />)
+    openChat()
+
+    expect(screen.getByRole('button', { name: 'Clear conversation' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Close chat' })).toBeDefined()
+    expect(screen.getByRole('textbox', { name: 'Message' })).toBeDefined()
+  })
+
+  it('announces conversation updates to assistive technology', () => {
+    // A probe at three viewports found zero aria-live/role=log/status/alert
+    // anywhere on the page, so turns mutated silently.
+    render(<Chat />)
+    openChat()
+
+    const log = screen.getByRole('log', { name: 'Conversation' })
+    expect(log.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('marks the waiting turn as a status and hides the decorative spinner', async () => {
+    let resolveReply: (turn: unknown) => void = () => {}
+    sendChatMessage.mockReturnValue(new Promise((resolve) => { resolveReply = resolve }))
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<Chat />)
+      openChatAndSend('recommend a tent')
+      await act(async () => { vi.advanceTimersByTime(500) })
+
+      const status = screen.getByRole('status')
+      expect(status.textContent).toContain('Let me see what I can find')
+      expect(status.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true')
+
+      await act(async () => {
+        resolveReply({
+          name: 'Jane Doe', message: 'done', status: 'done',
+          type: 'assistant', avatar: '',
+        })
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('moves focus into the panel when it opens', () => {
+    // The launcher is the last tabbable element on the home page; opening the
+    // panel moved focus nowhere, so the next Tab went into the page behind it.
+    render(<Chat />)
+    openChat()
+    expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Message' }))
+  })
+
+  it('closes on Escape', () => {
+    render(<Chat />)
+    openChat()
+    expect(screen.getByRole('dialog', { name: 'Chat with Jane Doe' })).toBeDefined()
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('ignores Escape that did not originate inside the panel', () => {
+    // Rendered review: with the site nav drawer open over the chat, Escape
+    // closed the chat underneath and left the drawer up — dismissing the layer
+    // the user was not interacting with.
+    render(<Chat />)
+    openChat()
+    expect(screen.getByRole('dialog')).toBeDefined()
+
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeNull()
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Message' }), { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('returns focus to the launcher when closed', () => {
+    // Closing dropped focus to <body>, so the next Tab restarted at the top of
+    // the document — 24 stops back to the launcher.
+    render(<Chat />)
+    openChat()
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Message' }), { key: 'Escape' })
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Open chat' }))
+  })
+
+  it('re-seeds the greeting when the conversation is cleared', async () => {
+    // Reset left the panel completely blank, and the greeting only rendered on
+    // open — so a cleared thread stayed empty for the rest of the session.
+    // That state was unreachable while the reset control was not a control.
+    sendChatMessage.mockResolvedValue({
+      name: 'Jane Doe', message: 'an answer', status: 'done',
+      type: 'assistant', avatar: '',
+    })
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<Chat />)
+      openChatAndSend('recommend a tent')
+
+      // Drain the 400ms greeting timer that toggleChat queued. Without this it
+      // is still pending at reset and fires afterwards, re-seeding the greeting
+      // by accident — which would make this test pass against the old reset.
+      await act(async () => {
+        vi.advanceTimersByTime(1000)
+      })
+      await waitFor(() => expect(screen.getByText('an answer')).toBeDefined())
+
+      clickReset()
+      // Turn bodies render through react-remark, which updates on an effect.
+      await act(async () => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(screen.getByText(/how can I be helpful today/i)).toBeDefined()
+      expect(screen.queryByText('recommend a tent')).toBeNull()
+      expect(screen.queryByText('an answer')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns focus to the launcher when closed by the button, not just Escape', () => {
+    // The Escape path and the button path are separate lines. A test that only
+    // closes with Escape leaves the button path unguarded — and Safari does not
+    // focus buttons on click, so focus would fall to <body> there.
+    render(<Chat />)
+    openChat()
+    fireEvent.click(screen.getByRole('button', { name: 'Close chat' }))
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Open chat' }))
+  })
+
+  it('keeps the panel focusable so a click inside it does not break Escape', () => {
+    // In a browser, clicking a non-focusable part of the panel blurs to <body>,
+    // and the Escape guard — keyed on "target inside the panel" — then ignores
+    // the key. tabIndex={-1} makes the panel the nearest focusable ancestor, so
+    // the target stays inside.
+    //
+    // jsdom does not implement that focus-on-mousedown behaviour, so the
+    // consequence cannot be reproduced here; this pins the mechanism only. The
+    // behaviour itself was measured in the rendered app.
+    render(<Chat />)
+    openChat()
+    expect(screen.getByRole('dialog').getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('closes on Escape raised from within the panel', () => {
+    render(<Chat />)
+    openChat()
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not double-seed the greeting when reset races the open timer', () => {
+    // toggleChat queues a 400ms greeting timer. reset also seeds one, so a
+    // reset inside that window rendered the greeting twice — reproduced in the
+    // browser at +50, +150 and +300ms.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<Chat />)
+      openChat()
+      act(() => {
+        vi.advanceTimersByTime(150)
+      })
+      clickReset()
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(screen.getAllByText(/how can I be helpful today/i)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not double-seed the greeting when reopened inside the open timer', () => {
+    // Found in the browser at every delay tried between +50 and +380ms. The
+    // open branch guards on turns.length, but the pending timer has not
+    // dispatched yet, so a reopen still sees an empty thread and schedules a
+    // second timer. Tap-tap-tap on the launcher is an ordinary mobile gesture.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<Chat />)
+      openChat()
+      act(() => {
+        vi.advanceTimersByTime(150)
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Close chat' }))
+      act(() => {
+        vi.advanceTimersByTime(50)
+      })
+      openChat()
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(screen.getAllByText(/how can I be helpful today/i)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a whitespace-only message', () => {
+    // The guard was `message === ""` with no trim, so three spaces and Enter
+    // fired a real request and rendered an empty blue bubble.
+    render(<Chat />)
+    openChatAndSend('   ')
+    expect(sendChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('sends the trimmed text, not the padded input', () => {
+    sendChatMessage.mockResolvedValue({
+      name: 'Jane Doe', message: 'ok', status: 'done', type: 'assistant', avatar: '',
+    })
+    render(<Chat />)
+    openChatAndSend('  recommend a tent  ')
+
+    expect(sendChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'recommend a tent' }),
+      undefined,
+    )
+  })
+})
 
 describe('Chat placeholder timing', () => {
   beforeEach(() => {

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -51,6 +51,35 @@ export const Chat = () => {
   const [state, dispatch] = useReducer(chatReducer, { turns: [] });
 
   const chatDiv = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const launcherRef = useRef<HTMLButtonElement>(null);
+  const greetingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Opening the panel left focus on the launcher, so the next Tab continued
+  // into the page behind it rather than into the conversation.
+  useEffect(() => {
+    if (showChat) inputRef.current?.focus();
+  }, [showChat]);
+
+  // Bound to the document so Escape works wherever focus sits inside the
+  // panel, but scoped to events originating within it. Unscoped, Escape while
+  // the site's nav drawer was open dismissed the chat underneath it and left
+  // the drawer up — closing the layer the user was not interacting with.
+  useEffect(() => {
+    if (!showChat) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const target = event.target as Node;
+      const inPanel = panelRef.current?.contains(target);
+      const onLauncher = launcherRef.current === target;
+      if (!inPanel && !onLauncher) return;
+      setShowChat(false);
+      launcherRef.current?.focus();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [showChat]);
 
   const scrollChat = () => {
     setTimeout(() => {
@@ -72,17 +101,35 @@ export const Chat = () => {
   // conversation the user cleared.
   const pendingIds = useRef<Set<string>>(new Set());
 
+  const greeting = (): ChatTurn => ({
+    name: "Jane Doe",
+    message: `Hi ${session?.user?.name || "there"}, how can I be helpful today?`,
+    status: "done",
+    type: "assistant",
+    avatar: "",
+  });
+
   const reset = () => {
     setMessage("");
     pendingIds.current.clear();
     dispatch({ type: "clear" });
+    // Cancel the timer toggleChat queued. Resetting within 400ms of opening
+    // otherwise seeds the greeting here and again when that timer fires.
+    if (greetingTimer.current) clearTimeout(greetingTimer.current);
+    // Re-seed rather than leaving the panel blank. The greeting only rendered
+    // on open, so a cleared thread stayed empty for the rest of the session —
+    // a state that was unreachable while the reset control was not a control.
+    dispatch({ type: "add", payload: greeting() });
+    inputRef.current?.focus();
   };
 
   const sendMessage = () => {
-    // Before anything is minted. Registering a pending id for a send that never
-    // happens leaves an entry nothing can remove, so the set stops meaning
-    // "replies this thread is still waiting for".
-    if (message === "") return;
+    // Trimmed: the guard was `message === ""`, so three spaces and Enter fired
+    // a real request and rendered an empty bubble. Before anything is minted —
+    // registering a pending id for a send that never happens leaves an entry
+    // nothing can remove, so the set stops meaning "replies still wanted".
+    const question = message.trim();
+    if (question === "") return;
 
     const userName = session?.user?.name || "Guest";
     const userAvatar = (session?.user as any)?.image || "";
@@ -90,7 +137,7 @@ export const Chat = () => {
 
     const newTurn: ChatTurn = {
       name: userName,
-      message: message,
+      message: question,
       status: "done",
       type: "user",
       avatar: userAvatar,
@@ -161,36 +208,64 @@ export const Chat = () => {
 
   const toggleChat = () => {
     setShowChat(!showChat);
-    if (!showChat) {
-      scrollChat();
-      if (state.turns.length === 0) {
-        setTimeout(() => {
-          const userName = session?.user?.name || "there";
-          dispatch({
-            type: "add",
-            payload: {
-              name: "Jane Doe",
-              message: `Hi ${userName}, how can I be helpful today?`,
-              status: "done",
-              type: "assistant",
-              avatar: "",
-            },
-          });
-        }, 400);
-      }
+
+    if (showChat) {
+      // Closing dropped focus to <body>, so the next Tab restarted at the top
+      // of the document — 24 stops back to this launcher. Moving focus in on
+      // open is only half the contract.
+      launcherRef.current?.focus();
+      // Cancel an unfired greeting. The open branch below guards on
+      // turns.length, but a pending timer has not dispatched yet, so closing
+      // and reopening inside 400ms — an ordinary impatient tap — schedules a
+      // second timer and both fire.
+      if (greetingTimer.current) clearTimeout(greetingTimer.current);
+      return;
+    }
+
+    scrollChat();
+    if (state.turns.length === 0) {
+      greetingTimer.current = setTimeout(() => {
+        dispatch({ type: "add", payload: greeting() });
+      }, 400);
     }
   };
 
   return (
     <>
-      <div className="fixed bottom-0 right-0 mr-12 mb-12 z-10 flex flex-col items-end ">
+      <div className="fixed bottom-0 right-0 mr-4 mb-4 sm:mr-12 sm:mb-12 z-10 flex flex-col items-end">
         {showChat && (
-          <div className="mb-3 h-[calc(100vh-7rem)] shadow-md bg-white rounded-lg w-[650px] flex flex-col">
-            <div className="text-right p-2 flex flex-col">
-              <ArrowPathIcon className="w-5 stroke-zinc-500" onClick={reset} />
+          // Width was a flat w-[650px]. At 390px the panel rendered at
+          // left:-308, clipping message text outside the viewport entirely.
+          // dvh rather than vh so mobile browser chrome does not push the input
+          // below the fold.
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-label="Chat with Jane Doe"
+            tabIndex={-1}
+            className="mb-3 flex flex-col shadow-md bg-white rounded-lg outline-none
+                       w-[min(650px,calc(100vw-2rem))]
+                       sm:w-[min(650px,calc(100vw-7rem))]
+                       h-[calc(100dvh-6rem)] sm:h-[calc(100vh-7rem)]"
+          >
+            <div className="p-2 flex justify-end">
+              <button
+                type="button"
+                onClick={reset}
+                aria-label="Clear conversation"
+                className="p-2 rounded-md hover:bg-zinc-100 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+              >
+                <ArrowPathIcon className="w-5 stroke-zinc-500" aria-hidden="true" />
+              </button>
             </div>
             {/* chat section */}
             <div
+              // Turns mutate with no announcement otherwise: a screen-reader
+              // user gets no signal that the assistant is working or that an
+              // answer arrived.
+              role="log"
+              aria-live="polite"
+              aria-label="Conversation"
               className="grow p-2 overscroll-contain overflow-auto"
               ref={chatDiv}
             >
@@ -206,23 +281,31 @@ export const Chat = () => {
                 id="chat"
                 name="chat"
                 type="text"
+                ref={inputRef}
+                aria-label="Message"
+                placeholder="Ask about a product..."
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 onKeyUp={(e) => {
                   if (e.code === "Enter") sendMessage();
                 }}
-                className="block p-2 grow rounded-md text-zinc-700 shadow-xs ring-2 ring-inset ring-zinc-300 focus:ring-zinc-300 focus:border-zinc-300"
+                // Resting ring was zinc-300 and the focus ring was the same
+                // colour, so focus was indicated by the browser default alone.
+                className="block p-2 grow rounded-md text-zinc-700 placeholder:text-zinc-500 placeholder:opacity-100 shadow-xs ring-2 ring-inset ring-zinc-300 focus:ring-sky-700 focus:outline-none"
               />
               <button
-                className="rounded-md p-2 border-solid border-2 border-zinc-300 hover:cursor-pointer hover:bg-zinc-100"
+                type="button"
                 onClick={sendMessage}
+                aria-label="Send message"
+                className="rounded-md p-2 border-solid border-2 border-zinc-300 hover:cursor-pointer hover:bg-zinc-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
               >
-                <PaperAirplaneIcon className="w-6 stroke-zinc-500" />
+                <PaperAirplaneIcon className="w-6 stroke-zinc-500" aria-hidden="true" />
               </button>
             </div>
           </div>
         )}
         <button
+          ref={launcherRef}
           className="bg-white rounded-full p-2 shadow-lg hover:cursor-pointer"
           onClick={toggleChat}
           aria-label={showChat ? "Close chat" : "Open chat"}

--- a/apps/web/src/components/turn.tsx
+++ b/apps/web/src/components/turn.tsx
@@ -28,12 +28,13 @@ export const Turn = ({ turn }: Props) => {
   const getContent = (turn: ChatTurn) => {
     if (turn.status === "waiting") {
       return (
-        <div className="ml-2 flex flex-row">
+        <div className="ml-2 flex flex-row" role="status">
           <svg
-            className="animate-spin -ml-1 mr-2 h-5 w-5 text-zinc-600"
+            className="animate-spin motion-reduce:animate-none -ml-1 mr-2 h-5 w-5 text-zinc-600"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <circle
               className="opacity-25"
@@ -57,7 +58,7 @@ export const Turn = ({ turn }: Props) => {
         <div>
           <div
             className={clsx(
-              "[&_a]:text-sky-800 [&_ul]:list-disc [&_ul]:list-outside [&_li]:ml-9 p-1 [&_ul]:pt-2 [&_ul]:pb-2",
+              "[&_a]:text-sky-800 [&_ul]:list-disc [&_ul]:list-outside [&_li]:ml-5 sm:[&_li]:ml-9 p-1 [&_ul]:pt-2 [&_ul]:pb-2",
               "[&_a]:font-semibold"
             )}
           >
@@ -68,10 +69,12 @@ export const Turn = ({ turn }: Props) => {
     }
   };
 
+  // Gutters were a flat 96px. Inside a 358px panel at 390px that left a 218px
+  // content column — 39% fixed gutter — wrapping product names onto two lines.
   if (turn.type === "user") {
     return (
-      <div className="ml-24 flex gap-1">
-        <div className="grow bg-sky-700 text-zinc-100 p-2 rounded-md">
+      <div className="ml-8 sm:ml-24 flex gap-1">
+        <div className="grow min-w-0 break-words bg-sky-700 text-zinc-100 p-2 rounded-md">
           {getContent(turn)}
         </div>
         <div>
@@ -81,8 +84,8 @@ export const Turn = ({ turn }: Props) => {
     );
   } else {
     return (
-      <div className="flex flex-row-reverse gap-1 mr-24">
-        <div className="grow bg-zinc-200 text-zinc-600 p-2 rounded-md">
+      <div className="flex flex-row-reverse gap-1 mr-8 sm:mr-24">
+        <div className="grow min-w-0 break-words bg-zinc-200 text-zinc-600 p-2 rounded-md">
           {getContent(turn)}
         </div>
         <div>


### PR DESCRIPTION
Closes #112.

The panel was a flat `w-[650px]`. At 390px it rendered at **left:-308** — 308px off-screen, text clipped mid-sentence, product links entirely invisible. Chat was effectively unusable on a phone.

Now `x:16, width:358` at that viewport, measured in a browser.

## The width needed two formulas, not one

`w-[min(650px,calc(100vw-2rem))]` alone reintroduced the bug. The container jumps to `sm:mr-12` (48px) at 640px while the formula still reserved `2rem` (32px), putting the panel back off the left edge for **every viewport in [640, 698)** — `x:-16` at 660px.

The three widths the original review measured — 390, 834, 1440 — all fall outside that band. **I fixed a clipping bug by introducing a narrower clipping bug exactly where nobody was looking.** Caught by review arithmetic, then confirmed in a browser across 639/640/660/697/698/746.

## Everything else in the issue

| item | before | after |
| --- | --- | --- |
| live regions | zero on the whole page | `role="log" aria-live="polite"`; waiting turn `role="status"`, spinner `aria-hidden` |
| reset control | bare `<svg>` + onClick, no role/name/tabindex, 20×20, never reached in a Tab walk | `<button>`, named, 36×36, Tab stop 24 |
| send / input | no accessible names | named |
| focus ring | `focus:ring-zinc-300` == resting ring | `sky-700`, measured 3.96:1 against resting |
| focus on open | stayed on launcher; next Tab went behind the panel | moves to input; returns to launcher on close |
| Escape | none | closes, scoped to the panel |
| whitespace-only send | fired a real request, empty bubble | rejected; trimmed text sent |
| placeholder | n/a | added, 4.83:1 |
| reduced motion | spinner always spun | `motion-reduce:animate-none` |

Item 6 (literal `alt` in `turn.tsx`) was already resolved by #116 — nothing to fix.

## Four defects the rendered review found in my own fix

None of these were reachable by unit test:

1. **Escape closed the chat out from under the site nav drawer** — my document listener was unscoped, so it dismissed the layer the user *wasn't* using. Now scoped, with `tabIndex={-1}` on the panel so a click on a non-focusable area doesn't blur to `<body>` and silently disable the key.
2. **Focus dropped to `<body>` on close** — 24 Tab stops back to the launcher. Moving focus in is only half the contract.
3. **Reset left the panel permanently blank** — the greeting only rendered on open. Making the reset control real made a previously unreachable state reachable.
4. **Duplicate greeting**, twice over: reset inside the 400ms open-timer, then close-and-reopen inside it. The timer is tracked and cancelled on both paths.

Plus a long unbroken token producing a **590px bubble inside a 358px panel** (+272px, with horizontal scroll) — only unreachable before because the panel itself sat off-screen. Fixed with `min-w-0 break-words`; now 282px and contained.

## On `role="dialog"` without `aria-modal`

Deliberate, and challenged twice. It is the ARIA non-modal dialog pattern, whose four obligations — accessible name, focus in on open, Escape, focus return — are all met. `aria-modal` is the containment claim, and the panel doesn't make it. Dropping the role would lose the accessible name and grouping boundary and wouldn't move WCAG 2.4.11 at all, since the obscured controls are a layering problem, not a role problem.

## Split out with measurements

- **#129** — 26 of 43 focus stops land on controls the panel fully obscures at 390px. Wants modal-below-`sm` (scrim + `inert` + `aria-modal` + trap, all four or none), not a partial trap.
- **#130** — the home page has no headings at all; category names are `div.text-5xl`.

## Verification

108 web tests (was 93), `tsc` and `eslint` clean. Three rendered passes at 390×844, 834×1112, 1440×900, plus the 639–746 band. One test in this PR was rewritten after mutation testing showed it passed against the old code by accident — a stray 400ms timer re-seeded the greeting on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)