### PR TITLE
docs: close three gaps the last session found in the workflow

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -65,4 +65,6 @@ If nothing scores 80 or above, say the change is approved and say what you exami
 
 Otherwise, for each finding: the file and line, what is wrong, the concrete scenario in which it produces a wrong result, the suggested fix, and the confidence score. Order by severity.
 
+Say of each whether it is a **defect** — the change is wrong, or would be once someone relied on it — or a **refinement**, worth applying but not worth another review round. The caller uses that to decide whether to come back, so a review that omits it leaves them with no way to stop. When a re-review returns only refinements, say so in as many words.
+
 Close with what you reviewed — the diff ranges and any untracked files — and anything you could not assess, such as generated files or binary assets.

--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -49,6 +49,8 @@ Host ports 5432 and 3000 may already be taken by unrelated projects. If so, use 
 
 Viewports to exercise when you can render: phone **390×844**, tablet **834×1112**, desktop **1440×900**.
 
+A viewport is a width in CSS pixels and says nothing about the pixels behind it. When the change affects what the browser *requests* rather than how it lays out — anything carrying a `srcset`, or a source whose dimensions changed — exercise **2× as well as 1×**. Density is a property of the browser context (`deviceScaleFactor: 2`), not of `browser_resize`, so it needs a second pass rather than another width. Where you cannot set it, compare the `w=` values the page asks the optimiser for against the CSS box each image occupies, and say that is what you did.
+
 ## What to inspect
 
 For the changed journey, as applicable:
@@ -59,6 +61,7 @@ For the changed journey, as applicable:
 - **Keyboard** — can the journey be completed without a mouse? Is anything reachable but unusable, or unreachable?
 - **Contrast** — does text meet WCAG AA (4.5:1 body, 3:1 large)?
 - **Responsiveness** — overflow, truncation, tap-target size, layout collapse
+- **Density** — when the change affects what the browser requests, does 2× hold up as well as 1×?
 - **Semantics** — headings in order, labelled form controls, meaningful alternative text, ARIA only where a native element will not do
 
 Capture screenshots at each viewport when rendering; they are the evidence for this step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,33 @@ Follow these steps in order for every change.
    - Run focused tests while iterating.
    - Refactor only while the relevant tests remain green.
 
+   **A guard added for behavior that already works has no red phase**, so the
+   confirm-it-fails bullet never reaches it. Write down which mistake each
+   assertion catches, and which ones nothing catches, then demonstrate it:
+   break an input on purpose and watch that assertion fail on it. Coverage
+   argued rather than demonstrated is the defect the guard was added to
+   prevent, one level up.
+
+   Point the guard at a fixture tree; do not damage the real one. These modules
+   compute their paths at import, so rebind **every path constant the assertion
+   dereferences** — found by reading the module, not guessed from its name.
+   That is more than the obvious one and is different per guard:
+   `test_image_encoding.py` reaches everything through `IMAGES_DIR`;
+   `test_image_references.py` also needs `PUBLIC_DIR`, which its `relative_to`
+   depends on, and `REPO_ROOT`, which it walks for references;
+   `test_page_headings.py` reads `REPO_ROOT` directly for the
+   component-supplied headings, so rebinding `APP_DIR` alone leaves that
+   assertion on the checkout. Rebinding a root that other constants were
+   derived from at import changes nothing they read.
+
+   Then confirm the run opened the fixture at all: a failure naming a path
+   inside it, or a vacuity guard reporting a count that matches what the
+   fixture holds. The count is the evidence, not the firing — a vacuity guard
+   fires on nothing found, which is equally what a mistyped fixture path
+   produces, and the assertions being demonstrated pass on the empty loop
+   either way. A green run that never opened the fixture looks exactly like a
+   guard that works.
+
 5. **Inspect the complete diff.** Review the branch diff plus all staged,
    unstaged, and untracked files. Remove accidental or unrelated changes while
    preserving work that belongs to the user. A real problem found here is filed
@@ -78,10 +105,20 @@ Follow these steps in order for every change.
    journey in the rendered application at representative phone, tablet, and
    desktop viewports; inspect interaction, loading, empty, error, focus,
    keyboard, contrast, and responsive states as applicable; and capture
-   screenshots or equivalent visual evidence. For changes with no UI impact,
-   explicitly record that rendered UI review is not applicable. If a finding
-   is not applicable, record the concrete reason rather than silently ignoring
-   it.
+   screenshots or equivalent visual evidence.
+
+   A viewport is a width in CSS pixels, which says nothing about how many
+   device pixels fill it. Where the change affects what the browser requests —
+   anything carrying a `srcset` — exercise it at **2x as well as 1x**. A 2x
+   screen asks for twice the CSS width, and the optimiser never upscales past
+   the source, so a source that satisfies 1x can fall short at 2x while every
+   1x measurement stays clean. The 600px re-encode first tried in #152 came out
+   at −0.9 to −2.2 dB PSNR at 1x and −4.4 to −6.6 dB at 2x: a difference at 1x
+   small enough to accept, and one at 2x that was plainly visible.
+
+   For changes with no UI impact, explicitly record that rendered UI review is
+   not applicable. If a finding is not applicable, record the concrete reason
+   rather than silently ignoring it.
 
 7. **Run `verifier` before code review.** Invoke the `verifier` sub-agent to run
    the builds, static checks, tests, and journey coverage appropriate for the
@@ -97,6 +134,13 @@ Follow these steps in order for every change.
    before committing. If review findings cause changes, rerun the appropriate
    tests and the `verifier`, then obtain a fresh `code-review` approval for the
    changed state.
