### PR TITLE
feat(web): add Playwright and cover the journeys nothing tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,9 @@ jobs:
       - name: Run end-to-end journeys
         if: always() && steps.run_smoke.outcome == 'success'
         env:
-          E2E_BASE_URL: http://127.0.0.1:3000
+          # Must match NEXTAUTH_URL in docker-compose.yml, or the session
+          # cookie is set for a different origin than the journeys browse.
+          E2E_BASE_URL: http://localhost:3000
         run: make test-e2e
 
       - name: Upload journey failure artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,46 @@ jobs:
           end_epoch="$(date +%s)"
           echo "duration_seconds=$((end_epoch-start_epoch))" >> "$GITHUB_OUTPUT"
 
+      # The smoke leaves the stack up (KEEP_STACK), so the journeys run against
+      # it rather than standing up a second one. This job otherwise sets up
+      # Python only, hence the Node steps here.
+      - name: Set up Node.js
+        if: always() && steps.run_smoke.outcome == 'success'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Cache Playwright browsers
+        if: always() && steps.run_smoke.outcome == 'success'
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('apps/web/package-lock.json') }}
+
+      - name: Install web dependencies and browser
+        if: always() && steps.run_smoke.outcome == 'success'
+        working-directory: apps/web
+        run: |
+          npm ci --workspaces=false --include=dev --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      - name: Run end-to-end journeys
+        if: always() && steps.run_smoke.outcome == 'success'
+        env:
+          E2E_BASE_URL: http://127.0.0.1:3000
+        run: make test-e2e
+
+      - name: Upload journey failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-journey-artifacts
+          path: apps/web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Capture dependency health snapshot
         id: dependencies_health_lite
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ next-env.d.ts
 
 # Testing / Coverage
 coverage/
+
+# Playwright run output; traces and screenshots are CI artifacts, not source.
+test-results/
+playwright-report/
+.playwright/
 .nyc_output/
 .pytest_cache/
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CHAT_ENV_TEMPLATE := $(CHAT_DIR)/.env.example
 
 .DEFAULT_GOAL := help
 
-.PHONY: help venv toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate lint typecheck test test-scripts test-web test-chat build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
+.PHONY: help venv toolchain-doctor env-contract-check agent-doctor env-init bootstrap setup setup-chat setup-chat-full local-provider-check diagnose-chat-local docker-init-fresh sync-web-env dev dev-web dev-chat up down migrate prisma-generate lint typecheck test test-scripts test-web test-chat test-e2e build quick-ci quick-ci-changed quick-ci-web quick-ci-chat e2e-smoke e2e-smoke-lite e2e-smoke-full release-dry-run docs-check agent-docs-check ci
 
 help: ## Show available tasks
 	@awk 'BEGIN {FS = ":.*##"; printf "\nAvailable tasks:\n\n"} /^[a-zA-Z0-9_-]+:.*##/ {printf "  %-24s %s\n", $$1, $$2} END {print ""}' $(MAKEFILE_LIST)
@@ -159,6 +159,9 @@ test-web: ## Run web tests
 
 test-chat: ## Run chat unit tests
 	$(CHAT_MAKE) test
+
+test-e2e: ## Run Playwright journeys against a running stack (see E2E_BASE_URL)
+	$(WEB_MAKE) test-e2e
 
 build: ## Build web app
 	$(WEB_MAKE) build

--- a/apps/web/Makefile
+++ b/apps/web/Makefile
@@ -33,6 +33,12 @@ test: ## Run web tests
 	$(MAKE) sync-env
 	$(NPM) run test
 
+test-e2e: ## Run Playwright journeys against a running stack (see E2E_BASE_URL)
+	$(NPM) run test:e2e
+
+install-e2e-browsers: ## Install the browser Playwright drives
+	$(NPM) exec -- playwright install --with-deps chromium
+
 build: ## Build web app
 	$(MAKE) sync-env
 	$(MAKE) prisma-generate

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * The journey nothing covered.
+ *
+ * The seed wrote a plaintext password while auth verifies with bcrypt, so no
+ * seeded account could sign in — for years, on every PR, with CI green. The
+ * seed ran in the web container on every smoke run and nothing asserted on
+ * what it produced.
+ *
+ * These credentials come from `prisma/seed.ts`, so this fails if the seed
+ * stops producing usable accounts, whatever the reason.
+ */
+const SEEDED_EMAIL = 'johnsmith@example.com'
+const SEEDED_PASSWORD = 'password'
+
+test.describe('authentication', () => {
+  test('a seeded account can sign in and reach its profile', async ({ page }) => {
+    await page.goto('/login')
+
+    await page.getByLabel('Email address').fill(SEEDED_EMAIL)
+    await page.getByLabel('Password').fill(SEEDED_PASSWORD)
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    // Success redirects home; a failure renders an inline error and stays put.
+    await expect(page).toHaveURL(/\/$/, { timeout: 15_000 })
+
+    // Assert the session is real, not merely that no error appeared. The
+    // header only renders the profile link for an authenticated session.
+    const profileLink = page.getByTitle('Profile Settings')
+    await expect(profileLink).toBeVisible()
+
+    await profileLink.click()
+    await expect(page).toHaveURL(/\/profile/)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+  })
+
+  test('a wrong password is rejected', async ({ page }) => {
+    // The other half. Without this, an auth path that accepted anything would
+    // satisfy the test above.
+    await page.goto('/login')
+
+    await page.getByLabel('Email address').fill(SEEDED_EMAIL)
+    await page.getByLabel('Password').fill('not-the-password')
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByTitle('Profile Settings')).toHaveCount(0)
+  })
+
+  test('the profile route is not reachable while signed out', async ({ page }) => {
+    await page.goto('/profile')
+    await expect(page.getByText(/access denied/i)).toBeVisible()
+  })
+})

