### PR TITLE
fix(chat): lint and type-check the scripts the service depends on

### DIFF
--- a/services/chat/Makefile
+++ b/services/chat/Makefile
@@ -91,10 +91,10 @@ deps-check: | $(VENV_PYTHON) ## Validate dependency pinning policy for chat serv
 	$(PYTHON) $(DEPS_CHECK_SCRIPT)
 
 lint: | $(VENV_PYTHON) ## Lint chat service
-	$(RUFF) check src/api tests
+	$(RUFF) check src/api tests scripts
 
 typecheck: | $(VENV_PYTHON) ## Type-check chat service
-	$(MYPY) --config-file mypy.ini src/api
+	$(MYPY) --config-file mypy.ini src/api scripts
 
 test: | $(VENV_PYTHON) ## Run chat unit tests
 	@mkdir -p $(COVERAGE_TMP_DIR)

--- a/services/chat/scripts/check_dependency_policy.py
+++ b/services/chat/scripts/check_dependency_policy.py
@@ -24,7 +24,6 @@ as `starlette` failing at test collection over `httpx2`.
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
 
 REQUIREMENT_FILES = (

--- a/tests/scripts/test_venv_wiring.py
+++ b/tests/scripts/test_venv_wiring.py
@@ -91,5 +91,46 @@ class DocsCheckWiringTests(unittest.TestCase):
         )
 
 
+class ChatLintScopeTests(unittest.TestCase):
+    """Every Python directory in the chat service must be linted and typed.
+
+    `scripts/` sat outside both targets, so `check_dependency_policy.py` — the
+    guard for the service's whole dependency policy — was held to a lower
+    standard than the code it guards, and an unused import survived on main.
+    """
+
+    SKIP = {".venv", "__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
+
+    def python_dirs(self) -> set[str]:
+        """Derived from disk, so a new directory is covered without editing this."""
+        chat = REPO_ROOT / "services/chat"
+        return {
+            path.relative_to(chat).parts[0]
+            for path in chat.rglob("*.py")
+            if not self.SKIP & set(path.parts)
+        }
+
+    def recipe(self, target: str) -> str:
+        makefile = read("services/chat/Makefile")
+        return makefile.split(f"\n{target}:", 1)[1].split("\n\n", 1)[0]
+
+    def test_every_python_directory_is_discovered(self):
+        """Without this the two tests below pass vacuously on an empty set."""
+        found = self.python_dirs()
+        self.assertIn("scripts", found)
+        self.assertIn("src", found)
+        self.assertGreaterEqual(len(found), 3)
+
+    def test_lint_covers_every_python_directory(self):
+        recipe = self.recipe("lint")
+        for directory in sorted(self.python_dirs()):
+            with self.subTest(directory=directory):
+                self.assertIn(directory, recipe)
+
+    def test_typecheck_covers_scripts(self):
+        """`tests/` is deliberately excluded — mypy runs on shipped code only."""
+        self.assertIn("scripts", self.recipe("typecheck"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #119.

`make lint` ran `ruff check src/api tests` and `make typecheck` ran mypy on `src/api` — so `services/chat/scripts/` sat outside both.

That directory holds `check_dependency_policy.py`, the guard for the service's entire dependency policy. It was held to a lower standard than the code it guards, and an unused `import sys` had been sitting on `main` as a result.

Both targets now cover it. `tests/` stays out of typecheck deliberately — mypy runs on shipped code.

## The guard derives its scope from disk

```python
def python_dirs(self) -> set[str]:
    chat = REPO_ROOT / "services/chat"
    return {path.relative_to(chat).parts[0]
            for path in chat.rglob("*.py")
            if not self.SKIP & set(path.parts)}
```

Naming `scripts` in the test would leave the next directory uncovered in exactly the same way. This asserts the lint recipe mentions *every* directory containing Python — so adding one and forgetting to lint it fails here.

Paired with `test_every_python_directory_is_discovered`, because an empty derived set would satisfy the loop vacuously. That's the failure mode this repo has hit before.

## Verification

Both new tests fail against the pre-change Makefile:

```
FAIL: test_lint_covers_every_python_directory (directory='scripts')
FAIL: test_typecheck_covers_scripts
```

117 guardrail tests pass under a bare venv (`pip`/`setuptools` only), matching what the `script-tests` job builds. `make quick-ci-chat` clean: ruff over the widened scope, mypy over 15 files, 60 unit tests, dependency policy at 26 pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)