### PR TITLE
fix(web): give the signed-out profile a heading and a way forward

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -50,6 +50,39 @@ test.describe('authentication', () => {
 
   test('the profile route is not reachable while signed out', async ({ page }) => {
     await page.goto('/profile')
-    await expect(page.getByText(/access denied/i)).toBeVisible()
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+    await expect(page.getByTitle('Profile Settings')).toHaveCount(0)
+  })
+
+  test('the signed-out profile offers a route back to signing in', async ({ page }) => {
+    // It rendered a bare "Access Denied" paragraph on an otherwise empty page:
+    // nothing for heading navigation to land on, and no way forward, so the
+    // page was a dead end. The source guard in tests/scripts cannot see this —
+    // it greps the file for `<h1`, which the authenticated branch satisfies.
+    await page.goto('/profile')
+
+    const heading = page.getByRole('heading', { level: 1 })
+    await expect(heading).toBeVisible()
+
+    // The link has to work, not merely exist.
+    await page.getByRole('link', { name: 'Sign in to continue' }).click()
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByLabel('Email address')).toBeVisible()
+  })
+
+  test('signing in from the profile dead end lands on the profile', async ({ page }) => {
+    // The whole point of the route forward: it should complete the journey the
+    // visitor was already trying to make.
+    await page.goto('/profile')
+    await page.getByRole('link', { name: 'Sign in to continue' }).click()
+
+    await page.getByLabel('Email address').fill(SEEDED_EMAIL)
+    await page.getByLabel('Password').fill(SEEDED_PASSWORD)
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    await expect(page.getByTitle('Profile Settings')).toBeVisible({ timeout: 15_000 })
+    await page.getByTitle('Profile Settings').click()
+    await expect(page).toHaveURL(/\/profile/)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
   })
 })

--- a/apps/web/e2e/headings.spec.ts
+++ b/apps/web/e2e/headings.spec.ts
@@ -18,12 +18,16 @@ async function outline(page: Page) {
   )
 }
 
