### PR TITLE
fix(web): stop the home product grid scrolling sideways on a phone

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -54,11 +54,15 @@ export default async function Home() {
           >
             {category.description}
           </div>
-          <div className="flex flex-row place-content-between gap-4 mt-4">
+          <div
+            className="grid grid-cols-2 gap-4 mt-4
+                       sm:grid-cols-[repeat(3,minmax(0,350px))] sm:justify-between"
+          >
             {category.products.map((product, j) => (
               <a
                 key={j}
                 href={`/products/${product.slug}`}
+                className="w-full max-w-[350px]"
               >
                 <div className="items-center">
                   <Image
@@ -66,9 +70,15 @@ export default async function Home() {
                     alt={product.name}
                     width={350}
                     height={350}
-                    className="rounded-3xl"
+                    // The box is fluid now, so the srcset has to be told about
+                    // it — keyed to the fixed 350px it serves a 384px asset
+                    // into a 175px slot on a phone.
+                    sizes="(min-width: 640px) 350px, 45vw"
+                    // w-full so the image scales into its column: at its
+                    // intrinsic 350px it overflows one instead.
+                    className="rounded-3xl w-full h-auto"
                   />
-                  <div className="text-center mt-2 text-2xl font-semibold">
+                  <div className="text-center mt-2 text-base sm:text-xl md:text-2xl font-semibold break-words">
                     {product.name}
                   </div>
                 </div>


### PR DESCRIPTION
Closes #115.

The grid was `flex flex-row place-content-between` (never wraps) and each `<Image>` had `width={350}` styled only `rounded-3xl`, so the image kept its intrinsic 350px and couldn't shrink into the row. `document.scrollWidth` measured **476 in a 390px viewport** — the page drifted sideways under a finger.

**Both parts had to change.** A grid alone leaves the image at 350px; `w-full` alone leaves the row unable to wrap.

## The issue described one layer; there were three

Halving the columns exposed the next one down. Product names are single unbreakable words — `MountainDream` measures **197.5px** at 24px — so they painted outside a 175px column and the document still grew. **Overflow went 476 → 400, not 476 → 390.**

An element-box scan finds nothing: `getBoundingClientRect()` on every element reports zero offenders. It's only visible scanning text-node line boxes via `Range.getClientRects()`.

Then a *single* `sm:` step on the type reintroduced it in a 9px band. At exactly 640 the grid drops to its narrowest three-column track (194.7px) while the type jumps to its largest (24px) — the worst pairing in the whole range, short by **2.8px**. Same shape as the width band in #131: a defect living precisely where two responsive rules change together. The bump is now staggered so 24px never meets the narrowest track.

| width | cols | track | type | word | fits |
| --- | --- | --- | --- | --- | --- |
| 320 | 2 | 140.0 | 16 | 131.7 | ✓ |
| 639 | 2 | 299.5 | 16 | 131.7 | ✓ |
| 640 | 3 | 194.7 | 20 | 164.6 | ✓ |
| 767 | 3 | 237.0 | 20 | 164.6 | ✓ |
| 768 | 3 | 237.3 | 24 | 197.5 | ✓ |
| 1440 | 3 | 408.0 | 24 | 197.5 | ✓ |

## Desktop preserved exactly, not approximately

Capping tracks at 350px and distributing free space between them reproduces the original flex distribution:

| | `main` | this PR |
| --- | --- | --- |
| row span | 92 → 1348 | **92 → 1348** |
| gaps | 103, 103 | **103, 103** |
| image | 350×350 | **350×350** |
| first image vs heading | aligned at 92 | **aligned at 92** |

An earlier revision used `mx-auto`, which centred each capped card in its 408px column, insetting the row 29px and breaking that alignment. Caught in review.

## Verification

Measured in a browser **against a live render of `main` on a second port**, not a reconstruction — the first reconstruction attempt injected `place-content-between` at runtime, which no longer exists in the generated Tailwind stylesheet since no source file uses it, and was silently measuring an unstyled block.

**Zero overflow at every integer width from 320 to 1600.** The residual below 350px is the hero `text-7xl` heading, present identically on `main` and untouched here.

`sizes` is declared now the box is fluid — keyed to the fixed 350px, a 2× phone fetched the `w=640` candidate for a 175px slot (now `w=384`, and `w=1920` → `w=750` at 1440).

## One deliberate behaviour change

Sleeping Bags has two products. `space-between` flung them to opposite edges with a **548px hole** and let them balloon to 350px — larger than the 259px cards in every three-product row above. They now sit in the first two tracks at the same size as every other row, leaving the third empty. I think that's better, but it's a visible change beyond the stated bug, so it should be a decision rather than a side effect.

No test added: `page.tsx` is an async server component, jsdom has no layout engine, and asserting Tailwind class strings would restate the diff. The check that catches this class of bug is the rendered sweep, not a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)