+
+   That loop has no natural end, so ask for one: **have the reviewer say which
+   findings are defects and which are refinements.** The loop ends on a round
+   returning no defects, however many refinements come with it. Apply those,
+   rerun the focused tests and the `verifier`, and record what was applied — a
+   refinement-only change does not earn a fresh review round, here or at
+   step 10.
 
 9. **Commit after approval.** Commit only after verification and code review
    are complete. Use Conventional Commits:
@@ -114,6 +158,9 @@ Follow these steps in order for every change.
       pre-commit review.
     - A changed state includes code, tests, documentation, generated files,
       conflict resolution, or any other staged, unstaged, or untracked content.
+    - Except refinements the reviewer classified as such and step 8 cleared:
+      applying those does not re-arm this, or the loop step 8 just ended
+      reopens here.
     - Do not repeat code review when the already-reviewed diff and worktree
       remain unchanged.
     - Push and create the pull request only after local verification and any


### PR DESCRIPTION
Three adjustments to the development workflow, each grounded in something that actually broke during the #96 re-encode rather than in something that merely sounds prudent. Both agent definitions move with AGENTS.md, because two of the three would otherwise require behaviour the agents performing those steps are never told about.

## 1. Step 4 — the red phase does not reach guards

*"Run it and confirm it fails for the expected reason"* is scoped to tests written **before** implementation. A guard protecting behaviour that already works has no before. It passes from the moment it is written, which is indistinguishable from catching something.

`tests/scripts/test_image_encoding.py` was written against 852 already-correct files, and its weight ceiling passed from the start while its stated rationale described a case its sibling assertion already caught. What surfaced that was one question — *for each mistake this guard exists to catch, which assertion fires?* — answerable only by building a corpus at the wrong setting:

| corpus | per-file ceiling | mean ceiling |
| --- | --- | --- |
| q94 | pass | pass |
| q95 | pass | **fails** |
| lossless | **fails** | fails |

Step 4 now requires that mapping to be written down and demonstrated, including the mistakes nothing catches.

It also names how to point a guard at a fixture without damaging the real tree — which I got wrong twice before getting right, and both wrong versions are why the paragraph is as specific as it is:

- **Damaging the checkout.** Testing the mean ceiling, I re-encoded 120 real catalogue files losslessly in place, timed out with 69 corrupted, and found my backup keyed on basename — which collides (`backpacks/76/detail.webp` vs `tents/26/detail.webp`), so restoring from it could have silently swapped images. Recovered by re-encoding from the git originals.
- **Rebinding the wrong constant.** The first written mechanism said rebind `REPO_ROOT`. These modules derive their paths at import, so that leaves them on the checkout: reproduced as **7 tests green having read the real repository**. Worse than the vague rule it replaced, because a false green does not prompt a question.
- **Generalising from one module.** The second version named one constant per guard, correct only for the module I had tested. `test_page_headings.py` reads `REPO_ROOT` directly for component-supplied headings; `test_image_references.py` needs `PUBLIC_DIR` for a `relative_to` and `REPO_ROOT` for its reference walk.

It now states the operation — rebind every path constant the assertion dereferences, found by reading the module — with the three modules as worked examples of how they differ. Verified against the guard that broke the previous rule, not the one it came from.

## 2. Step 6 — a viewport is a width in CSS pixels

It says nothing about how many device pixels fill it. A 2× screen asks for twice the CSS width, and the optimiser never upscales past the source, so a source that satisfies 1× can fall short at 2× while every 1× measurement stays clean.

That is exactly how #152's first pass went: **−0.9 to −2.2 dB PSNR at 1×, −4.4 to −6.6 dB at 2×**. Small enough to accept at 1×, plainly visible at 2×.

Sampling three viewports at one density has the blind spot #143 already filed about, one axis over. `.claude/agents/ui-review.md` gains the requirement, the mechanism (`deviceScaleFactor` is a browser-context property, not a `browser_resize` argument), a fallback where it cannot be set, and a **Density** entry in `## What to inspect` — without that last part, an agent could render 1× only and violate nothing in its own definition.

## 3. Step 8 — the re-review loop had no exit

*"If review findings cause changes… obtain a fresh `code-review` approval"*, with nothing distinguishing a defect from a refinement. #152 ran four rounds.

The reviewer now classifies findings; the loop ends on a round returning no defects. Step 10 gains the matching exemption — without it, applying refinements makes the worktree differ from the last approved state, so step 10 re-arms the loop step 8 just closed. `.claude/agents/code-review.md` gains the vocabulary step 8 depends on, since its Output section had none.

## What this PR's own review found

Four rounds, and the rule is doing its job — I stopped on the round that returned no defects, not when I got tired. Findings against my own prose, all the failure mode this session kept producing:

- Step 8's termination rule **did not terminate** — step 10 reopened it.
- Step 6 required 2× from an agent with no concept of density and no mechanism for it. Same shape as #100; filed **#160** for the structural gap that nothing checks whether a requirement AGENTS.md places on a step is described in the agent executing it.
- *"Most traffic is 2x"* — a claim about traffic this app has no data for. Replaced with the mechanism, which needs none.
- *"sampling three viewports at one density has the same blind spot as sampling three viewports"* — compares a thing to itself.
- *"fonts"* as a DPR-varying download — wrong twice: font downloads do not vary with density, and this repo loads no web fonts.
- A convergence heuristic that contradicted the repo's own model, in which steps 6–8 turn up unrelated things *because* the reviewers read more than the change touches.
- The two step 4 mechanism errors above.
- Final round, refinement only: *"a vacuity guard firing"* is satisfied by an empty result set — a mistyped fixture path fires it too. The count is the evidence, not the firing.

## Verification

`make docs-check`, `make agent-docs-check`, `make test-scripts` (142). Markdown and agent definitions only; no pointer file gained content. Rendered UI review is not applicable — no UI surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)