### PR TITLE
docs: make unrelated findings into issues, not review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,9 @@ Follow these steps in order for every change.
 
 5. **Inspect the complete diff.** Review the branch diff plus all staged,
    unstaged, and untracked files. Remove accidental or unrelated changes while
-   preserving work that belongs to the user.
+   preserving work that belongs to the user. A real problem found here is filed
+   as an issue before the change is removed — see *Unrelated findings become
+   issues* below.
 
 6. **Run `ui-review` before verification.** After the main agent completes an
    implementation pass, invoke the `ui-review` sub-agent. The `ui-review`
@@ -124,6 +126,43 @@ Follow these steps in order for every change.
     a failing or pending required check. Self-merges are allowed when these
     conditions are met. Use squash merge for short-lived development branches
     to keep `main` linear, then delete the merged branch.
+
+### Unrelated findings become issues
+
+Work turns up problems that are not the problem being worked on. A stale script,
+a pre-existing overflow, a check that does not check what it claims. This can
+happen at any step, and most often happens during steps 6 to 8, because
+`ui-review`, `verifier`, and `code-review` read more of the repository than the
+change touches.
+
+**File an issue at the moment of finding, before deciding what to do about it.**
+The finding is cheapest to write down while the context that produced it is
+still loaded, and an issue costs little if it later turns out to be nothing.
+
+Two failure modes this exists to prevent, and they pull in opposite directions:
+
+- **Silently widening the change.** Fixing it here inflates a reviewed diff with
+  work nobody scoped, and buries an independent decision inside an unrelated
+  pull request.
+- **Silently dropping it.** Mentioning it only in a review comment or a chat
+  reply means it is gone as soon as that context is. Nobody rediscovers it until
+  it breaks something.
+
+Filing an issue is what makes "not now" different from "never".
+
+Write enough that it can be acted on without rediscovering it: what is wrong,
+where, how it was found, and why it was not fixed at the time. Include the
+measurement if there was one. Link the issue from the pull request that surfaced
+it, so the reviewer can see the finding was handled rather than missed.
+
+Fix it in the current change only when leaving it would make that change wrong
+or unverifiable — a pre-existing problem the change makes materially worse, or a
+check that has to work for this change to be trustworthy. That is a judgement
+call, so state the reason in the commit message. When in doubt, file and leave
+it: a separate pull request is cheap, and an unscoped one is not.
+
+Sub-agents report findings; they do not file issues. Every finding they report
+that falls outside the current change needs the main agent to file it.
 
 ### Sub-agents this workflow depends on
 


### PR DESCRIPTION
Adds *Unrelated findings become issues* to the development workflow in AGENTS.md, and a pointer from step 5.

The practice was real but lived only in #148 ("Findings become issues"), which is durable context rather than the runbook. Anyone reading AGENTS.md to learn how this repository is worked would not have found it.

## What it says

File the issue **at the moment of finding**, before deciding what to do about it — the context that produced it is still loaded, and an issue costs little if it turns out to be nothing.

It names two failure modes, which pull in opposite directions:

- **Silently widening the change** — inflating a reviewed diff with unscoped work, and burying an independent decision inside an unrelated PR.
- **Silently dropping it** — a review comment or a chat reply is gone as soon as that context is.

Filing is what makes "not now" different from "never".

## The one judgement it adds

A narrow exception for fixing in place: a pre-existing problem the change makes materially worse, or a check that has to work for the change to be trustworthy. Both occurred in #152 — the category grid's `sizes` was pre-existing but the re-encode removed the headroom hiding it, and the e2e image check had to be fixed for the 852 new images to be verifiable at all.

Review confirmed this is narrower than what the runbook already demands rather than a loophole: steps 6 and 7 require every actionable finding to be fixed or explicitly resolved before proceeding, so an unqualified "always file, never fix" would contradict them head-on. It also traced the default to five prior issues where this repo already did exactly this — #151, #150, #112, #126, #130. The reason now has to go in the commit message.

## Corrections during review

Two claims of mine did not survive, both worth recording because they are the failure mode this repository keeps hitting:

1. The step 5 pointer said the rule "applies from here through step 8", contradicting the section's own scope one screen later — and the repo's history, since #133 and #119 were both found during implementation. It also said a real problem "gets an issue rather than a deletion", which inverts step 5's instruction to remove unrelated changes. Now: filed as an issue *before* the change is removed.

2. I wrote that the sub-agents "cannot" file issues because they are "read-only by design". Neither half holds. All three definitions grant `Bash`, `gh` is available, and none of their prompts forbid `gh issue create`; being read-only toward the repository has no bearing on filing an issue. It is now stated as what it actually is — a division of labour, not a capability: *"Sub-agents report findings; they do not file issues."*

The second is the same shape as #100: unenforced prose asserting sub-agent behaviour. `tests/scripts/test_agent_definitions.py` exists to guard exactly that, and would not have caught it, because it only parses below the `### Sub-agents this workflow depends on` heading.

## Filed while writing this

Dogfooding the rule — both are review observations that fell below the reporting bar but are real:

- **#153** — `code-review`'s rubric tells it to score pre-existing issues at 0 and not report "issues on lines the change did not touch", which is in tension with a workflow that asks for exactly those to be filed. Latent rather than active: the useful findings arrive under other headings today.
- **#154** — the guard in `test_agent_definitions.py` only covers agent names below one heading, so the names in this new section could go stale with the test green.

## Verification

`make docs-check`, `make agent-docs-check`, and `make test-scripts` (141) pass. Markdown only; no pointer file gained content. Rendered UI review is not applicable — no UI surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)