-const ROUTES = ['/', '/login', '/signup', '/about', '/faq', '/contact']
+const ROUTES = ['/', '/login', '/signup', '/about', '/faq', '/contact', '/profile']
 
 test.describe('heading outlines', () => {
   for (const route of ROUTES) {
     test(`${route} has one h1 and skips no level`, async ({ page }) => {
       await page.goto(route)
+      // Wait for the settled page. Routes gated on session status render a
+      // transient loading state with no heading, which is correct — reading
+      // before it resolves measures the wrong thing.
+      await page.locator('h1').first().waitFor({ state: 'attached', timeout: 15_000 })
       const headings = await outline(page)
 
       expect(headings.length, `${route} rendered no headings at all`).toBeGreaterThan(0)

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -68,7 +68,7 @@ async function overflowAt(page: Page, width: number): Promise<Offender[]> {
   }, width)
 }
 
-const ROUTES = ['/', '/login', '/signup', '/about']
+const ROUTES = ['/', '/login', '/signup', '/about', '/profile']
 
 test.describe('no horizontal overflow', () => {
   for (const route of ROUTES) {

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -26,10 +26,15 @@ describe('Profile Page', () => {
     expect(screen.getByText(/loading/i)).toBeDefined()
   })
 
-  it('shows access denied if unauthenticated', async () => {
+  it('offers a heading and a route forward if unauthenticated', async () => {
+    // Was a bare "Access Denied" paragraph: no heading for heading navigation
+    // to land on, and no way to reach the sign-in the visitor needs.
     vi.mocked(useSession).mockReturnValue({ status: 'unauthenticated' } as any)
     render(<ProfilePage />)
-    expect(screen.getByText(/access denied/i)).toBeDefined()
+
+    expect(screen.getByRole('heading', { level: 1 })).toBeDefined()
+    const link = screen.getByRole('link', { name: 'Sign in to continue' })
+    expect(link.getAttribute('href')).toBe('/login')
   })
 
   it('renders tabs if authenticated', async () => {

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import Header from "@/components/header";
 import AvatarUpload from "@/components/avatar-upload";
 import PasswordChangeForm from "@/components/password-change-form";
@@ -29,11 +30,41 @@ export default function ProfilePage() {
   }, [status]);
 
   if (status === "loading" || (status === "authenticated" && isLoadingProfile)) {
-    return <div className="flex justify-center items-center h-screen"><p>Loading...</p></div>;
+    // role=status so the wait is announced rather than being a silent blank
+    // screen for anyone not watching the pixels.
+    return (
+      <div
+        role="status"
+        className="flex justify-center items-center h-screen"
+      >
+        <p>Loading your profile...</p>
+      </div>
+    );
   }
 
   if (status === "unauthenticated") {
-    return <div className="flex justify-center items-center h-screen"><p>Access Denied</p></div>;
+    // Was a bare "Access Denied" paragraph on an otherwise empty page: no
+    // heading for heading navigation to land on, and no route forward, so a
+    // signed-out visitor had to work out where to go on their own.
+    return (
+      <>
+        <Header />
+        <main className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+          <h1 className="text-4xl font-semibold text-zinc-800">
+            Sign in to view your profile
+          </h1>
+          <p className="max-w-prose text-lg text-zinc-600">
+            Your profile is only visible while you are signed in.
+          </p>
+          <Link
+            href="/login"
+            className="rounded-md bg-zinc-800 px-6 py-2 text-lg text-zinc-100 hover:bg-zinc-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+          >
+            Sign in to continue
+          </Link>
+        </main>
+      </>
+    );
   }
 
   const handleAvatarUpload = async (url: string) => {

--- a/tests/scripts/test_page_headings.py
+++ b/tests/scripts/test_page_headings.py
@@ -52,8 +52,14 @@ class PageHeadingTests(unittest.TestCase):
             missing, [], "routes render no heading element at all"
         )
 
-    def test_every_route_has_exactly_one_h1(self):
-        """More than one h1 is as unhelpful as none — it flattens the outline."""
+    def test_every_route_declares_an_h1(self):
+        """Source can only tell you an h1 exists somewhere in the file.
+
+        It cannot tell you how many render at once: a page gated on session
+        status declares one h1 per branch, and exactly one of them renders.
+        `apps/web/e2e/headings.spec.ts` asserts the "exactly one" property
+        against the rendered document, which is the only place it is knowable.
+        """
         wrong = {}
         for page in route_pages():
             name = route_name(page)
@@ -62,10 +68,9 @@ class PageHeadingTests(unittest.TestCase):
                 source = (REPO_ROOT / "apps/web" / HEADING_FROM_COMPONENT[name]).read_text(
                     encoding="utf-8"
                 )
-            count = len(H1.findall(source))
-            if count != 1:
-                wrong[name] = count
-        self.assertEqual(wrong, {}, "each route needs exactly one h1")
+            if not H1.search(source):
+                wrong[name] = 0
+        self.assertEqual(wrong, {}, "each route must declare an h1")
 
     def test_component_supplied_headings_still_exist(self):
         """Stops the allowlist above from silently excusing a real gap.


### PR DESCRIPTION
Closes #140.

`/profile` rendered a bare `<p>Access Denied</p>` centred on an otherwise empty page — no heading for heading navigation to land on, and no route to the sign-in the visitor needs. A dead end, reached by following a link the header shows *while signed out*.

Now: the site header, an `h1` saying what to do rather than what went wrong, and a link to `/login`. The loading state gains `role="status"` so the wait is announced instead of being a silent blank screen.

## Journeys, because source scanning cannot see this

Three assert the **rendered** signed-out page:

- it has a heading
- its link actually reaches the login form — not merely that a link exists
- signing in from there completes the journey the visitor was making

All three fail against the previous page, along with the `/profile` heading sweep:

```
✘ the profile route is not reachable while signed out
✘ the signed-out profile offers a route back to signing in
✘ signing in from the profile dead end lands on the profile
✘ /profile has one h1 and skips no level
```

## Fixing it exposed the other half of #140

`profile/page.tsx` now declares **two** `h1` elements in source — one per render branch — and exactly one renders. The source guard asserted "exactly one `h1` per file", which source simply cannot know.

So it now asserts only that an `h1` is **declared**, and the rendered journey owns the exactly-one property where it is knowable. That is the limitation #140 documented, resolved rather than worked around:

> `tests/scripts/test_page_headings.py` scans page source for `<h1`, so `profile/page.tsx` passes while two of its three render states have no heading at all.

## Two test bugs of my own, found while building this

- The outline was read **before the session resolved**, catching the transient loading state that legitimately has no heading. It now waits for the settled page — which matters for any session-gated route, not just this one.
- `"Sign in"` matched both the header link and the new one (strict-mode violation). The copy is now **"Sign in to continue"**, which is also clearer than a bare "Sign in" next to a header that says the same thing.

131 guardrail tests, 111 web tests, 24 journeys green against a stack with no `.env`, `tsc`/`eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)