### PR TITLE
perf(web): size the home grid images to the boxes they occupy

### DIFF
--- a/apps/web/e2e/image-delivery.spec.ts
+++ b/apps/web/e2e/image-delivery.spec.ts
@@ -21,9 +21,19 @@ import { test, expect, type Page } from '@playwright/test'
  * common desktop windows; those land on a box just above the 384 rung, which is
  * where a too-loose assertion hides. 640, 1024 and 1280 are grid breakpoints,
  * and 1224 is where a category card crosses 384 on its own.
+ *
+ * 1015 and 1016 are where a home card crosses 320, so a `sizes` that overstates
+ * it by under a pixel still tips those two into the next rung at 2x — a real
+ * defect that survived a first fix because nothing sat between 1024 and 1152.
+ * 1017
+ * is the width after it, where the card is 320.328 and genuinely does need the
+ * larger rung: it fails if the box is rounded before being scaled by density,
+ * which is the other way to get this wrong. 1105 and 1106 sit either side of
+ * the home grid's 350px cap engaging.
  */
 const WIDTHS = [
-  390, 412, 414, 430, 574, 640, 768, 834, 841, 860, 900, 1024, 1152, 1224, 1280, 1440,
+  390, 412, 414, 430, 574, 640, 768, 834, 841, 860, 900, 1015, 1016, 1017, 1024, 1105, 1106,
+  1152, 1224, 1280, 1440,
 ]
 
 /** Densities to exercise. Most traffic is not 1x, and 1x cannot see this. */
