### PR TITLE
perf(web): size the about page mission image to the box it occupies

### DIFF
--- a/apps/web/e2e/image-delivery.spec.ts
+++ b/apps/web/e2e/image-delivery.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Images are requested at the size they are displayed.
+ *
+ * `next/image` picks a width from the srcset ladder using the `sizes`
+ * attribute, so a `sizes` that does not describe the real box makes the browser
+ * fetch the wrong file — and every other check passes, because the wrong file
+ * still decodes and still fills the box. Nothing here is visible: the page
+ * renders identically whether it downloaded 57 KiB or 132 KiB.
+ *
+ * A `fill` image is where this goes wrong quietly, because it has no `width`
+ * prop sitting next to `sizes` looking inconsistent. Omit `sizes` entirely and
+ * Next assumes `100vw`, which is right only for an image that spans the
+ * viewport.
+ */
+
+/**
+ * Widths where this app's layout changes the box, plus the ones that sit
+ * inside a gap in the ladder below. 412, 414 and 430 are common phone widths
+ * and 841-900 common desktop windows; all of them land on a box just above the
+ * 384 rung, which is where a too-loose assertion hides.
+ */
+const WIDTHS = [390, 412, 414, 430, 640, 768, 834, 841, 860, 900, 1024, 1280, 1440]
+
+/** Densities to exercise. Most traffic is not 1x, and 1x cannot see this. */
+const DENSITIES = [1, 2]
+
+type Delivery = {
+  box: number
+  requested: number | null
+  ladder: number[]
+  loading: string
+}
+
+/**
+ * What the page rendered, and what it offered to render.
+ *
+ * The rung list comes from the served `srcset` rather than from a copy of
+ * Next's defaults. A copy is wrong the moment either half moves — mine had a
+ * `16` in it that Next has never emitted — and it is wrong silently, because a
+ * phantom rung only matters for a box small enough to select it. Parsing what
+ * was actually offered cannot drift from what was actually offered.
+ */
+async function deliveryOf(page: Page, alt: string): Promise<Delivery> {
+  return page.evaluate((alt) => {
+    const image = document.querySelector<HTMLImageElement>(`img[alt="${alt}"]`)
+    if (!image) throw new Error(`no image with alt "${alt}"`)
+    return {
+      box: Math.round(image.getBoundingClientRect().width),
+      requested: Number((image.currentSrc || '').match(/[?&]w=(\d+)/)?.[1]) || null,
+      ladder: (image.srcset || '')
+        .split(',')
+        .map((candidate) => Number(candidate.trim().match(/\s(\d+)w$/)?.[1]))
+        .filter((width) => Number.isFinite(width) && width > 0)
+        .sort((a, b) => a - b),
+      loading: image.loading,
+    }
+  }, alt)
+}
+
+/** The smallest rung the browser was offered that covers the device pixels. */
+const expectedRung = (ladder: number[], box: number, density: number): number =>
+  ladder.find((rung) => rung >= box * density) ?? ladder[ladder.length - 1]
+
+test.describe('image delivery', () => {
+  test('the about page mission image is sized to its box', async ({ browser }, testInfo) => {
+    // Two dozen cold page loads, one per width and density.
+    test.slow()
+
+    const overfetched: Record<string, string> = {}
+    const laddersSeen: number[] = []
+
+    // A fresh context per measurement, not one page resized between them.
+    // Sharing a cache lets the browser keep a larger candidate it already has
+    // rather than fetch the smaller one the new width calls for, so the second
+    // and later widths measure the cache instead of `sizes`. Each pass here is
+    // a new visitor, which is the case that matters.
+    for (const density of DENSITIES) {
+      for (const width of WIDTHS) {
+        const at = `${width}@${density}x`
+        const context = await browser.newContext({
+          viewport: { width, height: 900 },
+          deviceScaleFactor: density,
+          baseURL: testInfo.project.use.baseURL,
+        })
+        try {
+          const page = await context.newPage()
+          await page.goto('/about')
+          // Not `networkidle`: the session poll retries in the background on a
+          // stack without auth configured, so the network never goes quiet and
+          // this waits out the timeout. The signal wanted is narrower anyway —
+          // the browser has chosen a candidate.
+          await page.waitForFunction(
+            () => !!document.querySelector<HTMLImageElement>('img[alt="Our Mission"]')?.currentSrc,
+          )
+
+          const { box, requested, ladder } = await deliveryOf(page, 'Our Mission')
+
+          expect(requested, `no optimiser width at ${at} — is the image served through next/image?`).toBeTruthy()
+          expect(box, `image had no box at ${at}`).toBeGreaterThan(0)
+          expect(ladder.length, `no w descriptors in the srcset at ${at}`).toBeGreaterThan(0)
+          laddersSeen.push(ladder.length)
+
+          const expected = expectedRung(ladder, box, density)
+          if (requested !== expected) {
+            overfetched[at] = `${box}px box at ${density}x asked for w=${requested}, expected w=${expected}`
+          }
+        } finally {
+          // A context from the `browser` fixture is not closed for us, and an
+          // assertion above can leave the loop early.
+          await context.close()
+        }
+      }
+    }
+
+    // The rung list is parsed, so a parse that silently yielded one candidate
+    // would make every comparison above trivially true.
+    expect(Math.min(...laddersSeen), 'the srcset offered too few candidates to be measuring anything').toBeGreaterThan(3)
+    expect(overfetched, 'cases where the request is not the smallest rung covering the box').toEqual({})
+  })
+
+  test('the about page mission image is not lazy, because it is the LCP element', async ({ page }) => {
+    // Measured rather than assumed: at every width but the narrowest, this
+    // image is what largest-contentful-paint reports. Lazy-loading the LCP
+    // element defers the request until layout says it is near the viewport,
+    // which is exactly the request that should start first.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto('/about')
+    // See the note above: the session poll keeps the network busy, and the
+    // signal wanted is that the image has painted.
+    await page.waitForFunction(
+      () => document.querySelector<HTMLImageElement>('img[alt="Our Mission"]')?.complete === true,
+    )
+
+    const isLcp = await page.evaluate(
+      () =>
+        new Promise<boolean>((resolve) => {
+          let element: Element | null = null
+          new PerformanceObserver((list) => {
+            const entries = list.getEntries()
+            element = (entries[entries.length - 1] as unknown as { element: Element }).element
+          }).observe({ type: 'largest-contentful-paint', buffered: true })
+          setTimeout(
+            () => resolve(element === document.querySelector('img[alt="Our Mission"]')),
+            500,
+          )
+        }),
+    )
+
+    expect(isLcp, 'this test is about the LCP element; it is no longer the LCP element').toBe(true)
+    expect((await deliveryOf(page, 'Our Mission')).loading).not.toBe('lazy')
+  })
+})

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -31,6 +31,34 @@ export default function AboutPage() {
                 src="/images/about/mission.png"
                 alt="Our Mission"
                 fill
+                // A `fill` image has no width prop, so without `sizes` Next
+                // assumes 100vw and the browser fetches for the whole viewport
+                // — w=1080 for a 604px box, and w=1080 for a 381px one.
+                //
+                // The box is one column of a two-column grid inside the
+                // container: half of it, less half the 48px gap and half the
+                // 24px padding, so `50vw - 36px`. The container stops growing
+                // at the xl breakpoint, which fixes the column at 604px. Below
+                // md the grid is one column and the box is the container.
+                // The spaces inside the parens are load-bearing. Next finds the
+                // viewport percentages with /(^|\s)(1?\d?\d)vw/ to trim the
+                // srcset to the rungs a percentage of the viewport can reach;
+                // `calc(50vw` puts a paren before the `vw`, nothing matches,
+                // and it emits all eleven rungs instead of five. Selection is
+                // unaffected either way — this is 780 bytes of dead candidates
+                // per response, listed twice because `priority` preloads them.
+                sizes="(min-width: 1280px) 604px, (min-width: 768px) calc( 50vw - 36px ), calc( 100vw - 24px )"
+                // Largest-contentful-paint reports this image at every width
+                // above 390. It was lazy, so the request that decides LCP was
+                // the one deferred longest: on a throttled desktop load this
+                // buys 300-500ms of LCP for 70-140ms of FCP, because the
+                // preload goes ahead of the stylesheet.
+                //
+                // At 390 that trade is a small loss — the LCP element there is
+                // a paragraph, so the FCP cost buys nothing. Kept anyway:
+                // next/image has no way to make this conditional on width, and
+                // the widths that gain outnumber the one that pays.
+                priority
                 className="object-cover"
              />
           </div>


### PR DESCRIPTION
Closes #157.

The about page's mission image is a `fill` `next/image` with no `sizes`. A `fill` image has no `width` prop sitting beside `sizes` looking inconsistent, so the omission is easy to miss — and Next's fallback is `100vw`, which is right only for an image spanning the viewport. This one is a column of a two-column grid.

It was also `loading="lazy"` while being the LCP element, so the request that decides LCP was the one deferred longest.

## Measured, fresh context per width

| width | box | before | after |
| --- | --- | --- | --- |
| 390 | 366 | w=640 (57 KiB) | w=384 (23 KiB) |
| 768 | 348 | w=828 (89 KiB) | w=384 (23 KiB) |
| 834 | 381 | w=1080 (132 KiB) | w=384 (23 KiB) |
| 1024 | 476 | w=1080 | w=640 (57 KiB) |
| 1280+ | 604 | w=1080 (132 KiB) | w=640 (57 KiB) |

#157 estimated ~75 KiB at desktop, which is right — but the worst case is a tablet, not a desktop: **109 KiB at 834**.

## The `sizes` value, and why it has odd spaces

The box is half the container, less half the 48px gap and half the 24px padding — `calc( 50vw - 36px )` — until the container stops growing at 1280 and fixes the column at 604px. Verified exact at every boundary, including 768 where the grid engages and the box *drops* from 743 to 348.

**The spaces inside the parens are load-bearing.** `next/image` finds viewport percentages with `/(^|\s)(1?\d?\d)vw/` in order to trim the srcset to the rungs a percentage of the viewport can actually reach. `calc(50vw` puts a paren before the `vw`, so nothing matches and Next emits its entire unfiltered ladder. Selection is unaffected — the browser picks by descriptor either way — but the dead candidates ship twice, since `priority` also preloads them:

```
calc(50vw - 36px)    → 32 48 64 96 128 256 384 640 750 828 1080   (718 bytes)
calc( 50vw - 36px )  →                     384 640 750 828 1080   (380 bytes)
```

## `priority` is a trade, stated as one

On a throttled desktop load the preload lands ahead of the render-blocking stylesheet: **+300–500 ms LCP for −70–140 ms FCP**. Favourable. At 390 it is a small net loss — the LCP element there is a paragraph, so the FCP cost buys nothing — and `next/image` cannot make this conditional on width. Kept, with both sides in the comment.

CLS is 0.0000 at all six viewport/density combinations; `h-80` plus `bg-zinc-200` already reserves the box.

## The spec was wrong three times, and passed every time

`apps/web/e2e/image-delivery.spec.ts` asserts the requested width is the smallest srcset rung covering the box, at 1× and 2×, with a fresh browser context per measurement. It got there via three wrong versions, each caught by a different gate:

1. **Shared page across widths** — the browser kept a larger cached candidate rather than fetching the smaller one, so later widths measured the cache instead of `sizes`. It reported over-fetch that was not real.
2. **A 1.5× tolerance** justified by the 384→640 gap. The ladder's widest gap is 128→256, a factor of **1.98**, so the threshold could not tolerate the gap it claimed to and only passed because the sampled widths straddled the failure band. `ui-review` found real widths that broke it — 412, 414, 430, 841, 860, 900.
3. **A hardcoded copy of Next's default `imageSizes`** containing a `16` that Next has never emitted. `verifier` checked it against the installed Next rather than against my reasoning.

It now parses the ladder out of the served `srcset`, so it cannot describe a ladder that is not there, and asserts the exact rung, so there is no tolerance to get wrong.

Because the spec was restructured after going green, the red phase was re-run against the shipping version: **15 failing cases**, three of which the 1×-only version could not see (`390@2x`, `430@2x`, `768@2x`).

Also replaced `networkidle` with a wait on the image having chosen a candidate — the session poll retries in the background on a stack without auth configured, so the network never goes quiet and the test times out. That would have been flaky in CI.

## One belief corrected

I expected `w=384` into a ~380px box to look soft on a HiDPI tablet. It cannot: `sizes` is in CSS pixels and the browser multiplies by DPR when selecting, so 834@2× requests `w=828`. Nothing upscales. The measured residue is −17.5% edge energy at 834@2×, indistinguishable side by side at native raster.

## Filed rather than folded in

- **#164** — `alt="Our Mission"` duplicates the `h2` beside it, so a screen reader announces the phrase twice and never learns what the picture shows. An editorial call, not a one-word fix.
- **#165** — `about/mission.png` sits in the `fullBleed` allowlist justified as "a `fill` image in a full-width band". This change measured that band: it never exceeds 604 CSS px. The exemption still holds, for a different reason, and `fullBleed` is now a misleading name.
- **#166** — two other `sizes` attributes overfetch across the tablet band, including the category grid value I set in #159 from a single sampled width. The new spec generalises to both.

## Verification

`make -C apps/web quick-ci` (115 tests, 33 files), `make test-scripts` (142), 27 Playwright tests green twice against a real dockerized stack, containerized smoke, and a rendered pass at three viewports × two densities plus a 35-width sweep. Only `/about` emits an image preload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)