### PR TITLE
perf(web): stop the image srcset offering widths no source can fill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ COPY apps/web/package*.json ./
 COPY apps/web/src ./src
 COPY apps/web/public ./public
 COPY apps/web/next.config.js ./
+# next.config.js derives its image srcset ceiling from this, so the build needs
+# it even though it sits outside apps/web. Builder stage only: the standalone
+# output inlines the resolved value, so the runner never reads the file.
+COPY config/catalogue_images.json /app/config/catalogue_images.json
 COPY apps/web/tsconfig.json ./
 COPY apps/web/tailwind.config.ts ./
 COPY apps/web/postcss.config.js ./

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,8 +1,34 @@
+const catalogueImages = require('../../config/catalogue_images.json')
+
+// next/image asks the optimiser for a width from this ladder, and the optimiser
+// never upscales past the source. Every candidate at or above the source width
+// therefore returns identical bytes: with the default ladder, w=1080 through
+// w=3840 were six byte-identical responses per image, each its own cache entry.
+//
+// So the ladder stops at the first step past the largest source we ship, which
+// is the encoding contract's max dimension -- derived rather than written down
+// twice, so raising the contract raises this with it.
+//
+// The steps below the ceiling are Next's defaults. They fit the smaller boxes
+// exactly -- the 350px grid card takes 750 at 2x, the 400px category card 828 --
+// and the larger ones are short of 2x for want of source, not for want of a
+// ladder step: the 550px detail image asks for 1100 and the about page's 604px
+// band for 1208, and both get the same 1024 they got before this change.
+const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840]
+const sourceWidth = catalogueImages.maxDimension
+const deviceSizes = [
+  ...DEFAULT_DEVICE_SIZES.filter((width) => width < sourceWidth),
+  DEFAULT_DEVICE_SIZES.find((width) => width >= sourceWidth) ?? sourceWidth,
+]
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Emit a traced, self-contained server bundle so the Docker runtime image
   // ships only the dependencies actually reached at runtime.
   output: 'standalone',