--- a/apps/web/e2e/browse.spec.ts
+++ b/apps/web/e2e/browse.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * The anonymous shopping journey, end to end against the real stack.
+ *
+ * `scripts/e2e_smoke.py` checks that these routes return 200. That is not the
+ * same as them working: a category page rendered every product with a broken
+ * image for years while returning 200, and a Next 16 upgrade once shipped
+ * product pages that 404'd on every slug while the suite stayed green.
+ */
+test.describe('browsing', () => {
+  test('home lists categories and each links to a category page', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+
+    const categoryHeadings = page.getByRole('heading', { level: 2 })
+    expect(await categoryHeadings.count()).toBeGreaterThan(0)
+
+    // Follow a real product link rather than asserting one exists. A link to a
+    // slug the database does not have still renders.
+    const firstProduct = page.locator('a[href^="/products/"]').first()
+    await expect(firstProduct).toBeVisible()
+    await firstProduct.click()
+
+    await expect(page).toHaveURL(/\/products\//)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+  })
+
+  test('a category page renders its products', async ({ page }) => {
+    await page.goto('/')
+    const categoryLink = page.locator('a[href^="/products/category/"]').first()
+
+    if ((await categoryLink.count()) === 0) {
+      // Reached directly when the home page links only to products.
+      await page.goto('/products/category/tents')
+    } else {
+      await categoryLink.click()
+    }
+
+    await expect(page).toHaveURL(/\/products\/category\//)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+    expect(await page.getByRole('heading', { level: 2 }).count()).toBeGreaterThan(0)
+  })
+
+  test('every image the journey renders actually loads', async ({ page }) => {
+    // The gap that let /images/placeholder.png survive: pages returned 200
+    // while the assets they referenced 404'd. Status codes are collected from
+    // the network rather than inferred from the DOM.
+    const failed: string[] = []
+    page.on('response', (response) => {
+      const url = response.url()
+      if (/\.(png|jpe?g|webp|gif|svg)(\?|$)/i.test(url) && response.status() >= 400) {
+        failed.push(`${response.status()} ${url}`)
+      }
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const images = page.locator('img')
+    expect(await images.count()).toBeGreaterThan(0)
+    expect(failed, 'image requests returned an error status').toEqual([])
+  })
+})

--- a/apps/web/e2e/browse.spec.ts
+++ b/apps/web/e2e/browse.spec.ts
@@ -56,9 +56,33 @@ test.describe('browsing', () => {
     })
 
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
 
     const images = page.locator('img')
+    await expect(images.first()).toBeVisible()
+
+    // next/image lazy-loads below the fold, so scroll the page to make the rest
+    // actually request. Without this the check only ever sees the hero.
+    await page.evaluate(async () => {
+      for (let y = 0; y < document.body.scrollHeight; y += window.innerHeight) {
+        window.scrollTo(0, y)
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    })
+
+    // Deliberately not asserting every img is `complete`: a lazy image that
+    // never entered the viewport never loads, which is correct behaviour, so
+    // that assertion can never pass on a long page. What matters is that
+    // nothing the page *did* request came back an error.
+    await expect
+      .poll(
+        async () =>
+          images.evaluateAll((nodes) =>
+            nodes.filter((node) => (node as HTMLImageElement).complete).length,
+          ),
+        { timeout: 20_000, message: 'no images finished loading' },
+      )
+      .toBeGreaterThan(0)
+
     expect(await images.count()).toBeGreaterThan(0)
     expect(failed, 'image requests returned an error status').toEqual([])
   })

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -25,6 +25,7 @@
         "sharp": "^0.35.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
@@ -1738,6 +1739,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@prisma/adapter-pg": {
@@ -9733,6 +9750,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "prepare": "cd ../.. && husky || true"
+    "prepare": "cd ../.. && husky || true",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -28,6 +29,7 @@
     "sharp": "^0.35.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * End-to-end journeys against a running stack.
+ *
+ * There is deliberately no `webServer` here. These journeys cross web, chat and
+ * the database, so the stack has to be the real composed one — `make e2e-up`
+ * locally, or the stack the Integration E2E Smoke job already leaves running.
+ * Starting `next dev` from Playwright would test a web app talking to nothing.
+ *
+ * Retries are off. A retried failure is a failure that gets ignored, and a
+ * suite nobody trusts is the state this repo has been recovering from. If a
+ * journey is flaky, that is a finding rather than something to paper over.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  // One worker: every journey shares a single stack and a single database, so
+  // parallel runs would race each other's data rather than find real bugs.
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+})

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3000',
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // Playwright specs match vitest's default glob. Left in, vitest picks them
+    // up and fails on `@playwright/test` imports it cannot run.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'e2e/**'],
   },
   resolve: {
     alias: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
         condition: service_healthy
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/contoso-db
-      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+      # Defaulted so the stack authenticates out of the box. Without it CI and
+      # a bare `docker compose up` have no secret, and every sign-in fails at
+      # /api/auth/error rather than rejecting a credential.
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-local-development-only-not-a-real-secret}
       - NEXTAUTH_URL=http://localhost:3000
       - CHAT_ENDPOINT=http://chat:8000/api/create_response
       - CHAT_API_KEY=${CHAT_API_KEY:-dummy}

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -68,6 +68,39 @@ Enable local LLM/vector stack in chat image when needed:
 make e2e-smoke CHAT_INSTALL_LOCAL_STACK=1
 ```
 
+## End-to-end journeys
+
+`scripts/e2e_smoke.py` checks that routes respond. The Playwright journeys in
+`apps/web/e2e/` check that they *work* — a page can return 200 while every
+image on it 404s, or while no seeded account can sign in.
+
+They run against a stack that is already up, so bring one up first:
+
+```bash
+make e2e-smoke KEEP_STACK=1     # leaves db + chat + web running
+make test-e2e                    # then drive the journeys against it
+```
+
+Point them elsewhere with `E2E_BASE_URL`:
+
+```bash
+make test-e2e E2E_BASE_URL=http://127.0.0.1:3300
+```
+
+First run needs the browser:
+
+```bash
+make -C apps/web install-e2e-browsers
+```
+
+In CI they run inside `Integration E2E Smoke`, after the smoke, against the
+stack `KEEP_STACK` leaves behind. Traces and screenshots for a failed journey
+are uploaded as the `e2e-journey-artifacts` artifact.
+
+Retries are deliberately off. A retried failure is a failure that gets
+ignored; if a journey is flaky, that is a finding to chase rather than
+something to absorb.
+
 ## Profile Selection
 
 - `e2e-smoke-lite`: default for PRs and fast contract validation.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "release:dry-run": "make release-dry-run",
     "ci": "make ci",
     "ci:web": "make -C apps/web ci",
-    "ci:chat": "make -C services/chat ci"
+    "ci:chat": "make -C services/chat ci",
+    "test:e2e": "make test-e2e"
   }
 }

--- a/tests/scripts/test_e2e_journey_wiring.py
+++ b/tests/scripts/test_e2e_journey_wiring.py
@@ -1,0 +1,91 @@
+"""The end-to-end journeys must actually run somewhere.
+
+A suite wired into make targets and a package script but invoked by no
+workflow looks maintained and produces no signal — that is what
+`services/chat/tests/integration` was, and why it was removed rather than
+kept. These checks exist so the Playwright journeys cannot drift into the
+same state.
+
+They assert wiring, not behaviour. Whether a journey passes is the journeys'
+own job; whether anything runs them is this file's.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEB_DIR = REPO_ROOT / "apps/web"
+
+
+def read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def integration_job() -> str:
+    """The `integration-e2e` job block from ci.yml."""
+    content = read(".github/workflows/ci.yml")
+    match = re.search(
+        r"^  integration-e2e:$(.*?)(?:^  \S|\Z)", content, re.MULTILINE | re.DOTALL
+    )
+    if match is None:
+        raise AssertionError("integration-e2e job not found in ci.yml")
+    return match.group(1)
+
+
+class JourneyWiringTests(unittest.TestCase):
+    def test_journey_specs_exist(self):
+        """Guards the checks below from passing against an empty directory."""
+        specs = sorted((WEB_DIR / "e2e").glob("*.spec.ts"))
+        self.assertGreaterEqual(len(specs), 2, "expected journey specs under apps/web/e2e")
+        for spec in specs:
+            with self.subTest(spec=spec.name):
+                self.assertIn("test(", spec.read_text(encoding="utf-8"))
+
+    def test_ci_runs_the_journeys(self):
+        """The whole point. Without this step the suite is an orphan."""
+        job = integration_job()
+        self.assertIn("make test-e2e", job)
+        self.assertIn("playwright install", job)
+
+    def test_journeys_run_against_the_stack_the_smoke_leaves_up(self):
+        """They must target the composed stack, not a server they start.
+
+        A journey pointed at `next dev` would exercise a web app talking to no
+        chat service and no seeded database, which is most of what these
+        journeys are for.
+        """
+        job = integration_job()
+        self.assertIn("E2E_BASE_URL", job)
+        self.assertIn("KEEP_STACK", job)
+        # Match the key, not the word: the config explains in prose why it has
+        # no webServer, and a substring check fails on its own comment.
+        self.assertNotRegex(
+            read("apps/web/playwright.config.ts"),
+            re.compile(r"^\s*webServer\s*:", re.MULTILINE),
+        )
+
+    def test_make_target_exists(self):
+        self.assertRegex(read("Makefile"), re.compile(r"^test-e2e:", re.MULTILINE))
+        self.assertRegex(read("apps/web/Makefile"), re.compile(r"^test-e2e:", re.MULTILINE))
+
+    def test_vitest_does_not_also_collect_the_journeys(self):
+        """Playwright specs match vitest's default glob.
+
+        Collected by vitest they fail on `@playwright/test` imports it cannot
+        run, which reads as a broken unit suite rather than a config problem.
+        """
+        self.assertIn("e2e/**", read("apps/web/vitest.config.ts"))
+
+    def test_retries_are_not_enabled(self):
+        """A retried failure is a failure that gets ignored.
+
+        If a journey is flaky that is a finding. Turning on retries here would
+        hide exactly the intermittent breakage these journeys exist to surface.
+        """
+        config = read("apps/web/playwright.config.ts")
+        self.assertRegex(config, re.compile(r"retries:\s*0"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Playwright, wired into CI, with six journeys against the real composed stack.

## Why

`scripts/e2e_smoke.py` checks that routes **respond**. That is not the same as them **working**, and this repo has the receipts:

- a category page returned 200 for years while referencing `/images/placeholder.png`, which has never existed (#133)
- a Next 16 upgrade shipped product pages that 404'd on every slug while the suite stayed green (#60/#61)
- no seeded account could sign in, because the seed wrote a plaintext password past a bcrypt check (#139)

All three ran in CI and reported success.

## The journeys

| spec | covers |
| --- | --- |
| `browse.spec.ts` | home → category → product; category renders products; **every image request returns non-error** |
| `auth.spec.ts` | seeded account signs in and reaches its profile; wrong password rejected; profile denied while signed out |

## Verified to have teeth

Not assumed. Setting a seeded password back to plaintext in the database — the exact shape of #139 — fails the sign-in journey:

```
✘ authentication › a seeded account can sign in and reach its profile
  Error: expect(page).toHaveURL(expected) failed
         - unexpected value "http://127.0.0.1:3300/login"
```

with a screenshot captured. **It would have caught #139 on the first PR.** Restoring a real bcrypt hash returns all 6 to green in ~9s.

## Wiring, deliberately

A suite nothing runs is what `services/chat/tests/integration` was, and why it was deleted rather than kept. So:

- The journeys run **inside `Integration E2E Smoke`**, against the stack `KEEP_STACK` already leaves up. No second stack, no new job. That job sets up Python only, hence the Node steps.
- Browsers cached on the lockfile hash; traces and screenshots upload as `e2e-journey-artifacts` on failure.
- Guardrails in `tests/scripts` assert the wiring itself: that CI invokes them, that they target the composed stack, that vitest doesn't also collect them, that retries stay off. Removing the CI step fails `test_ci_runs_the_journeys`.

## Two deliberate choices

**No `webServer`.** These journeys cross web, chat and the database. Starting `next dev` from Playwright would test a web app talking to nothing.

**Retries off.** A retried failure is a failure that gets ignored, and a suite nobody trusts is the state this repo has been recovering from. If a journey is flaky, that is a finding.

## Traps hit while building this

Recorded because they'll bite the next person:

- `npm install` from `apps/web` resolves the **root** `package.json` as the workspace root and writes the untracked root lockfile — Playwright never reached `apps/web/package-lock.json`, which is what `npm ci --workspaces=false` reads. Same trap that broke 15 test files earlier in this session.
- Playwright specs match vitest's default glob; without an `exclude`, vitest collects them and fails on `@playwright/test` imports it cannot run. Verified by removing the exclude.
- Compose **merges** port lists rather than replacing them, so a scratch override needs `!override` or it still binds the original port.

111 web tests, 131 guardrail tests in a bare venv, `tsc`/`eslint`/`docs-check` clean, 6 journeys green against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)