### PR TITLE
chore: track the entire CLI hook wiring

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code post-task'"
+          }
+        ]
+      },
+      {
+        "matcher": "TaskCreate|TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code post-todo'"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code pre-task'"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code session-end'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"\\\\n\\\\nEntire CLI is enabled but not installed or not on PATH.\\\\nInstallation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks claude-code session-start'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code stop'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code user-prompt-submit'"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+
+[features]
+hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex post-tool-use'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"Entire CLI is enabled but not installed or not on PATH. Installation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks codex session-start'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex stop'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex user-prompt-submit'",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
+      }
+    ],
+    "stop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+settings.local.json
+metadata/
+logs/
+redactors/local/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "telemetry": true
+}

--- a/.github/hooks/entire.json
+++ b/.github/hooks/entire.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli agent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli error-occurred'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli post-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli pre-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-end'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-start'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "subagentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli subagent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli user-prompt-submitted'",
+        "comment": "Entire CLI"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,12 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 
+# Agent Tooling
+# The hook wiring is shared; the per-developer overrides beside it are not.
+# Nothing in the repo enforced that split — it held only for whoever happened
+# to carry the rule in a global gitignore.
+.claude/settings.local.json
+
 # IDE and Editor Files
 .vscode/
 .idea/


### PR DESCRIPTION
## What

Tracks the seven `entire` CLI config files that wire it into Claude Code, Codex, Cursor and Copilot CLI, and adds one root `.gitignore` line.

These describe how this repository is worked on, so they belong to the repository rather than to whoever installed the tool first.

## Safety of committing executable hooks

These files run shell commands on agent lifecycle events, so committing them means they run for anyone who clones and uses one of those tools. What limits that:

- **Every hook is guarded** — 7/7, 4/4, 7/7 and 8/8 commands carry `command -v entire >/dev/null 2>&1 || exit 0`, and the guard sits *inside* the same shell that would exec the binary, so there is no window where anything runs without the tool. All exit 0, so no hook can block a tool call or fail a session.
- **Nothing here pushes data anywhere.** The git-level hooks live in `.husky/_/`, which is ignored by `*`, so they do not follow a clone.
- **No secrets.** Every blob was grepped for absolute paths, usernames, tokens, IPs and UUIDs — zero hits. The only URL is the public `docs.entire.io` install guide.
- **Codex additionally requires** a per-machine trust review before committed hook entries execute at all.

## The file was stale

`.claude/settings.json` matched on `Task` and `TodoWrite` — tool names that no longer exist, so three of its seven hooks fired for nothing. `entire doctor` says so directly: "The installed hooks use outdated tool matchers and no longer fire."

That matters *because* we are tracking it. Committing it as-is would have handed every contributor the out-of-date warning, and the fix it suggests rewrites a now-tracked file — a dirty tree and a spurious diff each, defeating the point. The committed file is regenerated (`entire agent add claude-code --force`); the only change is three matcher values, and `doctor` now reports `✓ Claude Code hook config: OK`.

## Ignore rules

`.entire/.gitignore` (excluding `tmp/`, `metadata/`, `logs/`, `settings.local.json`, `redactors/local/`) lands in the **same commit** as the settings that produce that data, so there is no window in which a transcript could be committed. Each rule was confirmed in effect with `git check-ignore -v`, and every staged path confirmed not ignored.

The root `.gitignore` gains `.claude/settings.local.json`. It was previously excluded only for whoever happened to carry that rule in a personal global gitignore — with `.claude/settings.json` now tracked, the first contributor without one would commit their own settings.

## Worth knowing

`.entire/settings.json` sets `"enabled": true`, so cloning activates session capture for anyone with `entire` on `PATH` without them opting in. Captured transcripts stay local under the ignored `.entire/metadata/`. `"telemetry": true` matches the tool's own default and opting out writes to the doubly-ignored `.entire/settings.local.json`. Happy to document this in CONTRIBUTING.md as a follow-up if you want contributors to learn it from docs rather than from a hook message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)