### PR TITLE
fix(web): let the home hero band grow with its own text

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -17,6 +17,7 @@ const WIDTHS = [
   360, 375, 390, 414, // phones
   639, 640, 641, // sm boundary
   767, 768, 769, // md boundary
+  834, // iPad Air portrait, in the 254px gap between the md and lg boundaries
   1023, 1024, // lg boundary
   1280, 1440,
 ]
@@ -101,6 +102,77 @@ test.describe('no horizontal overflow', () => {
       if (offenders.length > 0) broken[width] = offenders
     }
     expect(broken, 'widths where content spills past the viewport').toEqual({})
+  })
+})
+
+test.describe('no vertical collision', () => {
+  test('the home hero never paints over the first category heading', async ({ page }) => {
+    // The horizontal sweep above cannot see this one. The hero band is a fixed
+    // height, so when its text wraps to more lines than that height allows it
+    // escapes downwards and paints across the section below — no element is
+    // wider than the viewport at any point, and the document never scrolls
+    // sideways, so every assertion in this file stayed green while the phone
+    // layout was visibly broken.
+    //
+    // Asserted against the first `h2` rather than against the band's own
+    // height: what matters is that the two do not collide, and stating it that
+    // way survives whatever shape the fix takes.
+    await page.goto('/')
+
+    // The header's two buttons plus the hero's heading, subhead and body. A
+    // walk that stops early inspects fewer and reports no collisions, which is
+    // indistinguishable from a clean page: the anchor below is whichever `h2`
+    // comes first, so an `h2` introduced anywhere above the categories would
+    // silently retarget it and leave the hero unmeasured.
+    const TEXT_BLOCKS_BEFORE_THE_FIRST_CATEGORY = 5
+
+    const collisions: Record<number, string[]> = {}
+    const inspected: Record<number, number> = {}
+    for (const width of WIDTHS) {
+      await page.setViewportSize({ width, height: 900 })
+      await page.waitForTimeout(120)
+
+      const result = await page.evaluate(() => {
+        const heading = document.querySelector('h2')
+        if (!heading) return { offenders: ['no h2 on the page to collide with'], seen: 0 }
+        const headingTop = heading.getBoundingClientRect().top
+
+        // Everything above the first category heading in document order: the
+        // header and the hero. Text rects rather than element boxes, for the
+        // reason the horizontal check gives — a box can measure clean while
+        // the text inside it paints past the edge.
+        const found: string[] = []
+        let seen = 0
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+        let node: Node | null
+        while ((node = walker.nextNode())) {
+          if (!node.textContent?.trim()) continue
+          if (!(heading.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING)) {
+            break
+          }
+          seen += 1
+          const range = document.createRange()
+          range.selectNodeContents(node)
+          for (const rect of Array.from(range.getClientRects())) {
+            if (rect.height > 0 && rect.bottom > headingTop + 1) {
+              found.push(`"${node.textContent.trim().slice(0, 40)}" ends ${Math.round(rect.bottom - headingTop)}px into the heading`)
+            }
+          }
+        }
+        return { offenders: found, seen }
+      })
+
+      if (result.offenders.length > 0) collisions[width] = result.offenders
+      if (result.seen < TEXT_BLOCKS_BEFORE_THE_FIRST_CATEGORY) inspected[width] = result.seen
+    }
+
+    // Before the collision assertion, because an empty `collisions` is equally
+    // what a walk that inspected nothing produces.
+    expect(
+      inspected,
+      `widths where fewer than ${TEXT_BLOCKS_BEFORE_THE_FIRST_CATEGORY} text blocks were measured, so the check below is weaker than it looks`,
+    ).toEqual({})
+    expect(collisions, 'widths where the hero paints over the section below').toEqual({})
   })
 })
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -21,7 +21,16 @@ export default async function Home() {
     <>
       <Header />
       <Block
-        outerClassName="bg-blend-multiply bg-center bg-hero-image h-80 bg-neutral-600"
+        // min-h-80, not h-80: the band keeps its full-bleed proportions on a
+        // desktop while growing with its own text on narrower screens. At a
+        // fixed height the copy wrapped past the bottom edge and painted over
+        // the first category, at every width from 360 to 769.
+        //
+        // bg-cover bg-no-repeat because the default is `auto` and `repeat`,
+        // so the 1024x450 image tiled: already visible as a vertical seam past
+        // 1024px wide, and a horizontal one as soon as the band grows taller
+        // than 450px, which min-h-80 lets it do.
+        outerClassName="bg-blend-multiply bg-center bg-cover bg-no-repeat bg-hero-image min-h-80 pb-8 bg-neutral-600"
         innerClassName=""
       >
         <h1 className="text-zinc-100 pt-12 text-7xl font-black subpixel-antialiased">


### PR DESCRIPTION
Closes #149.

The home hero band was `h-80` — a fixed height. Its copy wraps to more lines than that allows on a narrow screen, so it escaped downwards and painted across the first category heading.

## Wider than the issue reported

I added the check before the fix. It failed at **every width from 360 through 834**, not just 390:

| width | 360 | 375 | 390 | 414 | 639 | 640 | 767 | 768 | 769 | 834 | 1023+ |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| overlap | 258px | 230px | 230px | 198px | 110px | 38px | 10px | 10px | 10px | 10px | clean |

Every phone and tablet width. Clean from 1023 up, which is where it had been looked at.

## The fix

`min-h-80 pb-8`. Under border-box sizing the padding is absorbed while the content is short, so **from 1280 up the geometry is byte-identical to the old `h-80`** — the desktop hero is unchanged by this commit and cannot have become bottom-heavy.

It also sets `bg-cover bg-no-repeat`. That is a pre-existing defect this change would otherwise make materially worse, not an unrelated fix: the background defaulted to `background-size: auto` and `background-repeat: repeat`, so the 1024×450 image **tiled**. Already a vertical seam past 1024px wide — the van and tent repeat at both edges — and a horizontal one as soon as `min-h-80` lets the band exceed 450px. Fixed here under the AGENTS.md carve-out, with the reason in the commit message as that rule requires.

## Why nothing caught it

`layout.spec.ts` sweeps 15 widths for horizontal overflow, and this was invisible to all of it: no element is wider than the viewport at any point, and the document never scrolls sideways. Every assertion stayed green while the phone layout was visibly broken.

The new `no vertical collision` block asserts no text preceding the first `h2` paints below that heading's top. It also **asserts how many text blocks it measured, before checking for collisions** — an empty collision list is equally what a walk that inspected nothing produces, and the anchor is whichever `h2` comes first, so an `h2` introduced above the categories would silently retarget it. Injecting one into the hero drops the count from 5 to 2 and fails the guard.

`834` is added to `WIDTHS`. It sat in a 254px gap between sampled widths, was broken by 10px, and is the tablet viewport step 6 asks for — the sweep's own docstring says it straddles boundaries so defects cannot hide between samples.

## Verification

- **Rendered**: 16 widths at 1×, the three required viewports at 1× and 2×, plus landscape. Text contrast over the newly-visible image measured at 7.1:1 worst case, and structurally incapable of failing — `bg-blend-multiply` against `bg-neutral-600` clamps any background pixel regardless of what `bg-cover` reveals.
- **Verifier**: 25 Playwright tests green against a real seeded stack, `quick-ci` 115, `test_scripts` 142, containerized smoke. The defect was reproduced by DOM mutation rather than by editing files, confirming the guard fires at 390 and at exactly 10px at 834.
- The retarget guard was reproduced three separate ways on a second, from-scratch stack.

`bg-cover` at 360 shows only 25% of the image width and still reads as a campsite — but that is a property of this artwork, whose subject is centred, not of `bg-cover`. Art with an off-centre subject would crop to empty sky and nothing here would notice.

## Filed rather than folded in

- **#162** — the `h1` is `text-7xl` at every width and overflows at 320px. Pre-existing, and invisible because the sweep starts at 360. The same unscaled type is why the copy wrapped in the first place; a responsive scale would fix the overflow, bring the phone band back toward its intended proportions, and make landscape fit.
- **#158** — gained a measurement: `bg-cover` raises the upscale on that 833 KB PNG to 2.7–3.8× at 2×, so the asset is now the wrong resolution as well as the wrong format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)