### PR TITLE
perf(web): size the product images to the boxes they occupy

### DIFF
--- a/apps/web/e2e/image-delivery.spec.ts
+++ b/apps/web/e2e/image-delivery.spec.ts
@@ -16,19 +16,60 @@ import { test, expect, type Page } from '@playwright/test'
  */
 
 /**
- * Widths where this app's layout changes the box, plus the ones that sit
- * inside a gap in the ladder below. 412, 414 and 430 are common phone widths
- * and 841-900 common desktop windows; all of them land on a box just above the
- * 384 rung, which is where a too-loose assertion hides.
+ * Widths where these layouts change the box, plus the ones that sit inside a
+ * gap in the ladder. 412, 414 and 430 are common phone widths and 841-900
+ * common desktop windows; those land on a box just above the 384 rung, which is
+ * where a too-loose assertion hides. 640, 1024 and 1280 are grid breakpoints,
+ * and 1224 is where a category card crosses 384 on its own.
  */
-const WIDTHS = [390, 412, 414, 430, 640, 768, 834, 841, 860, 900, 1024, 1280, 1440]
+const WIDTHS = [
+  390, 412, 414, 430, 574, 640, 768, 834, 841, 860, 900, 1024, 1152, 1224, 1280, 1440,
+]
 
 /** Densities to exercise. Most traffic is not 1x, and 1x cannot see this. */
 const DENSITIES = [1, 2]
 
+/**
+ * The surfaces that serve an optimised image, and how to find one.
+ *
+ * Neither catalogue path is hardcoded, for the reason `browse.spec.ts` gives: a
+ * slug rots silently when the catalogue changes, and the page still renders for
+ * a missing one. Each is resolved once per surface — following a link on every
+ * one of the three dozen measurements doubles the page loads and runs the test
+ * out of time.
+ *
+ * The category slug comes from the catalogue data rather than from a link,
+ * because nothing on the home page links to a category: it lists products
+ * directly. `browse.spec.ts` carries a fallback for the same reason.
+ */
+const SURFACES = [
+  { name: 'about mission', resolve: async () => '/about' },
+  {
+    name: 'product detail',
+    resolve: async (page: Page) => {
+      await page.goto('/')
+      // Not `/products/category/...`, which shares the prefix.
+      return page
+        .locator('a[href^="/products/"]:not([href*="/category/"])')
+        .first()
+        .getAttribute('href')
+    },
+  },
+  {
+    name: 'category grid',
+    resolve: async (page: Page) => {
+      const response = await page.goto('/categories.json')
+      const categories = (await response?.json()) as { slug: string }[]
+      return categories?.[0]?.slug ? `/products/category/${categories[0].slug}` : null
+    },
+  },
+]
+
 type Delivery = {
   box: number
   requested: number | null
+  /** Candidates in the srcset, before parsing. The parse is checked against it. */
+  offered: number
   ladder: number[]
   loading: string
 }