+  images: {
+    deviceSizes,
+  },
   typescript: {
     // !! WARN !!
     // Dangerously allow production builds to successfully complete even if

--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import catalogueImages from '../../config/catalogue_images.json'
+
+// The ladder is derived rather than written down, so that raising the encoding
+// contract raises the srcset ceiling with it. That derivation is the only thing
+// standing between a contract change and six byte-identical optimiser responses
+// per image coming back, and until this file existed nothing but a full
+// `next build` could tell you it had broken.
+//
+// Asserted against the config rather than against `[640, 750, 828, 1080]`: a
+// literal would have to be edited in step with the contract, which is the
+// duplication the derivation removes.
+const nextConfig = require('./next.config.js')
+
+const deviceSizes: number[] = nextConfig.images.deviceSizes
+const sourceWidth: number = catalogueImages.maxDimension
+
+describe('image deviceSizes', () => {
+  it('is a valid ladder', () => {
+    expect(deviceSizes.length).toBeGreaterThan(0)
+    expect(deviceSizes.every(Number.isInteger)).toBe(true)
+    expect(deviceSizes).toStrictEqual([...deviceSizes].sort((a, b) => a - b))
+    expect(new Set(deviceSizes).size).toBe(deviceSizes.length)
+  })
+
+  it('reaches the full source width', () => {
+    // Short of this and the largest box is served a downscale it need not have
+    // had -- the failure the ceiling must not cause while removing duplicates.
+    expect(Math.max(...deviceSizes)).toBeGreaterThanOrEqual(sourceWidth)
+  })
+
+  it('offers exactly one candidate at or above the source width', () => {
+    // Every candidate past the source returns identical bytes, because the
+    // optimiser does not upscale. More than one is the waste #150 removed.
+    expect(deviceSizes.filter((width) => width >= sourceWidth)).toHaveLength(1)
+  })
+
+  it('keeps the steps that fit the boxes below the ceiling', () => {
+    // The grid cards need 750 and 828 at 2x. Deriving the ceiling must not cost
+    // the rungs underneath it.
+    for (const width of [640, 750, 828]) {
+      if (width < sourceWidth) {
+        expect(deviceSizes).toContain(width)
+      }
+    }
+  })
+})

--- a/tests/scripts/test_image_encoding.py
+++ b/tests/scripts/test_image_encoding.py
@@ -85,6 +85,38 @@ def webp_dimensions(data: bytes) -> tuple[int, int]:
     raise ValueError(f"unrecognised WebP chunk: {chunk!r}")
 
 
+def raster_dimensions(data: bytes) -> tuple[int, int]:
+    """Canvas size from a PNG, JPEG or WebP header.
+
+    Only as much of each format as the allowlist needs: PNG carries width and
+    height at a fixed offset in the IHDR chunk, and JPEG in whichever SOF marker
+    the encoder used, which has to be walked to.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return (
+            int.from_bytes(data[16:20], "big"),
+            int.from_bytes(data[20:24], "big"),
+        )
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return webp_dimensions(data)
+    if data[:2] == b"\xff\xd8":
+        offset = 2
+        while offset + 9 < len(data):
+            if data[offset] != 0xFF:
+                raise ValueError("JPEG segment out of sync")
+            marker = data[offset + 1]
+            length = int.from_bytes(data[offset + 2 : offset + 4], "big")
+            # SOF0-SOF15, excluding the non-frame markers that share the range.
+            if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                return (
+                    int.from_bytes(data[offset + 7 : offset + 9], "big"),
+                    int.from_bytes(data[offset + 5 : offset + 7], "big"),
+                )
+            offset += 2 + length
+        raise ValueError("no JPEG frame header found")
+    raise ValueError("unrecognised image format")
+
+
 def catalogue_images() -> list[Path]:
     """Every image under public/images that is not an allowlisted background."""
     return sorted(
@@ -131,6 +163,38 @@ class CatalogueEncodingTests(unittest.TestCase):
             [],
             "catalogue images must be WebP; run "
             "`node scripts/reencode-catalogue-images.mjs`",
+        )
+
+    def test_full_bleed_images_fit_the_srcset_ceiling(self):
+        """The allowlist is exempt from the encoding, not from the delivery.
+
+        `apps/web/next.config.js` derives its `deviceSizes` ceiling from
+        `maxDimension`, because the optimiser never upscales and every srcset
+        candidate above the largest source returns identical bytes. Of the three
+        allowlisted images only `about/mission.png` goes through the optimiser,
+        so only it can be capped that way -- `hero.png` and `contact-bg.jpg` are
+        CSS background-image URLs, which `deviceSizes` cannot reach at all.
+        The allowlist is checked whole regardless: it is three files, the cost
+        is nothing, and the alternative is a second list to keep in step with
+        how each asset happens to be referenced today.
+
+        Dimensions come from the WebP parser above only for WebP; the allowlist
+        is PNG and JPEG, so this reads their headers directly. Both formats put
+        the size in a fixed place near the front of the file.
+        """
+        undersupplied = {}
+        for name in sorted(FULL_BLEED):
+            path = IMAGES_DIR / name
+            if not path.is_file():
+                continue  # covered by test_full_bleed_allowlist_is_not_stale
+            width, height = raster_dimensions(path.read_bytes())
+            if max(width, height) > MAX_DIMENSION:
+                undersupplied[name] = f"{width}x{height}"
+        self.assertEqual(
+            undersupplied,
+            {},
+            f"full-bleed images wider than the {MAX_DIMENSION}px srcset ceiling "
+            "derived in apps/web/next.config.js; they would be served capped",
         )
 
     def test_catalogue_images_are_at_display_resolution(self):


### PR DESCRIPTION
Closes #150.

`next/image` was using its default `deviceSizes` ladder, which runs to 3840. No source in the repo is wider than 1024px and the optimiser never upscales past its source, so **`w=1080` through `w=3840` returned six byte-identical responses per image** — each one its own optimiser cache entry.

Confirmed against a running image rather than inferred. On `main`, all five widths came back identical:

```
mission.png  w=1080  200  135936B  md5 d4ef7a54
             w=1200  200  135936B  md5 d4ef7a54
             w=1920  200  135936B  md5 d4ef7a54
             w=2048  200  135936B  md5 d4ef7a54
             w=3840  200  135936B  md5 d4ef7a54
```

On this branch those four now return `400 Bad Request` (`"w" parameter (width) of 1920 is not allowed`) and the ladder is `[640, 750, 828, 1080]`.

## Derived, not written down twice

The ladder comes from `maxDimension` in `config/catalogue_images.json` — the default rungs below the source width, plus the first at or above it. Raising the encoding contract raises the srcset ceiling with it. Hardcoding `[640, 750, 828, 1080]` would have been the same duplication that #152 introduced the shared config to remove.

`apps/web/next.config.test.ts` guards the arithmetic, since otherwise only a full `next build` could tell you it had broken. It asserts against the config rather than the literal, so it does not need editing when the contract changes. Verified in both directions: raising `maxDimension` to 1600 adapts the ladder to `[640,750,828,1080,1200,1920]` with all four assertions still green, and hardcoding the ladder back to Next's defaults fails *"offers exactly one candidate at or above the source width"* with 5.

## Nothing is served smaller than before

`ui-review` rendered this against a baseline built from `main`'s config and diffed full-page canvases at nine page/viewport combinations, DPR 1 and 2:

| page | phone/DPR2 | tablet/DPR2 | desktop/DPR1 | desktop/DPR2 |
| --- | --- | --- | --- | --- |
| `/about` | 0 | 0 | 0 | 0 |
| `/products/trailmaster-x4-tent` | 0 | 0 | 0 | 0 |
| `/` | 0 | 0 | 0 | 0 |

Differing pixels, out of up to 33.6M per comparison. Two surfaces sit below 2× — the 550px detail image at 0.93× and the about page's 604px band at 0.85× — but they are short **for want of source, not for want of a rung**, and `main` received the identical 1024px bytes after requesting 1200 and 1920.

## The part that only a real build caught

`next.config.js` now `require`s a file above `apps/web/`, and the Dockerfile's builder stage copies individual files out of that directory. The image build failed with `Cannot find module '../../config/catalogue_images.json'` — which would have taken down `docker/build-push-action` and both e2e-smoke jobs, while `quick-ci`, a local `next build` and the whole script suite passed. Found by `ui-review`, since it builds the image to render against it.

Fixed in the builder stage only, and verified rather than assumed: the standalone output inlines `deviceSizes":[640,750,828,1080]`, contains no reference to `catalogue_images`, and `config/` is not traced into the bundle. The verifier built all stages and confirmed `/app/config` does not exist in the runner image.

This is #148's "verifying in a richer environment than the real one" in its purest form — the working tree had the file, the build context did not.

## New guard

Deriving the ceiling from `maxDimension` couples something that was previously independent: the three full-bleed images are deliberately exempt from the encoding contract, so a background wider than `maxDimension` would now be capped on delivery with nothing to say so. `test_full_bleed_images_fit_the_srcset_ceiling` says so and names `next.config.js` in the failure message.

Its `raster_dimensions()` helper reads PNG, JPEG and WebP headers. The JPEG width/height order is the kind of thing two square fixtures would not catch, so it was checked against non-square files in each format — including progressive JPEG — and independently by the verifier against a 301×517 fixture.

## Filed rather than folded in

- **#157** — `/about`'s mission image has no `sizes` (so `100vw` for a 604px box, ~75 KiB wasted per view) and lazy-loads while being the likely LCP element. Found independently by both `ui-review` and `code-review`.
- **#158** — `hero.png` and `contact-bg.jpg` are CSS backgrounds, so they bypass the optimiser entirely and ship raw: 1.2 MB unoptimised on the two main entry points, a larger delivered-byte problem than this one.

## Worth one moment's thought on deploy

Removed widths now return 400 rather than an image. No consumer in the repo hardcodes them. If any HTML is CDN-cached across the deploy, previously-emitted `w=1920` srcset URLs will 400 until it expires; browsers fall back to `src`, so it degrades gracefully.

## Verification

`make -C apps/web quick-ci` (115 tests, 33 files), `make test-scripts` (142), `docker build` both stages, and the e2e smoke equivalent against a real stack. Rendered pass showed no console errors, CLS 0.0000, and no horizontal overflow at any viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)