@@ -44,6 +54,7 @@ const DENSITIES = [1, 2]
  */
 const SURFACES = [
   { name: 'about mission', resolve: async () => '/about' },
+  { name: 'home grid', resolve: async () => '/' },
   {
     name: 'product detail',
     resolve: async (page: Page) => {
@@ -93,7 +104,11 @@ async function deliveryOf(page: Page): Promise<Delivery> {
     if (!image) throw new Error('no optimised image on the page')
     const candidates = (image.srcset || '').split(',').filter((part) => part.trim())
     return {
-      box: Math.round(image.getBoundingClientRect().width),
+      // Unrounded. A grid column is routinely fractional — 320.328px at one
+      // width here — and rounding it down before multiplying by the density
+      // understates the need by up to half a device pixel, which is enough to
+      // expect the rung below the one the browser correctly chose.
+      box: image.getBoundingClientRect().width,
       requested: Number((image.currentSrc || '').match(/[?&]w=(\d+)/)?.[1]) || null,
       offered: candidates.length,
       ladder: candidates
@@ -120,13 +135,19 @@ const expectedRung = (ladder: number[], box: number, density: number): number =>
 test.describe('image delivery', () => {
   for (const surface of SURFACES) {
     test(`the ${surface.name} image is sized to its box`, async ({ browser }, testInfo) => {
-      // Thirty-two cold page loads, one per width and density, each making the
-      // optimiser resize for a combination it has not cached. Locally the
-      // slowest surface takes 48s; `test.slow()` would allow 90s, and CI runs
-      // this inside the container on a shared vCPU where those resizes are the
-      // bottleneck — near enough to the limit to time out under load rather
-      // than fail for a reason worth reading.
-      test.setTimeout(180_000)
+      // One cold browser context per width and density, so 42 page loads a
+      // surface. The cost is the loads, not the resizing: the optimiser caches
+      // to disk across the whole run, so the home grid's 20 images resolve to
+      // about 50 distinct resizes against some 600 requests. What differs
+      // between surfaces is how many subresources each load waits on — 15 on
+      // the home grid against 1 on the about page — which is why home takes
+      // ~80s locally where about takes ~38.
+      //
+      // The e2e job took 8.4 minutes with one surface and 9.7 with three,
+      // against a 35-minute job budget, so the job has room and this cap is the
+      // only real exposure. 240s is three times the slowest local surface, on a
+      // shared CI vCPU.
+      test.setTimeout(240_000)
 
       const overfetched: Record<string, string> = {}
 
@@ -175,7 +196,9 @@ test.describe('image delivery', () => {
 
             const expected = expectedRung(ladder, box, density)
             if (requested !== expected) {
-              overfetched[at] = `${box}px box at ${density}x asked for w=${requested}, expected w=${expected}`
+              overfetched[at] =
+                `${box.toFixed(2)}px box at ${density}x needs ${Math.ceil(box * density)}, ` +
+                `asked for w=${requested}, expected w=${expected}`
             }
           } finally {
             // A context from the `browser` fixture is not closed for us, and an

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -79,10 +79,25 @@ export default async function Home() {
                     alt={product.name}
                     width={350}
                     height={350}
-                    // The box is fluid now, so the srcset has to be told about
-                    // it — keyed to the fixed 350px it serves a 384px asset
-                    // into a 175px slot on a phone.
-                    sizes="(min-width: 640px) 350px, 45vw"
+                    // 350px is the cap, not the box. The `minmax(0, 350px)`
+                    // tracks only reach it once the container can hold three of
+                    // them plus the gaps — from 1106px of viewport. Below that
+                    // the card tracks the viewport, and declaring 350 made a 2x
+                    // screen fetch w=750 where w=640 covers it, everywhere from
+                    // 640 to about 1016.
+                    //
+                    // So: the container less its gaps, over the column count,
+                    // with the fixed value only where the cap engages.
+                    //
+                    // The last clause has to keep a literal `50vw`. Next reads
+                    // the srcset's floor off the smallest `vw` token it can find
+                    // with /(^|\s)(1?\d?\d)vw/ — it never sees the arithmetic
+                    // around it. With `50vw` the floor is 320 and the ladder
+                    // starts at 384; write it as `( 100vw - 40px ) / 2` and Next
+                    // reads 100vw, drops every rung below 640, and a 175px phone
+                    // card fetches w=640. The middle clause's `100vw` is
+                    // harmless only because this one is here.
+                    sizes="(min-width: 1106px) 350px, (min-width: 640px) calc( ( 100vw - 56px ) / 3 ), calc( 50vw - 20px )"
                     // w-full so the image scales into its column: at its
                     // intrinsic 350px it overflows one instead.
                     className="rounded-3xl w-full h-auto"


### PR DESCRIPTION
Closes #171.

`350px` is the cap, not the box. The `minmax(0, 350px)` tracks only reach it once the container can hold three of them plus the gaps — from **1106px** of viewport. Below that the card tracks the viewport, so declaring 350 made a 2× screen fetch `w=750` where `w=640` covers it, everywhere from 640 to about 1016.

| viewport | card | before (2×) | after (2×) |
| --- | --- | --- | --- |
| 640 | 195 | w=750 | w=640 |
| 834 | 259 | w=750 | w=640 |
| 900 | 281 | w=750 | w=640 |
| 1016 | 320 | w=750 | w=640 |

At the worst case the new bytes are **1.8× sharper and 24% smaller** — the old path encoded at 750 and let the browser resample down to 640, two resamples for a softer result.

## The value was wrong twice first, and both were correct at every width I sampled

**`calc( ( 100vw - 40px ) / 2 )`** — arithmetically exact. But Next reads the srcset floor off the smallest `vw` *token* with `/(^|\s)(1?\d?\d)vw/` and never sees the division, so it read `100vw`, filtered every rung below 640 out of the ladder, and a 175px phone card fetched `w=640` instead of `w=384`.

**The spec passed on it.** It asserts the request is the smallest rung *offered* — so trimming the ladder makes the assertion easier to satisfy, not harder. I caught it by noticing the srcset had lost a rung. Recorded on #168.

**`calc( 33.4vw - 18.7px )`** — switched to a decimal to make the token honest. That regex cannot start at a digit preceded by `.`, so it matched nothing and the floor was coming from the tail `50vw` all along; my comment described a mechanism that was not operating. And the 0.33–0.70px over-declaration still tipped **1015 and 1016 at 2×** into `w=750` — the very bug this closes, surviving at the top of its own range, in a gap the sweep stepped over.

**Shipped:** the exact `( 100vw - 56px ) / 3` for the middle clause, and a literal `50vw` in the tail whose only job is to hold the floor at 384. Verified against Next's parser, and swept 320–1120 at both densities with zero mismatches.

What caught each attempt was a reviewer sweeping 1,181 and then 1,602 widths — not my sampling, twice.

## The spec

Home is now a fourth surface, and the box is no longer rounded before being scaled by density. At 1017 the card is 320.328 and genuinely needs the larger rung; a rounded 320 would have called the browser's correct `w=750` an overfetch. That width is in the sweep now, and confirmed to fail under the old rounded logic.

`test.setTimeout(240_000)` with the cost measured rather than guessed: **91% of the optimiser requests are cache hits** (594 requests, 51 distinct keys), so the cost is the cold contexts and their subresources — 15 per load on home against 1 on about — not resize work. My first explanation for that 80 seconds was wrong, so it is now the measured one.

## Filed rather than folded in

- **#173** — the home surface's entire 1× pass has no red phase. Every swept width expects `w=384` and gets it under the shipped value, the old value, *and* both broken intermediates. Half that surface's runtime asserts something that never failed for the bug it was added to catch. The fix is per-surface widths and densities, which also makes the timeout comfortable again.
- **#174** — all four `sizes` values correct `100vw` by a pixel constant, but `100vw` includes a classic scrollbar while the container does not. Playwright hides scrollbars, so the whole class of skew is invisible to the spec that guards them.
- **#168** gained a note that the ladder-floor convention now has to hold in four separate strings, protected only by prose — and that the most tempting edit in each regresses phone delivery while leaving the suite green.

## Verification

`make -C apps/web quick-ci` (115 tests, 33 files), **30/30 Playwright** against a real seeded stack with row counts asserted rather than trusted, a 1,602-sample sweep at both densities, and the ladder-floor mechanism confirmed against Next's source rather than my description of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)