### PR TITLE
fix(web): render an empty state instead of a placeholder that does not exist

### DIFF
--- a/apps/web/src/app/products/category/[slug]/page.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.tsx
@@ -45,13 +45,27 @@ export default async function CategoryPage({
               className="group"
             >
               <div className="aspect-square w-full overflow-hidden rounded-3xl bg-gray-200">
-                <Image
-                  src={product.image || "/images/placeholder.png"}
-                  alt={product.name}
-                  width={350}
-                  height={350}
-                  className="h-full w-full object-cover object-center group-hover:opacity-75 transition-opacity"
-                />
+                {product.image ? (
+                  <Image
+                    src={product.image}
+                    alt={product.name}
+                    width={350}
+                    height={350}
+                    sizes="(min-width: 1024px) 350px, (min-width: 640px) 45vw, 90vw"
+                    className="h-full w-full object-cover object-center group-hover:opacity-75 transition-opacity"
+                  />
+                ) : (
+                  // An empty state rather than a placeholder image: it costs no
+                  // request, and it makes the missing data visible instead of
+                  // papering over it.
+                  <div
+                    role="img"
+                    aria-label={`No image available for ${product.name}`}
+                    className="flex h-full w-full items-center justify-center text-sm text-gray-500"
+                  >
+                    No image available
+                  </div>
+                )}
               </div>
               <div className="mt-4 text-center">
                 <h3 className="text-2xl font-semibold text-gray-900">

--- a/tests/scripts/test_image_references.py
+++ b/tests/scripts/test_image_references.py
@@ -1,0 +1,72 @@
+"""Every image path referenced by the web app must exist on disk.
+
+`next/image` does not fail the build for a missing file under `public/` — it
+404s at request time. Unit tests assert DOM text and the e2e smoke asserts page
+status, so neither notices that a page it just rendered points at an asset that
+is not there. That is how a fallback to `/images/placeholder.png` survived when
+no such file had ever existed.
+
+This also runs in the other direction: deleting an image that data still points
+at fails here rather than in a browser.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_DIR = REPO_ROOT / "apps/web/public"
+
+# Paths are written as site-absolute URLs, so they resolve against public/.
+IMAGE_REF = re.compile(r"/images/[A-Za-z0-9_./-]+\.(?:jpg|jpeg|png|webp|svg|gif)", re.I)
+
+SEARCH_ROOTS = ("apps/web/src", "apps/web/public", "apps/web/prisma")
+SKIP_DIRS = {"node_modules", ".next", "__pycache__"}
+BINARY_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".ico", ".woff", ".woff2"}
+
+
+def referenced_images() -> dict[str, list[str]]:
+    """Map each referenced /images/... path to the files that reference it."""
+    found: dict[str, list[str]] = {}
+    for root in SEARCH_ROOTS:
+        for path in (REPO_ROOT / root).rglob("*"):
+            if not path.is_file() or SKIP_DIRS & set(path.parts):
+                continue
+            if path.suffix.lower() in BINARY_SUFFIXES:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for match in IMAGE_REF.finditer(text):
+                found.setdefault(match.group(0), []).append(
+                    str(path.relative_to(REPO_ROOT))
+                )
+    return found
+
+
+class ImageReferenceTests(unittest.TestCase):
+    def test_references_are_found(self):
+        """Without this the check below passes vacuously on a broken regex.
+
+        The catalogue carries hundreds of image paths; finding none would mean
+        the scan is not reaching the data files rather than that all is well.
+        """
+        self.assertGreater(len(referenced_images()), 100)
+
+    def test_every_referenced_image_exists(self):
+        missing = {
+            ref: sources
+            for ref, sources in referenced_images().items()
+            if not (PUBLIC_DIR / ref.lstrip("/")).is_file()
+        }
+        self.assertEqual(
+            missing,
+            {},
+            "referenced image files do not exist under apps/web/public; "
+            "next/image 404s at request time rather than failing the build",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #133.

The category card fell back to `/images/placeholder.png` when a product had no image:

```tsx
src={product.image || "/images/placeholder.png"}
```

No such file has ever existed anywhere in the repo. It was **the only dangling reference among 855 image paths**, so that branch rendered a 404.

Latent rather than live — all 210 products currently carry an image, so the first one added without one would have found it.

## An empty state, not a placeholder file

A placeholder image costs a request and tells the reader nothing, while a product with no image is a data problem worth being visible. The empty state carries `role="img"` and an accessible name so it isn't a silent gap for screen readers.

## Why nothing caught it

- Unit tests assert DOM text, not that image URLs resolve.
- `scripts/e2e_smoke.py` asserts page status, not the assets those pages reference.
- `next/image` does not fail the build for a missing file under `public/` — it 404s at request time.

Same shape as #121: a check that passes on a broken result because it never looks at the thing that broke.

## The guard

`tests/scripts/test_image_references.py` — every `/images/...` literal in web source, data, and prisma must resolve to a file on disk. Verified against `main`:

```
AssertionError: {'/images/placeholder.png': ['apps/web/src/app/products/category/[slug]/page.tsx']} != {}
```

It names the referencing file, so a failure is actionable rather than a puzzle.

Paired with `test_references_are_found`, asserting the scan sees >100 references. Finding zero would satisfy the emptiness check while meaning the scan is broken — the vacuous-pass mode this repo keeps hitting.

**It also runs in the other direction.** Deleting an image the catalogue still points at now fails here rather than in a browser — worth having in place *before* any of the #66 image cleanup, which will move a lot of files.

The guard proved itself immediately: it failed on a first draft of this commit, because the explanatory comment still quoted the dead path.

121 guardrail tests in a bare venv, 108 web tests, `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)