@@ -42,83 +83,114 @@ type Delivery = {
  * phantom rung only matters for a box small enough to select it. Parsing what
  * was actually offered cannot drift from what was actually offered.
  */
-async function deliveryOf(page: Page, alt: string): Promise<Delivery> {
-  return page.evaluate((alt) => {
-    const image = document.querySelector<HTMLImageElement>(`img[alt="${alt}"]`)
-    if (!image) throw new Error(`no image with alt "${alt}"`)
+async function deliveryOf(page: Page): Promise<Delivery> {
+  return page.evaluate(() => {
+    // The first image the optimiser served, not the first `img` — a surface may
+    // carry an unoptimised logo or icon ahead of the one under measurement.
+    const image = [...document.querySelectorAll('img')].find((candidate) =>
+      candidate.currentSrc.includes('/_next/image'),
+    )
+    if (!image) throw new Error('no optimised image on the page')
+    const candidates = (image.srcset || '').split(',').filter((part) => part.trim())
     return {
       box: Math.round(image.getBoundingClientRect().width),
       requested: Number((image.currentSrc || '').match(/[?&]w=(\d+)/)?.[1]) || null,
-      ladder: (image.srcset || '')
-        .split(',')
+      offered: candidates.length,
+      ladder: candidates
         .map((candidate) => Number(candidate.trim().match(/\s(\d+)w$/)?.[1]))
         .filter((width) => Number.isFinite(width) && width > 0)
         .sort((a, b) => a - b),
       loading: image.loading,
     }
-  }, alt)
+  })
 }
+
+/** Resolved once the browser has chosen a candidate for that first image. */
+const waitForSelection = (page: Page) =>
+  page.waitForFunction(() =>
+    [...document.querySelectorAll('img')].some((image) =>
+      image.currentSrc.includes('/_next/image'),
+    ),
+  )
 
 /** The smallest rung the browser was offered that covers the device pixels. */
 const expectedRung = (ladder: number[], box: number, density: number): number =>
   ladder.find((rung) => rung >= box * density) ?? ladder[ladder.length - 1]
 
 test.describe('image delivery', () => {
-  test('the about page mission image is sized to its box', async ({ browser }, testInfo) => {
-    // Two dozen cold page loads, one per width and density.
-    test.slow()
+  for (const surface of SURFACES) {
+    test(`the ${surface.name} image is sized to its box`, async ({ browser }, testInfo) => {
+      // Thirty-two cold page loads, one per width and density, each making the
+      // optimiser resize for a combination it has not cached. Locally the
+      // slowest surface takes 48s; `test.slow()` would allow 90s, and CI runs
+      // this inside the container on a shared vCPU where those resizes are the
+      // bottleneck — near enough to the limit to time out under load rather
+      // than fail for a reason worth reading.
+      test.setTimeout(180_000)
 
-    const overfetched: Record<string, string> = {}
-    const laddersSeen: number[] = []
+      const overfetched: Record<string, string> = {}
 
-    // A fresh context per measurement, not one page resized between them.
-    // Sharing a cache lets the browser keep a larger candidate it already has
-    // rather than fetch the smaller one the new width calls for, so the second
-    // and later widths measure the cache instead of `sizes`. Each pass here is
-    // a new visitor, which is the case that matters.
-    for (const density of DENSITIES) {
-      for (const width of WIDTHS) {
-        const at = `${width}@${density}x`
-        const context = await browser.newContext({
-          viewport: { width, height: 900 },
-          deviceScaleFactor: density,
-          baseURL: testInfo.project.use.baseURL,
-        })
-        try {
-          const page = await context.newPage()
-          await page.goto('/about')
-          // Not `networkidle`: the session poll retries in the background on a
-          // stack without auth configured, so the network never goes quiet and
-          // this waits out the timeout. The signal wanted is narrower anyway —
-          // the browser has chosen a candidate.
-          await page.waitForFunction(
-            () => !!document.querySelector<HTMLImageElement>('img[alt="Our Mission"]')?.currentSrc,
-          )
+      const discovery = await browser.newContext({ baseURL: testInfo.project.use.baseURL })
+      let path: string | null
+      try {
+        path = await surface.resolve(await discovery.newPage())
+      } finally {
+        await discovery.close()
+      }
+      expect(path, `found no link to the ${surface.name} surface`).toBeTruthy()
 
-          const { box, requested, ladder } = await deliveryOf(page, 'Our Mission')
+      // A fresh context per measurement, not one page resized between them.
+      // Sharing a cache lets the browser keep a larger candidate it already has
+      // rather than fetch the smaller one the new width calls for, so the second
+      // and later widths measure the cache instead of `sizes`. Each pass here is
+      // a new visitor, which is the case that matters.
+      for (const density of DENSITIES) {
+        for (const width of WIDTHS) {
+          const at = `${width}@${density}x`
+          const context = await browser.newContext({
+            viewport: { width, height: 900 },
+            deviceScaleFactor: density,
+            baseURL: testInfo.project.use.baseURL,
+          })
+          try {
+            const page = await context.newPage()
+            await page.goto(path!)
+            // Not `networkidle`: the session poll retries in the background on a
+            // stack without auth configured, so the network never goes quiet and
+            // this waits out the timeout. The signal wanted is narrower anyway —
+            // the browser has chosen a candidate.
+            await waitForSelection(page)
 
-          expect(requested, `no optimiser width at ${at} — is the image served through next/image?`).toBeTruthy()
-          expect(box, `image had no box at ${at}`).toBeGreaterThan(0)
-          expect(ladder.length, `no w descriptors in the srcset at ${at}`).toBeGreaterThan(0)
-          laddersSeen.push(ladder.length)
+            const { box, requested, offered, ladder } = await deliveryOf(page)
 
-          const expected = expectedRung(ladder, box, density)
-          if (requested !== expected) {
-            overfetched[at] = `${box}px box at ${density}x asked for w=${requested}, expected w=${expected}`
+            expect(requested, `no optimiser width at ${at} — is the image served through next/image?`).toBeTruthy()
+            expect(box, `image had no box at ${at}`).toBeGreaterThan(0)
+            // Against the srcset's own candidate count, not a magic number: a
+            // parse that dropped rungs would make the comparison below trivially
+            // true, and any floor picked instead coupled this to the encoding
+            // contract, which is free to narrow the ladder without saying
+            // anything about whether `sizes` is right.
+            expect(ladder.length, `dropped srcset candidates while parsing at ${at}`).toBe(offered)
+            expect(ladder.length, `an empty srcset at ${at}`).toBeGreaterThan(0)
+
+            const expected = expectedRung(ladder, box, density)
+            if (requested !== expected) {
+              overfetched[at] = `${box}px box at ${density}x asked for w=${requested}, expected w=${expected}`
+            }
+          } finally {
+            // A context from the `browser` fixture is not closed for us, and an
+            // assertion above can leave the loop early.
+            await context.close()
           }
-        } finally {
-          // A context from the `browser` fixture is not closed for us, and an
-          // assertion above can leave the loop early.
-          await context.close()
         }
       }
-    }
 
-    // The rung list is parsed, so a parse that silently yielded one candidate
-    // would make every comparison above trivially true.
-    expect(Math.min(...laddersSeen), 'the srcset offered too few candidates to be measuring anything').toBeGreaterThan(3)
-    expect(overfetched, 'cases where the request is not the smallest rung covering the box').toEqual({})
-  })
+      expect(
+        overfetched,
+        `${surface.name}: cases where the request is not the smallest rung covering the box`,
+      ).toEqual({})
+    })
+  }
 
   test('the about page mission image is not lazy, because it is the LCP element', async ({ page }) => {
     // Measured rather than assumed: at every width but the narrowest, this
@@ -149,6 +221,6 @@ test.describe('image delivery', () => {
     )
 
     expect(isLcp, 'this test is about the LCP element; it is no longer the LCP element').toBe(true)
-    expect((await deliveryOf(page, 'Our Mission')).loading).not.toBe('lazy')
+    expect((await deliveryOf(page)).loading).not.toBe('lazy')
   })
 })

--- a/apps/web/src/app/products/[slug]/page.tsx
+++ b/apps/web/src/app/products/[slug]/page.tsx
@@ -139,7 +139,15 @@ export default async function Page({
             alt={product.name}
             width={550}
             height={550}
-            sizes="(min-width: 1024px) 550px, 100vw"
+            // `max-w-[550px]` caps the box, so it stops growing once the
+            // container can hold 550 — from 574px of viewport, not from the
+            // lg breakpoint the old value keyed on. Between the two it claimed
+            // the whole viewport for a 550px box and pulled w=1080.
+            //
+            // Spaces inside the parens: next/image finds the viewport
+            // percentage with /(^|\s)(1?\d?\d)vw/ to trim the srcset, and
+            // `calc(100vw` hides it behind a paren.
+            sizes="(min-width: 574px) 550px, calc( 100vw - 24px )"
             className="rounded-3xl w-full h-auto max-w-[550px] lg:mr-6"
           />
           <div

--- a/apps/web/src/app/products/category/[slug]/page.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.tsx
@@ -51,10 +51,21 @@ export default async function CategoryPage({
                     alt={product.name}
                     width={350}
                     height={350}
-                    // 400px, not the 350 the width prop names: the three-column
-                    // grid gives each card a 397px box at 1440, so 350 asks for
-                    // an asset that then has to be upscaled to fill it.
-                    sizes="(min-width: 1024px) 400px, (min-width: 640px) 45vw, 90vw"
+                    // The card is the container split by the column count, less
+                    // the gaps and the container's own padding — so it tracks
+                    // the viewport between each breakpoint and only settles
+                    // once the container stops growing at xl.
+                    //
+                    // The previous value was a single 400px measured at 1440.
+                    // That is the top of the three-column range; at 1024 the
+                    // same card is 317px, so it pulled w=640 where w=384 covers
+                    // it. Deriving a `sizes` from one sampled width is the
+                    // mistake this replaces.
+                    //
+                    // Written as `100vw / 3` rather than `33.33vw` so that
+                    // next/image's /(^|\s)(1?\d?\d)vw/ can still find the
+                    // percentage and trim the srcset.
+                    sizes="(min-width: 1280px) 398px, (min-width: 1024px) calc( 100vw / 3 - 24px ), (min-width: 640px) calc( 50vw - 24px ), calc( 100vw - 24px )"
                     className="h-full w-full object-cover object-center group-hover:opacity-75 transition-opacity"
                   />
                 ) : (


### PR DESCRIPTION
Closes #166. Two `sizes` attributes described boxes that do not exist.

## Product detail

`(min-width: 1024px) 550px, 100vw` → `(min-width: 574px) 550px, calc( 100vw - 24px )`

The image carries `max-w-[550px]`, so the box stops growing once the container can hold 550 — at **574px of viewport**, not at the `lg` breakpoint the old value keyed on. Between the two it claimed the whole viewport for a 550px box:

| viewport | box | before | after |
| --- | --- | --- | --- |
| 768 | 550 | w=828 | w=640 |
| 834–900 | 550 | w=1080 | w=640 |

w=1080 is 149 KiB and w=640 is 49 KiB, and there are 3–6 of these per product page.

## Category grid

A single `400px` → four clauses derived from the container arithmetic.

The card is the container split by the column count, less the gaps and the container's own padding, so it tracks the viewport between each breakpoint and only settles once the container stops growing at `xl`. The old value was one number I measured at 1440 in #159 — the top of the three-column range. At 1024 the same card is **317px**, so it pulled w=640 where w=384 covers it.

Repeating that method here would have been the same mistake with a different number, so every box was measured against the formula at 18 widths before either value was written. `ui-review` then confirmed both across **1,181 widths** — exact everywhere, including 639/640/641 where the grid goes one to two columns and 1279/1280 where the container caps.

`100vw / 3` rather than `33.33vw`: `next/image` finds the viewport percentage with `/(^|\s)(1?\d?\d)vw/` to trim the srcset, and a decimal matches as `33vw`, setting a ratio a third of the truth.

## This is not a pure win, and the issue implies it is

Around **817–853px the category grid gets heavier** — 262 KiB → 632 KiB across 14 images at 834.

The old `45vw` understated a 393px box as 375, so the browser took the 384 rung and upscaled it 2.3% — imperceptible, and cheap. The honest value declares 393, and the next rung up is 640. Accuracy costs 63% more pixels in that band.

The value stays accurate; the driver is the **384→640 gap in the ladder**, filed as #168 along with a second limit it exposed: any `sizes` whose narrowest clause is `100vw` gets every rung below 640 filtered out, so the detail page can never serve below `w=640` even at 390px. The spec is blind to that by construction — it asserts the smallest rung *offered*.

Confirmed wins for balance: detail at 834/1× **−336 KiB (−67%)**, detail at 390/2× **−31 KiB**.

## The spec

Now sweeps three surfaces at 1× and 2×, fresh context per measurement. Each surface resolves its path once — the category slug from `/categories.json`, because nothing on the home page links to a category, which is why `browse.spec.ts` carries a fallback. That file is the seed input rather than a parallel copy, so the slug cannot rot against the database.

Its vacuity guard now compares the parsed rung list against the srcset's own candidate count instead of a floor. A floor was wrong in both directions: coupled to the encoding contract, which may narrow the ladder without saying anything about `sizes`, or low enough to miss a parse that dropped rungs. Verified by breaking the parse — both floors passed, the comparison failed.

## Corrections during review

- A stale `deliveryOf(page, 'Our Mission')` survived an earlier refactor of that helper. A real arity mismatch, and **nothing in this repo type-checks e2e specs** — filed as #170.
- I lowered the vacuity floor from `> 3` to `> 1` after being told the detail ladder had "zero margin" at 4 rungs. It doesn't — 4 > 3 passes. I gave up detection to fix a failure that wasn't happening, which is what led to removing the number entirely.

## Verification

`make -C apps/web quick-ci` (115 tests, 33 files), `make test-scripts` (142), **29/29 Playwright** against a real seeded stack, and the two surfaces confirmed failing without the fix at exactly 19 cases. `test.slow()` became an explicit 3-minute timeout: the slowest surface takes 48s locally against a 90s budget, and CI runs this in the container on a shared vCPU where the optimiser's resizes are the bottleneck.

## Also filed

- **#168** — the ladder gap, and the unreachable sub-640 rungs
- **#169** — both these pages lazy-load their above-fold LCP image, the defect #157 fixed on `/about`
- **#170** — e2e specs are never type-checked
- **#171** — the home grid has the same defect on a third surface, visible only at 2× between 640 and ~1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)