### PR TITLE
docs(ci): correct docs-check's stale claim about surface routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,9 @@ release-dry-run: | $(VENV_PYTHON) ## Validate release prerequisites without publ
 docs-check: | $(VENV_PYTHON) ## Validate docs links and agent doc pointers
 	$(PYTHON) scripts/verify_docs.py
 	$(MAKE) agent-docs-check
-	# AGENTS.md is a docs path, so a change to it never reaches test-scripts.
-	# This guard reads AGENTS.md, so it has to run here too.
+	# Deliberately redundant: test-scripts runs for every change and covers this
+	# too. Repeated here so docs-check is worth running on its own, which is how
+	# it is reached from `make ci` and from the docs job.
 	$(PYTHON) -m unittest discover -s tests/scripts -p "test_agent_definitions.py"
 
 agent-docs-check: | $(VENV_PYTHON) ## Verify CLAUDE.md/GEMINI.md/copilot-instructions.md stay pointers to AGENTS.md (set FIX=1 to restore)

--- a/tests/scripts/test_venv_wiring.py
+++ b/tests/scripts/test_venv_wiring.py
@@ -1,11 +1,21 @@
 """Guard the rule that every Python command runs from the project virtualenv."""
 
+import importlib.util
 import re
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github/workflows"
+
+
+def load_detector():
+    spec = importlib.util.spec_from_file_location(
+        "detect_changed_surfaces", REPO_ROOT / "scripts/detect_changed_surfaces.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def read(relative: str) -> str:
@@ -78,9 +88,12 @@ class VenvWiringTests(unittest.TestCase):
 
 class DocsCheckWiringTests(unittest.TestCase):
     def test_docs_check_runs_the_agent_definition_guard(self):
-        """AGENTS.md classifies as docs, so docs-check is the only path that
-        runs for an AGENTS.md-only change. The guard reads AGENTS.md, so it has
-        to be invoked here or that drift goes unchecked."""
+        """docs-check must be worth running on its own.
+
+        It is reached directly from `make ci` and the docs job, so the guard
+        that reads AGENTS.md is invoked here as well as by test-scripts.
+        Deliberately redundant — see the companion test below.
+        """
         makefile = read("Makefile")
         recipe = makefile.split("docs-check:", 1)[1].split("\n\n", 1)[0]
         self.assertIn(
@@ -89,6 +102,20 @@ class DocsCheckWiringTests(unittest.TestCase):
             "docs-check must run the agent-definition guard; without it, "
             "renumbering the workflow in AGENTS.md would not be caught",
         )
+
+    def test_the_redundancy_is_redundant(self):
+        """Pins why the duplicate exists, so the reason cannot go stale again.
+
+        The recipe used to claim a docs-only change "never reaches
+        test-scripts". That stopped being true when the script-tests gate moved
+        off `runtime` to `none`, and nothing failed — a Makefile comment is a
+        mirror of the detector with no test holding the two together. This is
+        that test.
+        """
+        detector = load_detector()
+        flags = detector.classify(["AGENTS.md"])
+        self.assertIn("test-scripts", detector.recommended_targets(flags))
+        self.assertFalse(flags["none"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #123.

The `docs-check` recipe claimed:

> AGENTS.md is a docs path, so a change to it never reaches test-scripts.

That stopped being true in #124, when the `script-tests` gate moved off `runtime` to `none`. `test-scripts` now runs for **every** change, docs-only included:

```
docs/RELEASE.md -> ['test-scripts', 'docs-check']
AGENTS.md       -> ['test-scripts', 'docs-check']
```

`tests/scripts/test_venv_wiring.py` repeated the same premise in its docstring. Nothing failed when both went stale, because a Makefile comment is a mirror of the detector with no test holding the two together — the same class of drift that produced #89 and #105.

## Kept the duplicate, fixed the reason

The issue offered dropping the special case or rewording it. Rewording: `docs-check` is reached directly from `make ci` and the docs job, so it should be worth running on its own, and the cost is re-running seven fast tests. **What was wrong was the justification, not the behaviour.**

## The companion test is the point

```python
def test_the_redundancy_is_redundant(self):
    detector = load_detector()
    flags = detector.classify(["AGENTS.md"])
    self.assertIn("test-scripts", detector.recommended_targets(flags))
    self.assertFalse(flags["none"])
```

A comment asserting a routing fact should fail when the routing changes. Verified: removing the `test-scripts` clause from `recommended_targets` fails this test (along with four others), rather than silently turning the comment back into fiction.

Also swept for other stale routing claims — `grep -rn "classifies as\|only path\|never reaches"` across the Makefiles, `tests/scripts`, and `scripts`. These two were the only ones; the third hit is a live assertion message, not a claim.

115 guardrail tests pass in a bare venv; `make docs-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)