### PR TITLE
fix(web): make the chat panel modal below sm

### DIFF
--- a/apps/web/e2e/chat-modality.spec.ts
+++ b/apps/web/e2e/chat-modality.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * The chat panel is modal below `sm` and is not modal at `sm` and up.
+ *
+ * That asymmetry is the whole point, so both halves are asserted. At 390 the
+ * panel fills the viewport, so everything behind it is obscured and a focus
+ * stop landing there is WCAG 2.2 2.4.11 Focus Not Obscured (Minimum), Level AA
+ * -- 26 of 43 stops did. At 1440 the panel occupies a corner, the page around
+ * it is genuinely usable, and trapping focus there would take the site
+ * navigation away for no reason.
+ *
+ * A test that only pinned the 390 half would pass just as happily if the panel
+ * became modal everywhere, which is the fix #112's reviewers rejected.
+ */
+
+const PHONE = { width: 390, height: 844 }
+const DESKTOP = { width: 1440, height: 900 }
+
+type Stop = {
+  /** Inside the chat widget -- the panel or its launcher. */
+  inWidget: boolean
+  /** Covered by something else at its own centre point. */
+  obscured: boolean
+  label: string
+}
+
+/**
+ * One full Tab cycle, classified.
+ *
+ * Bounded rather than run until it revisits the first element: with no trap the
+ * cycle is 43 stops and passes through browser-owned stops that report nothing
+ * useful, and a loop that waits for an exact repeat can miss the wrap and run
+ * forever.
+ */
+async function tabCycle(page: Page, presses: number): Promise<Stop[]> {
+  const stops: Stop[] = []
+  for (let i = 0; i < presses; i += 1) {
+    await page.keyboard.press('Tab')
+    const stop = await page.evaluate(() => {
+      const element = document.activeElement as HTMLElement | null
+      if (!element || element === document.body) return null
+
+      const dialog = document.querySelector('[role="dialog"]')
+      const widget = dialog?.parentElement ?? null
+
+      // Covered at its centre point, which is deliberately stricter than the
+      // success criterion: 2.4.11 (Minimum) is failed only when a control is
+      // *entirely* hidden, and this fires on partial coverage too.
+      //
+      // Stricter is the right bar here because of what the fix makes true —
+      // every stop ends up inside the panel, and the panel is the topmost
+      // thing, so zero is reachable and any non-zero result is a real defect
+      // rather than a tolerated near-miss. It is not a general 2.4.11 oracle,
+      // and at 1440 it reports 16 stops that are only partly covered. See #183.
+      const box = element.getBoundingClientRect()
+      const x = box.left + box.width / 2
+      const y = box.top + box.height / 2
+      const onTop =
+        box.width > 0 && box.height > 0 ? document.elementFromPoint(x, y) : element
+      const obscured = !!onTop && onTop !== element && !element.contains(onTop)
+
+      return {
+        inWidget: !!widget && widget.contains(element),
+        obscured,
+        label: `${element.tagName.toLowerCase()}${
+          element.getAttribute('aria-label') ? `[${element.getAttribute('aria-label')}]` : ''
+        }`,
+      }
+    })
+    if (stop) stops.push(stop)
+  }
+  return stops
+}
+
+async function openChat(page: Page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Open chat' }).click()
+  await expect(page.getByRole('dialog', { name: /chat/i })).toBeVisible()
+}
+
+test.describe('chat panel modality', () => {
+  test('below sm the panel is modal', async ({ page }) => {
+    await page.setViewportSize(PHONE)
+    await openChat(page)
+
+    const dialog = page.getByRole('dialog', { name: /chat/i })
+
+    // All four parts, because half of this is worse than none of it:
+    // `aria-modal` without a trap tells assistive technology something false,
+    // and a trap without `inert` leaves the covered controls clickable.
+    await expect(dialog, 'the panel does not claim containment below sm').toHaveAttribute(
+      'aria-modal',
+      'true',
+    )
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'page content behind the panel is not inert below sm',
+    ).toBe(true)
+
+    // A sheet that has covered the whole site has to say what it is. The panel
+    // carried no heading at all while the document behind it had eight.
+    await expect(
+      dialog.getByRole('heading', { name: 'Chat with Jane Doe' }),
+      'the sheet has no visible title',
+    ).toBeVisible()
+
+    // Exactly one, not "at least one". The header close and the launcher are
+    // both named "Close chat", and rendering both would be ambiguous to a
+    // screen reader and unaddressable by name here.
+    await expect(
+      page.getByRole('button', { name: 'Close chat' }),
+      'more than one control is named "Close chat" below sm',
+    ).toHaveCount(1)
+
+    const stops = await tabCycle(page, 50)
+
+    // Vacuity guard. Every assertion below holds trivially over an empty
+    // cycle, and an empty cycle is also what a panel that failed to open
+    // produces -- which is a different bug reported as a pass.
+    expect(stops.length, 'the Tab cycle recorded no focus stops at all').toBeGreaterThan(2)
+
+    expect(
+      stops.filter((stop) => stop.obscured).map((stop) => stop.label),
+      'focus stops landing on controls painted over at their centre',
+    ).toEqual([])
+
+    // Caught by `inert`, not by the focus trap. Disabling the trap leaves this
+    // green, because inert content is out of the tab order altogether — so read
+    // this as "the page behind is inert and stays inert", and see the comment
+    // on the trap in `chat.tsx` for what nothing here covers.
+    expect(
+      stops.filter((stop) => !stop.inWidget).map((stop) => stop.label),
+      'focus escaped the chat widget while it was modal',
+    ).toEqual([])
+  })
+
+  test('at sm and up the panel is not modal', async ({ page }) => {
+    await page.setViewportSize(DESKTOP)
+    await openChat(page)
+
+    const dialog = page.getByRole('dialog', { name: /chat/i })
+
+    await expect(
+      dialog,
+      'the panel claims containment at a width where it does not contain',
+    ).not.toHaveAttribute('aria-modal', 'true')
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'page content is inert at a width where the panel covers only a corner',
+    ).toBe(false)
+
+    // The card keeps the launcher as its close control, so the header one must
+    // not also be here. The count is what makes this the complement of the 390
+    // assertion rather than a weaker restatement of it.
+    await expect(
+      page.getByRole('button', { name: 'Close chat' }),
+      'more than one control is named "Close chat" at 1440',
+    ).toHaveCount(1)
+
+    const stops = await tabCycle(page, 50)
+    expect(stops.length, 'the Tab cycle recorded no focus stops at all').toBeGreaterThan(2)
+
+    // The complement of the test above, and the reason this file has two. The
+    // site navigation has to stay reachable here.
+    expect(
+      stops.some((stop) => !stop.inWidget),
+      'focus never left the chat widget at 1440, so the panel is trapping everywhere',
+    ).toBe(true)
+  })
+
+  test('modality follows a resize while the panel is open', async ({ page }) => {
+    // The breakpoint is not only a first-paint decision. Rotating a phone, or
+    // dragging a desktop window narrow, has to move the panel between the two
+    // contracts -- and leaving `inert` behind on the way out would strand the
+    // page unusable with no dialog on screen to explain why.
+    await page.setViewportSize(DESKTOP)
+    await openChat(page)
+
+    await page.setViewportSize(PHONE)
+    await expect(page.getByRole('dialog', { name: /chat/i })).toHaveAttribute(
+      'aria-modal',
+      'true',
+    )
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'narrowing to phone width did not make the page content inert',
+    ).toBe(true)
+
+    await page.setViewportSize(DESKTOP)
+    await expect(page.getByRole('dialog', { name: /chat/i })).not.toHaveAttribute(
+      'aria-modal',
+      'true',
+    )
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'widening back to desktop left the page content inert',
+    ).toBe(false)
+  })
+
+  test('closing the panel releases the page', async ({ page }) => {
+    // `inert` outlives the thing that set it if the cleanup is keyed on the
+    // wrong dependency. The symptom is a page that cannot be clicked or tabbed
+    // with nothing visible to blame.
+    await page.setViewportSize(PHONE)
+    await openChat(page)
+    await page.getByRole('button', { name: 'Close chat' }).click()
+
+    await expect(page.getByRole('dialog', { name: /chat/i })).toHaveCount(0)
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'the page is still inert after the panel closed',
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/components/chat.test.tsx
+++ b/apps/web/src/components/chat.test.tsx
@@ -9,6 +9,25 @@ vi.mock('next-auth/react', () => ({
 // jsdom does not implement scrollTo; the component calls it after each turn.
 beforeEach(() => {
   Element.prototype.scrollTo = vi.fn()
+
+  // Desktop by default, which is the width every test below this line was
+  // written against — the panel as a corner card, non-modal, launcher present.
+  //
+  // Without this they inherit the stub in `src/test/setup.ts`, which reports
+  // "no match" for everything; for a `min-width` query that means compact, so
+  // the whole pre-existing suite would silently move to the modal sheet variant
+  // and desktop would be exercised by nothing. `Chat modality` overrides this
+  // per test.
+  window.matchMedia = ((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia
 })
 
 const sendChatMessage = vi.fn()
@@ -639,5 +658,226 @@ describe('Chat placeholder timing', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+/**
+ * Modality below `sm` only.
+ *
+ * The e2e spec is where the fix is really proven, because obscuring is a
+ * question about painted pixels and jsdom paints nothing. What is worth
+ * asserting here is the part that is pure state: which of the four modal
+ * behaviours are attached, on which side of the breakpoint, and whether they
+ * come off again.
+ */
+describe('Chat modality', () => {
+  // The component inerts its own *siblings*, so the fixture has to put one
+  // there. This mirrors the root layout, where <main> and <Chat> sit together
+  // inside one flex container.
+  //
+  // Getting this wrong is silent in the useful direction: with `behind`
+  // somewhere else in the tree it simply never receives `inert`, and the test
+  // fails saying so rather than passing on a structure the app does not have.
+  function renderInLayout() {
+    const parent = document.createElement('div')
+    document.body.appendChild(parent)
+    render(<Chat />, { container: parent })
+    // After `render`, not before: React takes ownership of the container and
+    // clears it, so a sibling added first is gone by the time the panel exists.
+    // Still before the panel opens, though — the effect reads the sibling list
+    // once, when the panel becomes modal.
+    const behind = document.createElement('main')
+    behind.innerHTML = '<a href="/products">a product</a>'
+    parent.appendChild(behind)
+    return { parent, behind, cleanup: () => parent.remove() }
+  }
+
+  // A controllable `matchMedia`, replacing the always-false one in setup.ts.
+  // The component asks for `(min-width: 640px)` and treats a non-match as
+  // compact, so `matches` is the inverse of the thing being described.
+  //
+  // One object per mount, with a live getter: the component captures the
+  // MediaQueryList once and re-reads `matches` when a change fires, so a
+  // harness that swapped in a fresh object would leave it reading the old one
+  // forever — and would report that as the component ignoring resizes.
+  function useViewport(compact: boolean) {
+    const state = { compact }
+    const listeners = new Set<() => void>()
+    window.matchMedia = ((query: string) => ({
+      get matches() {
+        return !state.compact
+      },
+      media: query,
+      onchange: null,
+      addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+      removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+    return {
+      resizeTo(nowCompact: boolean) {
+        state.compact = nowCompact
+        act(() => {
+          listeners.forEach((listener) => listener())
+        })
+      },
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('claims containment and inerts the page below sm', () => {
+    useViewport(true)
+    const { behind, cleanup } = renderInLayout()
+    openChat()
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+    expect(behind).toHaveAttribute('inert')
+    // Never the widget itself — that would take the panel down with the page.
+    expect(screen.getByRole('dialog').parentElement).not.toHaveAttribute('inert')
+
+    cleanup()
+  })
+
+  it('claims nothing at sm and up', () => {
+    useViewport(false)
+    const { behind, cleanup } = renderInLayout()
+    openChat()
+
+    // `role="dialog"` stays: it carries the accessible name and the grouping
+    // boundary. Only the containment claim is width-dependent.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-modal')
+    expect(behind).not.toHaveAttribute('inert')
+
+    cleanup()
+  })
+
+  it('releases the page when the panel closes', () => {
+    useViewport(true)
+    const { behind, cleanup } = renderInLayout()
+    openChat()
+    expect(behind).toHaveAttribute('inert')
+
+    // `inert` outliving the panel is the failure that leaves a page nothing can
+    // click and nothing on screen to explain why.
+    fireEvent.click(screen.getByRole('button', { name: 'Close chat' }))
+    expect(behind).not.toHaveAttribute('inert')
+
+    cleanup()
+  })
+
+  it('restores body scrolling when the panel closes', () => {
+    useViewport(true)
+    const { cleanup } = renderInLayout()
+
+    openChat()
+    expect(document.body.style.overflow).toBe('hidden')
+    fireEvent.click(screen.getByRole('button', { name: 'Close chat' }))
+    expect(document.body.style.overflow).toBe('')
+
+    cleanup()
+  })
+
+  it('releases the page when Escape closes the sheet', () => {
+    // The cleanups key off `isModal`, not off which control did the closing —
+    // but nothing demonstrated that, and every other release test clicks the
+    // button. A trigger-specific leak would leave the page unusable with no
+    // dialog on screen to blame.
+    useViewport(true)
+    const { behind, cleanup } = renderInLayout()
+    openChat()
+    expect(behind).toHaveAttribute('inert')
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(behind).not.toHaveAttribute('inert')
+    expect(document.body.style.overflow).toBe('')
+
+    cleanup()
+  })
+
+  it('wraps focus at both ends of the sheet', () => {
+    // The backward branch of the trap had no assertion pointed at it: the e2e
+    // spec only ever presses Tab forward, and 50 forward presses wrap the
+    // forward direction incidentally while never touching Shift+Tab.
+    //
+    // jsdom moves focus for neither, so this asserts the handler's own
+    // `focus()` calls rather than real tab navigation. That is the whole of
+    // what the handler contributes.
+    useViewport(true)
+    const { cleanup } = renderInLayout()
+    openChat()
+
+    const first = screen.getByRole('button', { name: 'Clear conversation' })
+    const last = screen.getByRole('button', { name: 'Send message' })
+
+    first.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    cleanup()
+  })
+
+  it('does not trap focus at sm and up', () => {
+    // The same keystroke that wraps on the sheet must do nothing on the card,
+    // or the site navigation is unreachable at desktop width — the outcome
+    // #112's reviewers rejected and the reason this is width-scoped at all.
+    useViewport(false)
+    const { cleanup } = renderInLayout()
+    openChat()
+
+    const first = screen.getByRole('button', { name: 'Clear conversation' })
+    first.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(first)
+
+    cleanup()
+  })
+
+  it('keeps focus inside the panel across a resize', () => {
+    // Widening unmounts the sheet's header close button. Focus sitting on it
+    // would otherwise land on <body>, and the next Tab restarts at the top of
+    // the document — 24 stops back, the same failure open and close already
+    // guard against.
+    const viewport = useViewport(true)
+    const { cleanup } = renderInLayout()
+    openChat()
+
+    screen.getByRole('button', { name: 'Close chat' }).focus()
+    viewport.resizeTo(false)
+
+    expect(document.activeElement).not.toBe(document.body)
+    expect(screen.getByRole('dialog').contains(document.activeElement)).toBe(true)
+
+    cleanup()
+  })
+
+  it('follows a resize across the breakpoint while open', () => {
+    const viewport = useViewport(false)
+    const { behind, cleanup } = renderInLayout()
+    openChat()
+    expect(behind).not.toHaveAttribute('inert')
+
+    // Narrowing with the panel already open. Modality is not only a decision
+    // made at first paint — rotating a phone crosses this line.
+    viewport.resizeTo(true)
+    expect(behind).toHaveAttribute('inert')
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+
+    // And back, because a trap left behind at desktop width is the regression
+    // that would make this whole change worse than not doing it.
+    viewport.resizeTo(false)
+    expect(behind).not.toHaveAttribute('inert')
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-modal')
+
+    cleanup()
   })
 })

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -54,13 +54,150 @@ export const Chat = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const launcherRef = useRef<HTMLButtonElement>(null);
+  const widgetRef = useRef<HTMLDivElement>(null);
   const greetingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Below `sm` the panel is a full-screen sheet, so it really does contain the
+  // user and says so. At `sm` and up it occupies a corner, the rest of the page
+  // is usable, and trapping focus would take the site navigation away.
+  //
+  // `false` until mounted, so the server and the first client render agree.
+  // Only the semantics depend on this; the sheet itself is `max-sm:` CSS and is
+  // right from first paint whether or not this has run.
+  const [isCompact, setIsCompact] = useState(false);
+
+  // The exact complement of Tailwind's `sm:`, expressed as its own query rather
+  // than a `max-width` with an epsilon, so a fractional viewport cannot land
+  // between the two and satisfy neither. `tailwind.config.ts` sets no `screens`
+  // override, so 640px is Tailwind's default and these two must move together.
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 640px)");
+    const sync = () => setIsCompact(!query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  const isModal = showChat && isCompact;
+
+  // The other three parts of being modal. All of them keyed on `isModal`, so a
+  // resize past the breakpoint with the panel open moves it between the two
+  // contracts rather than stranding it half-way — `aria-modal` without a trap
+  // tells assistive technology something false, and a trap without `inert`
+  // leaves the covered controls clickable.
+
+  // Everything beside the widget, found through the DOM rather than by tag: the
+  // widget's siblings are whatever the root layout puts next to it, and naming
+  // `main` here would silently stop covering the page the day that changes.
+  useEffect(() => {
+    if (!isModal) return;
+    const parent = widgetRef.current?.parentElement;
+    if (!parent) return;
+    const behind = Array.from(parent.children).filter(
+      (child): child is HTMLElement =>
+        child instanceof HTMLElement && child !== widgetRef.current
+    );
+    behind.forEach((element) => element.setAttribute("inert", ""));
+    return () => behind.forEach((element) => element.removeAttribute("inert"));
+  }, [isModal]);
+
+  // `inert` blocks pointer and focus but not scrolling, so without this the
+  // page slides around behind a sheet that covers all of it.
+  useEffect(() => {
+    if (!isModal) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isModal]);
+
+  // The trap covers the widget, not the panel: the launcher sits outside the
+  // dialog and is the close control, so a trap scoped to `panelRef` would make
+  // the one thing that dismisses the sheet the one thing Tab cannot reach.
+  //
+  // What this is for is narrower than it looks. `inert` above is what keeps
+  // focus off the obscured page — those elements leave the tab order entirely —
+  // so containment is not this block's job and the e2e spec's "nothing escaped
+  // the widget" assertion stays green without it. Measured, not assumed.
+  //
+  // What is covered: both wrap branches, by `wraps focus at both ends of the
+  // sheet` in chat.test.tsx, and their absence at desktop by `does not trap
+  // focus at sm and up`. Delete this effect and those go red.
+  //
+  // What is not covered by anything: the recovery branch below, for focus that
+  // is already outside the widget — removing that alone leaves the whole suite
+  // green. Nor is the case it exists for, Tab from the last control stepping
+  // into the browser's own chrome rather than back to the top of the sheet,
+  // which Playwright cannot see because it never leaves the page. Nor is
+  // degradation where `inert` is unsupported, which is the only reason
+  // containment does not rest on a single API.
+  useEffect(() => {
+    if (!isModal) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const widget = widgetRef.current;
+      if (!widget) return;
+      const focusable = Array.from(
+        widget.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      // Focus already outside the widget — a click on inert content cannot put
+      // it there, but the address bar can — so the next Tab returns rather than
+      // continuing through the page.
+      if (!widget.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isModal]);
 
   // Opening the panel left focus on the launcher, so the next Tab continued
   // into the page behind it rather than into the conversation.
   useEffect(() => {
     if (showChat) inputRef.current?.focus();
   }, [showChat]);
+
+  // Focus return, after the close rather than during it. Below `sm` the
+  // launcher is unmounted while the sheet is open, so a `focus()` inside the
+  // close handler runs against an element that is not in the document yet and
+  // silently drops focus to <body> — which is the bug moving focus in on open
+  // was added to fix, in the other direction. One mechanism rather than two, so
+  // both the Escape path and the button path go through here.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (wasOpen.current && !showChat) launcherRef.current?.focus();
+    wasOpen.current = showChat;
+  }, [showChat]);
+
+  // Crossing the breakpoint unmounts whichever close control belonged to the
+  // side being left — the sheet's header button on the way up, the launcher on
+  // the way down. With focus parked on it, focus falls to <body> and the next
+  // Tab restarts at the top of the document, which is the failure this
+  // component has already fixed on open and on close, arriving by a third
+  // route. Declared after the two effects above so it sees where they left
+  // focus rather than racing them.
+  useEffect(() => {
+    if (!showChat) return;
+    if (widgetRef.current?.contains(document.activeElement)) return;
+    panelRef.current?.focus();
+  }, [isCompact, showChat]);
 
   // Bound to the document so Escape works wherever focus sits inside the
   // panel, but scoped to events originating within it. Unscoped, Escape while
@@ -75,7 +212,6 @@ export const Chat = () => {
       const onLauncher = launcherRef.current === target;
       if (!inPanel && !onLauncher) return;
       setShowChat(false);
-      launcherRef.current?.focus();
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
@@ -212,8 +348,9 @@ export const Chat = () => {
     if (showChat) {
       // Closing dropped focus to <body>, so the next Tab restarted at the top
       // of the document — 24 stops back to this launcher. Moving focus in on
-      // open is only half the contract.
-      launcherRef.current?.focus();
+      // open is only half the contract. Returned by the effect above, which
+      // runs after the launcher is back in the document.
+      //
       // Cancel an unfired greeting. The open branch below guards on
       // turns.length, but a pending timer has not dispatched yet, so closing
       // and reopening inside 400ms — an ordinary impatient tap — schedules a
@@ -232,31 +369,80 @@ export const Chat = () => {
 
   return (
     <>
-      <div className="fixed bottom-0 right-0 mr-4 mb-4 sm:mr-12 sm:mb-12 z-10 flex flex-col items-end">
+      <div
+        ref={widgetRef}
+        className="fixed bottom-0 right-0 mr-4 mb-4 sm:mr-12 sm:mb-12 z-10 flex flex-col items-end"
+      >
         {showChat && (
+          // Two shapes, not one shape with overrides. Below `sm` a sheet, at
+          // `sm` and up a card, and the two sets of classes do not intersect —
+          // a base `rounded-lg` that `max-sm:rounded-none` has to win against
+          // depends on which variant Tailwind emits later, which is not
+          // something this file should be betting on.
+          //
           // Width was a flat w-[650px]. At 390px the panel rendered at
           // left:-308, clipping message text outside the viewport entirely.
           // dvh rather than vh so mobile browser chrome does not push the input
-          // below the fold.
+          // below the fold, and `top`/`height` rather than `inset-0` so the two
+          // do not over-constrain each other.
           <div
             ref={panelRef}
             role="dialog"
             aria-label="Chat with Jane Doe"
+            // Only where it is true. `role="dialog"` is not a claim of
+            // containment; this is.
+            aria-modal={isCompact ? true : undefined}
             tabIndex={-1}
-            className="mb-3 flex flex-col shadow-md bg-white rounded-lg outline-none
-                       w-[min(650px,calc(100vw-2rem))]
+            className="flex flex-col bg-white outline-none
+                       max-sm:fixed max-sm:inset-x-0 max-sm:top-0
+                       max-sm:h-[100dvh] max-sm:w-full
+                       sm:mb-3 sm:shadow-md sm:rounded-lg
                        sm:w-[min(650px,calc(100vw-7rem))]
-                       h-[calc(100dvh-6rem)] sm:h-[calc(100vh-7rem)]"
+                       sm:h-[calc(100vh-7rem)]"
           >
-            <div className="p-2 flex justify-end">
+            <div className="p-2 flex items-center gap-1 max-sm:border-b max-sm:border-zinc-200">
+              {/*
+                A sheet has to introduce itself. A corner card can borrow
+                identity from the page around it; this one has covered that
+                page, and without a title the whole surface carried no heading
+                at all while the document behind it had eight.
+              */}
+              {isCompact && (
+                <h2 className="pl-2 grow text-base font-semibold text-zinc-900">
+                  Chat with Jane Doe
+                </h2>
+              )}
               <button
                 type="button"
                 onClick={reset}
                 aria-label="Clear conversation"
-                className="p-2 rounded-md hover:bg-zinc-100 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+                className="ml-auto p-2 rounded-md hover:bg-zinc-100 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
               >
                 <ArrowPathIcon className="w-5 stroke-zinc-500" aria-hidden="true" />
               </button>
+              {/*
+                Dismissal belongs in the header on a sheet, and rendered on
+                `isCompact` rather than hidden with `sm:hidden` so that exactly
+                one control is named "Close chat" at any width — two would be
+                ambiguous to a screen reader and unaddressable by name in tests,
+                and a CSS-hidden one is still present in jsdom, where no
+                stylesheet runs.
+
+                It also un-crowds the bottom right. The launcher used to float
+                over the sheet 20px below the send button: two icon-only
+                controls of near-identical size in one column, where a mis-tap
+                discards the message being composed.
+              */}
+              {isCompact && (
+                <button
+                  type="button"
+                  onClick={toggleChat}
+                  aria-label="Close chat"
+                  className="p-2 rounded-md hover:bg-zinc-100 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+                >
+                  <XMarkIcon className="w-5 stroke-zinc-500" aria-hidden="true" />
+                </button>
+              )}
             </div>
             {/* chat section */}
             <div
@@ -304,18 +490,33 @@ export const Chat = () => {
             </div>
           </div>
         )}
-        <button
-          ref={launcherRef}
-          className="bg-white rounded-full p-2 shadow-lg hover:cursor-pointer"
-          onClick={toggleChat}
-          aria-label={showChat ? "Close chat" : "Open chat"}
-        >
-          {showChat ? (
-            <XMarkIcon className="w-6" />
-          ) : (
-            <ChatBubbleLeftRightIcon className="w-6" />
-          )}
-        </button>
+        {/*
+          Not rendered while the sheet is open, because the sheet's own header
+          is the way out there. Left in place it would be a second control named
+          "Close chat", and it would be behind the sheet in any case: the panel
+          is positioned below `sm` and this button is not, so it loses the paint
+          order regardless of where it sits in the source.
+
+          Only the state changes with width, not the element, so the launcher at
+          `sm` and up is exactly what it was.
+        */}
+        {!(isCompact && showChat) && (
+          <button
+            ref={launcherRef}
+            // Every other control in the widget styles its focus ring; this one
+            // was left on the browser default, and the focus trap makes it a
+            // stop that keyboard users land on every cycle.
+            className="bg-white rounded-full p-2 shadow-lg hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+            onClick={toggleChat}
+            aria-label={showChat ? "Close chat" : "Open chat"}
+          >
+            {showChat ? (
+              <XMarkIcon className="w-6" />
+            ) : (
+              <ChatBubbleLeftRightIcon className="w-6" />
+            )}
+          </button>
+        )}
       </div>
     </>
   );

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,6 +1,27 @@
 import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 
+// jsdom implements no media queries at all, so `window.matchMedia` is simply
+// absent and any component that asks about the viewport throws on mount rather
+// than failing an assertion.
+//
+// Reports "does not match" for everything, which for a `min-width` query means
+// the narrowest case. A test that cares which side of a breakpoint it is on
+// replaces this per-test — `chat.test.tsx` does — rather than relying on the
+// default meaning anything.
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia
+}
+
 // Mock next/router
 vi.mock('next/router', () => ({
   useRouter: () => ({


### PR DESCRIPTION
Closes #129.

At 390×844 the chat panel measured **358×748** — 92% of the width, 89% of the
height — and a full Tab cycle put **40 of 57 focus stops** on controls painted
over by it. WCAG 2.2 **2.4.11 Focus Not Obscured (Minimum)**, Level AA.

The panel *is* modal at phone width and *is not* at desktop width, and it
declared neither. #112 got the honest half right — `role="dialog"` without
`aria-modal` claims no containment, so nothing lied. It just did not move
2.4.11, because the obstruction is visual layering, not role.

## The decision

Modality becomes responsive, which is unusual enough to be worth stating: the
same component honours different contracts at different widths, and the parts
switch together and live, including on resize.

| | below `sm` (640px) | `sm` and up |
|---|---|---|
| shape | full-screen sheet | 650×788 corner card (unchanged) |
| `aria-modal` | `true` | absent |
| `inert` on siblings | yes | no |
| focus trap | yes | no |
| body scroll lock | yes | no |

A trap at desktop would take the site navigation away while the chat is open,
which is what #112's reviewers rejected.

| viewport | panel | obscured stops before | after |
|---|---|---|---|
| 390×844 | 358×748 → **390×844** | 40 of 57 | **0** |
| 1440×900 | 650×788 (unchanged) | — | unchanged |

## No scrim, though the issue lists one

Behind an opaque full-screen sheet a scrim is invisible, and `inert` already
blocks pointer and focus. It would be four lines that do nothing.

## Making it an actual sheet, not a card without margins

The rendered review caught three things that only matter once the panel owns the
whole viewport:

- **A visible `<h2>` title.** The panel carried no heading at all while the
  document it had just covered had eight.
- **Dismissal moved to the header.** The launcher used to float over the sheet
  20px below the send button — two icon-only controls of near-identical size in
  one column, where a mis-tap discards the message being composed. It is now not
  rendered while the sheet is open, so exactly one control is named "Close chat"
  at any width.
- **Focus return moved into an effect.** The launcher is unmounted at the moment
  the sheet closes, and `focus()` on an absent element silently drops focus to
  `<body>`. A second fallback covers crossing the breakpoint with focus on a
  control that the crossing unmounts.

## What the focus trap is and is not

`inert` is what provides containment — inert content leaves the tab order
entirely. Mutating the trap out leaves the e2e containment assertions green.

It is kept for Tab stepping into browser chrome (Playwright cannot see this: it
never leaves the page) and for degradation where `inert` is unsupported. The
comment on it names which of its branches are covered by tests and which are
not, rather than implying all of it is.

## Test environment

jsdom implements no media queries, so `src/test/setup.ts` grows a `matchMedia`
stub. `chat.test.tsx` pins desktop by default — without that the stub's
"no match" answer would have moved the entire pre-existing suite to the sheet
variant, leaving desktop exercised by nothing.

## Verification

`next build`, `tsc --noEmit`, repo-wide ESLint all clean. 124 vitest tests across
33 files, 38 Playwright tests, 142 Python guardrail tests — all pass. The new
spec ran 56 times with zero flakes.

Guards demonstrated against mutations rather than argued: modal-everywhere,
trap-at-desktop, inert-never-removed, launcher-rendered-while-modal,
scroll-lock-removed, resize-listener-dropped and the resize focus fallback each
turn a named test red.

## Known residual

2.4.11 still fails at 834 (5 of 23 stops) and 1440 (4 entirely hidden of 27).
Both follow directly from the non-modal decision at those widths — tracked in
 #183 with options. Also filed from the review: #184 (input ring and send border
at 1.48:1, failing 1.4.11) and #185 (error replies indistinguishable from real
answers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)