### PR TITLE
fix(web): move the chat modal boundary to lg and dismiss the card on focus-out

### DIFF
--- a/apps/web/e2e/chat-modality.spec.ts
+++ b/apps/web/e2e/chat-modality.spec.ts
@@ -1,20 +1,31 @@
 import { test, expect, Page } from '@playwright/test'
 
 /**
- * The chat panel is modal below `sm` and is not modal at `sm` and up.
+ * The chat panel is modal below `lg` and is not modal at `lg` and up.
  *
- * That asymmetry is the whole point, so both halves are asserted. At 390 the
- * panel fills the viewport, so everything behind it is obscured and a focus
- * stop landing there is WCAG 2.2 2.4.11 Focus Not Obscured (Minimum), Level AA
- * -- 26 of 43 stops did. At 1440 the panel occupies a corner, the page around
- * it is genuinely usable, and trapping focus there would take the site
- * navigation away for no reason.
+ * That asymmetry is the whole point, so both halves are asserted. Below the
+ * boundary the panel fills the viewport, so everything behind it is obscured
+ * and a focus stop landing there is WCAG 2.2 2.4.11 Focus Not Obscured
+ * (Minimum), Level AA -- 26 of 43 stops did at 390. At 1440 the panel occupies
+ * a corner and trapping focus would take the site navigation away for no
+ * reason.
  *
- * A test that only pinned the 390 half would pass just as happily if the panel
- * became modal everywhere, which is the fix #112's reviewers rejected.
+ * A test that only pinned the phone half would pass just as happily if the
+ * panel became modal everywhere, which is the fix #112's reviewers rejected.
+ *
+ * The boundary is `lg` rather than the `sm` #129 first used, because the card
+ * covered 72% of the viewport at 640, 75% at 768 and 70% at 834 -- not a
+ * corner. TABLET is in the band that moved, and is the case that would silently
+ * revert if someone put the breakpoint back.
+ *
+ * Above the boundary the panel closes when focus leaves it, which is what makes
+ * "non-modal" true rather than merely claimed: four ~400px product links sit
+ * entirely behind the card at 1440, and no scroll position can clear them --
+ * the panel leaves 12px above it and 100px below.
  */
 
 const PHONE = { width: 390, height: 844 }
+const TABLET = { width: 834, height: 1112 }
 const DESKTOP = { width: 1440, height: 900 }
 
 type Stop = {
@@ -80,7 +91,7 @@ async function openChat(page: Page) {
 }
 
 test.describe('chat panel modality', () => {
-  test('below sm the panel is modal', async ({ page }) => {
+  test('below lg the panel is modal', async ({ page }) => {
     await page.setViewportSize(PHONE)
     await openChat(page)
 
@@ -89,13 +100,13 @@ test.describe('chat panel modality', () => {
     // All four parts, because half of this is worse than none of it:
     // `aria-modal` without a trap tells assistive technology something false,
     // and a trap without `inert` leaves the covered controls clickable.
-    await expect(dialog, 'the panel does not claim containment below sm').toHaveAttribute(
+    await expect(dialog, 'the panel does not claim containment below lg').toHaveAttribute(
       'aria-modal',
       'true',
     )
     expect(
       await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
-      'page content behind the panel is not inert below sm',
+      'page content behind the panel is not inert below lg',
     ).toBe(true)
 
     // A sheet that has covered the whole site has to say what it is. The panel
@@ -110,7 +121,7 @@ test.describe('chat panel modality', () => {
     // screen reader and unaddressable by name here.
     await expect(
       page.getByRole('button', { name: 'Close chat' }),
-      'more than one control is named "Close chat" below sm',
+      'more than one control is named "Close chat" below lg',
     ).toHaveCount(1)
 
     const stops = await tabCycle(page, 50)
@@ -135,7 +146,7 @@ test.describe('chat panel modality', () => {
     ).toEqual([])
   })
 
-  test('at sm and up the panel is not modal', async ({ page }) => {
+  test('at lg and up the panel is not modal', async ({ page }) => {
     await page.setViewportSize(DESKTOP)
     await openChat(page)
 
@@ -167,6 +178,141 @@ test.describe('chat panel modality', () => {
       stops.some((stop) => !stop.inWidget),
       'focus never left the chat widget at 1440, so the panel is trapping everywhere',
     ).toBe(true)
+  })
+
+  test('at lg and up the panel closes when focus leaves it', async ({ page }) => {
+    await page.setViewportSize(DESKTOP)
+    await openChat(page)
+
+    // Out of the widget by the shortest route: Shift+Tab from the first control
+    // in the panel goes to whatever precedes the whole widget in the document.
+    await page.getByRole('button', { name: 'Clear conversation' }).focus()
+    await page.keyboard.press('Shift+Tab')
+
+    await expect(
+      page.getByRole('dialog', { name: /chat/i }),
+      'focus left the panel and the panel stayed open, so it is still covering the page',
+    ).toHaveCount(0)
+
+    // Where focus actually is, not merely that it is somewhere. `not.toBe(BODY)`
+    // was the first version of this and it could not see the bug it was written
+    // for: closing ran the focus-return effect, which pulled focus back onto the
+    // launcher, so one Shift+Tab dismissed the panel and left the user exactly
+    // where they started with the scroll position spent. The launcher passes a
+    // BODY check perfectly well.
+    const landed = await page.evaluate(() => {
+      const active = document.activeElement as HTMLElement | null
+      const launcher = document.querySelector('[aria-label="Open chat"]')
+      return {
+        tag: active?.tagName ?? null,
+        isLauncher: !!active && active === launcher,
+        inWidget: !!launcher?.parentElement?.contains(active as Node),
+      }
+    })
+    expect(landed.tag, 'focus fell to nothing when the panel closed').not.toBe('BODY')
+    expect(
+      landed.isLauncher,
+      'closing on focus-out dragged focus back to the launcher, undoing the keystroke',
+    ).toBe(false)
+    expect(
+      landed.inWidget,
+      'focus ended up back inside the chat widget the user was leaving',
+    ).toBe(false)
+  })
+
+  test('no control is entirely hidden at the moment it holds focus', async ({ page }) => {
+    // 2.4.11 exactly, at the width that motivated #183: a control fails only
+    // when it is *completely* covered, measured at four corners and the centre
+    // rather than the centre alone, which is the stricter proxy the phone test
+    // uses.
+    //
+    // Note what this does and does not say. It is about focused controls, not
+    // about coverage in general -- the card still covers 18 product links at
+    // 1440, and a mouse user still cannot click them until the panel is closed.
+    // What it pins is that focus never lands on one of them, because the panel
+    // leaves before focus arrives.
+    //
+    // Not vacuous, though it reads that way: the panel closes a few stops in,
+    // so most of the cycle measures a page with no panel on it. The vacuity
+    // guard below is what keeps that honest, and removing the close-on-focus-out
+    // effect turns this red -- four ~400px links go entirely behind the card,
+    // and no scroll position can clear them, since the panel leaves 12px above
+    // it and 100px below.
+    await page.setViewportSize(DESKTOP)
+    await openChat(page)
+
+    const hidden: string[] = []
+    let visited = 0
+    for (let i = 0; i < 60; i += 1) {
+      await page.keyboard.press('Tab')
+      const stop = await page.evaluate(() => {
+        const element = document.activeElement as HTMLElement | null
+        if (!element || element === document.body) return null
+        const box = element.getBoundingClientRect()
+        if (box.width === 0 || box.height === 0) return null
+        const points = [
+          [0.5, 0.5],
+          [0.02, 0.02],
+          [0.98, 0.02],
+          [0.02, 0.98],
+          [0.98, 0.98],
+        ]
+        const visible = points.filter(([fx, fy]) => {
+          const onTop = document.elementFromPoint(box.left + box.width * fx, box.top + box.height * fy)
+          return onTop === element || element.contains(onTop)
+        }).length
+        return visible === 0
+          ? `${element.tagName.toLowerCase()} ${(element.textContent ?? '').trim().slice(0, 30)}`
+          : false
+      })
+      if (stop === null) continue
+      visited += 1
+      if (stop !== false) hidden.push(stop)
+    }
+
+    // The walk has to have reached the page, not just the widget's own handful
+    // of controls -- otherwise "nothing was hidden" is a statement about four
+    // buttons that were never at risk.
+    expect(
+      visited,
+      'the Tab cycle never got past the widget, so this asserts almost nothing',
+    ).toBeGreaterThan(10)
+    expect(hidden, 'focus stops entirely hidden behind the chat panel (WCAG 2.4.11)').toEqual([])
+  })
+
+  test('the tablet band is modal, not a corner card', async ({ page }) => {
+    // 834 was on the card side of the old `sm` boundary while the card covered
+    // 70% of the viewport. This is the width that reverts silently if the
+    // breakpoint moves back, and the phone test would not notice.
+    await page.setViewportSize(TABLET)
+    await openChat(page)
+
+    await expect(page.getByRole('dialog', { name: /chat/i })).toHaveAttribute('aria-modal', 'true')
+    expect(
+      await page.locator('main').evaluate((main) => main.hasAttribute('inert')),
+      'page content behind the panel is not inert at 834',
+    ).toBe(true)
+
+    const panel = await page.getByRole('dialog', { name: /chat/i }).boundingBox()
+    expect(panel!.width, 'the panel is not full-width at 834').toBeGreaterThanOrEqual(834)
+  })
+
+  test('the boundary sits at exactly 1024', async ({ page }) => {
+    // The CSS variant and the media query are two separate spellings of one
+    // number. They drifted apart would be invisible: the sheet would be a sheet
+    // while claiming nothing, or a card claiming containment.
+    await page.setViewportSize({ width: 1023, height: 800 })
+    await openChat(page)
+    await expect(
+      page.getByRole('dialog', { name: /chat/i }),
+      'not modal at 1023, one pixel below the boundary',
+    ).toHaveAttribute('aria-modal', 'true')
+
+    await page.setViewportSize({ width: 1024, height: 800 })
+    await expect(
+      page.getByRole('dialog', { name: /chat/i }),
+      'still modal at 1024, which is where the card starts',
+    ).not.toHaveAttribute('aria-modal', 'true')
   })
 
   test('modality follows a resize while the panel is open', async ({ page }) => {

--- a/apps/web/src/components/chat.test.tsx
+++ b/apps/web/src/components/chat.test.tsx
@@ -10,8 +10,9 @@ vi.mock('next-auth/react', () => ({
 beforeEach(() => {
   Element.prototype.scrollTo = vi.fn()
 
-  // Desktop by default, which is the width every test below this line was
-  // written against — the panel as a corner card, non-modal, launcher present.
+  // Desktop by default -- `lg` and up -- which is the width every test below
+  // this line was written against: the panel as a corner card, non-modal,
+  // launcher present.
   //
   // Without this they inherit the stub in `src/test/setup.ts`, which reports
   // "no match" for everything; for a `min-width` query that means compact, so
@@ -662,7 +663,7 @@ describe('Chat placeholder timing', () => {
 })
 
 /**
- * Modality below `sm` only.
+ * Modality below `lg` only.
  *
  * The e2e spec is where the fix is really proven, because obscuring is a
  * question about painted pixels and jsdom paints nothing. What is worth
@@ -693,7 +694,7 @@ describe('Chat modality', () => {
   }
 
   // A controllable `matchMedia`, replacing the always-false one in setup.ts.
-  // The component asks for `(min-width: 640px)` and treats a non-match as
+  // The component asks for `(min-width: 1024px)` and treats a non-match as
   // compact, so `matches` is the inverse of the thing being described.
   //
   // One object per mount, with a live getter: the component captures the
@@ -729,7 +730,7 @@ describe('Chat modality', () => {
     vi.clearAllMocks()
   })
 
-  it('claims containment and inerts the page below sm', () => {
+  it('claims containment and inerts the page below lg', () => {
     useViewport(true)
     const { behind, cleanup } = renderInLayout()
     openChat()
@@ -742,7 +743,7 @@ describe('Chat modality', () => {
     cleanup()
   })
 
-  it('claims nothing at sm and up', () => {
+  it('claims nothing at lg and up', () => {
     useViewport(false)
     const { behind, cleanup } = renderInLayout()
     openChat()
@@ -826,7 +827,7 @@ describe('Chat modality', () => {
     cleanup()
   })
 
-  it('does not trap focus at sm and up', () => {
+  it('does not trap focus at lg and up', () => {
     // The same keystroke that wraps on the sheet must do nothing on the card,
     // or the site navigation is unreachable at desktop width — the outcome
     // #112's reviewers rejected and the reason this is width-scoped at all.
@@ -838,6 +839,73 @@ describe('Chat modality', () => {
     first.focus()
     fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
     expect(document.activeElement).toBe(first)
+
+    cleanup()
+  })
+
+  it('announces a reply that arrives after the panel closed', async () => {
+    // Closing on focus-out unmounts the `role="log"`, so a reply that settles
+    // afterwards lands in the reducer and is announced by nothing. Asking a
+    // question and then tabbing back into the page to keep browsing is the
+    // thing a non-modal panel is for, and this change is what made it
+    // reachable.
+    let resolveReply: (turn: unknown) => void = () => {}
+    sendChatMessage.mockReturnValue(new Promise((resolve) => { resolveReply = resolve }))
+
+    useViewport(false)
+    const { parent, cleanup } = renderInLayout()
+    openChat()
+
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    fireEvent.change(input, { target: { value: 'which tent for winter?' } })
+    fireEvent.keyUp(input, { code: 'Enter' })
+
+    // Out of the widget, which at this width closes the panel.
+    const outside = parent.querySelector('a')! as HTMLElement
+    fireEvent.focusIn(outside, { target: outside })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveReply({
+        name: 'Jane Doe', message: 'The TrailMaster X4.', status: 'done',
+        type: 'assistant', avatar: '',
+      })
+    })
+
+    expect(screen.getByText(/Jane Doe replied/i)).toBeInTheDocument()
+
+    cleanup()
+  })
+
+  it('stays silent while the panel is open, so a reply is not read twice', async () => {
+    // The log inside the panel is the announcement in that case. Two live
+    // regions saying the same thing is worse than one.
+    //
+    // The reply is settled inside `act` rather than awaited through `waitFor`
+    // on the message text. The first version did the latter and passed against
+    // a build with the open-guard deleted: `setAnnouncement` had run, and the
+    // assertion simply read the DOM before React re-rendered. A negative
+    // assertion that races the thing it is denying always passes.
+    let resolveReply: (turn: unknown) => void = () => {}
+    sendChatMessage.mockReturnValue(new Promise((resolve) => { resolveReply = resolve }))
+
+    useViewport(false)
+    const { cleanup } = renderInLayout()
+    openChat()
+
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    fireEvent.change(input, { target: { value: 'which tent?' } })
+    fireEvent.keyUp(input, { code: 'Enter' })
+
+    await act(async () => {
+      resolveReply({
+        name: 'Jane Doe', message: 'The TrailMaster X4.', status: 'done',
+        type: 'assistant', avatar: '',
+      })
+    })
+
+    expect(screen.getByText('The TrailMaster X4.')).toBeInTheDocument()
+    expect(screen.queryByText(/Jane Doe replied/i)).not.toBeInTheDocument()
 
     cleanup()
   })

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -56,22 +56,37 @@ export const Chat = () => {
   const launcherRef = useRef<HTMLButtonElement>(null);
   const widgetRef = useRef<HTMLDivElement>(null);
   const greetingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Why the panel last closed, read by the focus-return effect below.
+  const closedByFocusOut = useRef(false);
+  // Whether the panel is open *now*, for callbacks that were created while it
+  // was. A reply outlives the send that started it.
+  const showChatRef = useRef(false);
 
-  // Below `sm` the panel is a full-screen sheet, so it really does contain the
-  // user and says so. At `sm` and up it occupies a corner, the rest of the page
+  // Below `lg` the panel is a full-screen sheet, so it really does contain the
+  // user and says so. At `lg` and up it occupies a corner, the rest of the page
   // is usable, and trapping focus would take the site navigation away.
   //
   // `false` until mounted, so the server and the first client render agree.
-  // Only the semantics depend on this; the sheet itself is `max-sm:` CSS and is
+  // Only the semantics depend on this; the sheet itself is `max-lg:` CSS and is
   // right from first paint whether or not this has run.
   const [isCompact, setIsCompact] = useState(false);
 
-  // The exact complement of Tailwind's `sm:`, expressed as its own query rather
+  // What a reply announces when there is no panel to announce it in. See the
+  // effect below.
+  const [announcement, setAnnouncement] = useState("");
+
+  // The exact complement of Tailwind's `lg:`, expressed as its own query rather
   // than a `max-width` with an epsilon, so a fractional viewport cannot land
   // between the two and satisfy neither. `tailwind.config.ts` sets no `screens`
-  // override, so 640px is Tailwind's default and these two must move together.
+  // override, so 1024px is Tailwind's default and these two must move together.
+  //
+  // `lg` rather than `sm`, which is where #129 first drew it, because a card is
+  // only a card if the page is still there around it. Measured with the panel
+  // open: it covers 72% of the viewport at 640, 75% at 768 and 70% at 834 —
+  // against 40% at 1440. The three widths in that band were failing 2.4.11 the
+  // same way 390 was, one breakpoint up. See #183.
   useEffect(() => {
-    const query = window.matchMedia("(min-width: 640px)");
+    const query = window.matchMedia("(min-width: 1024px)");
     const sync = () => setIsCompact(!query.matches);
     sync();
     query.addEventListener("change", sync);
@@ -123,7 +138,7 @@ export const Chat = () => {
   //
   // What is covered: both wrap branches, by `wraps focus at both ends of the
   // sheet` in chat.test.tsx, and their absence at desktop by `does not trap
-  // focus at sm and up`. Delete this effect and those go red.
+  // focus at lg and up`. Delete this effect and those go red.
   //
   // What is not covered by anything: the recovery branch below, for focus that
   // is already outside the widget — removing that alone leaves the whole suite
@@ -168,21 +183,95 @@ export const Chat = () => {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [isModal]);
 
+  // At `lg` and up the panel stays non-modal, and non-modal is a claim that the
+  // page behind is still usable. It is not quite: the card still covers 30-54%
+  // of the viewport there, and at 1440 four product links sit entirely behind
+  // it. Nothing can scroll them clear — they are ~400px tall and the panel
+  // leaves 12px above it and 100px below, so there is nowhere to scroll them
+  // to. Shrinking the panel does not fix it either: what is hidden depends on
+  // where the grid puts links, not on the panel's area (1280 measures 0 hidden
+  // and 1440 measures 4).
+  //
+  // So the panel gets out of the way instead of pretending it already has.
+  // Keyboard only, and the criterion is too: 2.4.11 is about the *focused*
+  // control, and focus is the thing this can observe. A mouse user still cannot
+  // reach what the card covers — 6 of 22 product links at 1440 and 7 of 22 at
+  // 1024, at some scroll position — because clicking bare page fires no
+  // `focusin` and the panel stays up. That is #187, not this.
+  //
+  // Nothing focused can be obscured behind a panel that is gone, and the
+  // conversation is not lost — the turns live in the reducer, so reopening
+  // restores the thread rather than starting a new one. See #183.
+  //
+  // Only where it is not modal: below `lg` the surrounding page is `inert`, so
+  // focus cannot land there in the first place, and this would be dead code
+  // that closes the sheet on nothing.
+  //
+  // Backwards only, deliberately. The widget is last in the document, so Tab
+  // forward off its final control leaves the page entirely: no `focusin` fires,
+  // and the panel stays up until focus re-enters at the top, one keystroke
+  // later. That stop is the browser's own chrome — the address bar — and
+  // dismissing the panel while the user is up there would be closing it for
+  // something that is not a page interaction at all.
+  useEffect(() => {
+    if (!showChat || isCompact) return;
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target as Node | null;
+      if (target && widgetRef.current?.contains(target)) return;
+      // Focus has already moved to where the user asked for it. Say so, or the
+      // focus-return effect below reads this as an ordinary close and drags
+      // focus back onto the launcher they were leaving.
+      closedByFocusOut.current = true;
+      setShowChat(false);
+    };
+    document.addEventListener("focusin", onFocusIn);
+    return () => document.removeEventListener("focusin", onFocusIn);
+  }, [showChat, isCompact]);
+
+  useEffect(() => {
+    showChatRef.current = showChat;
+  }, [showChat]);
+
+  // Cancel an unfired greeting whenever the panel closes, by whatever route.
+  // The open branch of `toggleChat` guards on `turns.length`, but a pending
+  // timer has not dispatched yet, so closing and reopening inside 400ms — an
+  // ordinary impatient tap — schedules a second timer and both fire.
+  //
+  // Here rather than in `toggleChat`, which is where it used to live and only
+  // ever covered the button. Escape has always had the same hole, and closing
+  // on focus-out would have been a third way in. Measured, all three closed
+  // within 400ms and reopened: button one greeting, Escape two, focus-out two.
+  // One place, so a fourth close path cannot reintroduce it.
+  useEffect(() => {
+    if (showChat) return;
+    if (greetingTimer.current) clearTimeout(greetingTimer.current);
+  }, [showChat]);
+
   // Opening the panel left focus on the launcher, so the next Tab continued
   // into the page behind it rather than into the conversation.
   useEffect(() => {
     if (showChat) inputRef.current?.focus();
   }, [showChat]);
 
-  // Focus return, after the close rather than during it. Below `sm` the
+  // Focus return, after the close rather than during it. Below `lg` the
   // launcher is unmounted while the sheet is open, so a `focus()` inside the
   // close handler runs against an element that is not in the document yet and
   // silently drops focus to <body> — which is the bug moving focus in on open
   // was added to fix, in the other direction. One mechanism rather than two, so
   // both the Escape path and the button path go through here.
+  // Returned on an explicit dismissal — Escape, or the close button — and only
+  // then. A close caused by focus leaving the panel already has focus on the
+  // control the user moved to, and pulling it back onto the launcher undoes
+  // their keystroke: one Shift+Tab would close the panel, scroll to the link
+  // they reached, and then take focus off it again, leaving them where they
+  // started with the scroll position gone. That is WCAG 3.2.1 On Focus, and the
+  // widget is last in the document, so Shift+Tab is the only way out.
   const wasOpen = useRef(false);
   useEffect(() => {
-    if (wasOpen.current && !showChat) launcherRef.current?.focus();
+    if (wasOpen.current && !showChat && !closedByFocusOut.current) {
+      launcherRef.current?.focus();
+    }
+    closedByFocusOut.current = false;
     wasOpen.current = showChat;
   }, [showChat]);
 
@@ -314,6 +403,20 @@ export const Chat = () => {
       // the panel, which is mounted once in the root layout.
       if (!pendingIds.current.delete(pendingId)) return;
       dispatch({ type: "resolve", id: pendingId, payload: responseTurn });
+
+      // The panel's `role="log"` is what tells a screen-reader user an answer
+      // arrived, and closing on focus-out unmounts it mid-request. The turn
+      // still lands — this line ran — but with the log gone nothing says so,
+      // and asking a question then tabbing back into the page to keep browsing
+      // is what a non-modal panel is for. This change made that reachable, so
+      // it has to cover it.
+      //
+      // Here rather than in an effect watching `state.turns`: this is the
+      // moment a reply arrives, so there is no "did it arrive while closed?"
+      // to reconstruct, and no `setState` in an effect body to cascade from.
+      if (!showChatRef.current) {
+        setAnnouncement("Jane Doe replied. Open chat to read the answer.");
+      }
     };
 
     // sendChatMessage resolves with an error turn rather than rejecting, but a
@@ -350,14 +453,13 @@ export const Chat = () => {
       // of the document — 24 stops back to this launcher. Moving focus in on
       // open is only half the contract. Returned by the effect above, which
       // runs after the launcher is back in the document.
-      //
-      // Cancel an unfired greeting. The open branch below guards on
-      // turns.length, but a pending timer has not dispatched yet, so closing
-      // and reopening inside 400ms — an ordinary impatient tap — schedules a
-      // second timer and both fire.
-      if (greetingTimer.current) clearTimeout(greetingTimer.current);
       return;
     }
+
+    // Opening is reading: the announcement has served its purpose, and leaving
+    // it in the live region means the next reply that repeats it is a text
+    // change of nothing and may not be announced at all.
+    setAnnouncement("");
 
     scrollChat();
     if (state.turns.length === 0) {
@@ -374,9 +476,9 @@ export const Chat = () => {
         className="fixed bottom-0 right-0 mr-4 mb-4 sm:mr-12 sm:mb-12 z-10 flex flex-col items-end"
       >
         {showChat && (
-          // Two shapes, not one shape with overrides. Below `sm` a sheet, at
-          // `sm` and up a card, and the two sets of classes do not intersect —
-          // a base `rounded-lg` that `max-sm:rounded-none` has to win against
+          // Two shapes, not one shape with overrides. Below `lg` a sheet, at
+          // `lg` and up a card, and the two sets of classes do not intersect —
+          // a base radius that a max-width variant has to win against
           // depends on which variant Tailwind emits later, which is not
           // something this file should be betting on.
           //
@@ -394,13 +496,13 @@ export const Chat = () => {
             aria-modal={isCompact ? true : undefined}
             tabIndex={-1}
             className="flex flex-col bg-white outline-none
-                       max-sm:fixed max-sm:inset-x-0 max-sm:top-0
-                       max-sm:h-[100dvh] max-sm:w-full
-                       sm:mb-3 sm:shadow-md sm:rounded-lg
-                       sm:w-[min(650px,calc(100vw-7rem))]
-                       sm:h-[calc(100vh-7rem)]"
+                       max-lg:fixed max-lg:inset-x-0 max-lg:top-0
+                       max-lg:h-[100dvh] max-lg:w-full
+                       lg:mb-3 lg:shadow-md lg:rounded-lg
+                       lg:w-[min(650px,calc(100vw-7rem))]
+                       lg:h-[calc(100vh-7rem)]"
           >
-            <div className="p-2 flex items-center gap-1 max-sm:border-b max-sm:border-zinc-200">
+            <div className="p-2 flex items-center gap-1 mx-auto w-full max-w-2xl max-lg:border-b max-lg:border-zinc-200">
               {/*
                 A sheet has to introduce itself. A corner card can borrow
                 identity from the page around it; this one has covered that
@@ -452,7 +554,12 @@ export const Chat = () => {
               role="log"
               aria-live="polite"
               aria-label="Conversation"
-              className="grow p-2 overscroll-contain overflow-auto"
+              // Capped and centred rather than stretched. The sheet is as wide
+              // as the viewport up to 1023, and a conversation column that wide
+              // leaves the reply on one side and the input spanning the whole
+              // screen under it. No variant needed: the card is 650px, already
+              // narrower than the cap, so this binds only on the sheet.
+              className="grow p-2 overscroll-contain overflow-auto mx-auto w-full max-w-2xl"
               ref={chatDiv}
             >
               <div className="flex flex-col gap-4">
@@ -462,7 +569,7 @@ export const Chat = () => {
               </div>
             </div>
             {/* chat input section */}
-            <div className="p-3 flex gap-3">
+            <div className="p-3 flex gap-3 mx-auto w-full max-w-2xl">
               <input
                 id="chat"
                 name="chat"
@@ -491,14 +598,24 @@ export const Chat = () => {
           </div>
         )}
         {/*
+          `aria-live` without `role="status"`. The waiting turn inside the panel
+          is the page's status region and a test addresses it by that role; a
+          second one makes that query ambiguous, and this is a supplementary
+          announcer rather than something to navigate to. The live region works
+          on any element.
+        */}
+        <div aria-live="polite" className="sr-only">
+          {announcement}
+        </div>
+        {/*
           Not rendered while the sheet is open, because the sheet's own header
           is the way out there. Left in place it would be a second control named
           "Close chat", and it would be behind the sheet in any case: the panel
-          is positioned below `sm` and this button is not, so it loses the paint
+          is positioned below `lg` and this button is not, so it loses the paint
           order regardless of where it sits in the source.
 
           Only the state changes with width, not the element, so the launcher at
-          `sm` and up is exactly what it was.
+          `lg` and up is exactly what it was.
         */}
         {!(isCompact && showChat) && (
           <button

--- a/apps/web/src/components/turn.tsx
+++ b/apps/web/src/components/turn.tsx
@@ -71,10 +71,25 @@ export const Turn = ({ turn }: Props) => {
 
   // Gutters were a flat 96px. Inside a 358px panel at 390px that left a 218px
   // content column — 39% fixed gutter — wrapping product names onto two lines.
+  //
+  // `max-w-[46ch]` caps the other end. The gutters are fixed, so from 640 up the
+  // content column grew with the panel without limit: once #183 made the panel a
+  // full-screen sheet to 1023, a reply ran 81 characters per line at 834 and 103
+  // at 1023, against the 45–75 that is comfortable to read. The cap binds only
+  // where the panel is wide enough to exceed it, so the 390 measure above is
+  // untouched.
+  //
+  // `justify-end` is the cap's other half. While the bubble filled the column,
+  // which side a turn sat on was not a signal and only colour told them apart.
+  // Capped, it is a signal — and the default one pointed backwards: the
+  // assistant's bubble landed further right than the shopper's own, measured at
+  // 834 as assistant 228–649 against user 185–606. Main-end is the left for the
+  // row-reverse assistant row and the right for the user row, so one class puts
+  // each turn on the side every chat interface puts it.
   if (turn.type === "user") {
     return (
-      <div className="ml-8 sm:ml-24 flex gap-1">
-        <div className="grow min-w-0 break-words bg-sky-700 text-zinc-100 p-2 rounded-md">
+      <div className="ml-8 sm:ml-24 flex justify-end gap-1">
+        <div className="grow min-w-0 max-w-[46ch] break-words bg-sky-700 text-zinc-100 p-2 rounded-md">
           {getContent(turn)}
         </div>
         <div>
@@ -84,8 +99,8 @@ export const Turn = ({ turn }: Props) => {
     );
   } else {
     return (
-      <div className="flex flex-row-reverse gap-1 mr-8 sm:mr-24">
-        <div className="grow min-w-0 break-words bg-zinc-200 text-zinc-600 p-2 rounded-md">
+      <div className="flex flex-row-reverse justify-end gap-1 mr-8 sm:mr-24">
+        <div className="grow min-w-0 max-w-[46ch] break-words bg-zinc-200 text-zinc-600 p-2 rounded-md">
           {getContent(turn)}
         </div>
         <div>


### PR DESCRIPTION
Closes #183.

#129 drew the modal line at `sm`. One pixel above it, the "corner card" covered
**72% of the viewport**.

| viewport | panel | % of viewport | entirely hidden, before |
|---|---|---|---|
| 640×900 | 528×788 | **72%** | 5 |
| 768×1024 | 650×912 | **75%** | 4 |
| 834×1112 | 650×1000 | 70% | 4 |
| 1024×768 | 650×656 | 54% | 6 |
| 1440×900 | 650×788 | 40% | 4 |

Those first three widths were failing WCAG 2.4.11 exactly the way 390 was, one
breakpoint up. **The sheet now runs to `lg`**, and they go to zero.

## At `lg` and up, the card leaves when focus does

Four ~400px product links sat entirely behind the card at 1440, and **no scroll
position could clear them** — the panel leaves 12px above it and 100px below.
Shrinking it doesn't fix that either: what's hidden depends on where the grid
puts links, not on panel area (1280 already measured 0 while 1440 measured 4).

So the panel gets out of the way instead of pretending it already had. The
conversation survives — turns live in the reducer.

**Result: zero entirely-hidden focused controls at all eight measured widths.**

## Three things this change caused, caught by review and fixed here

- **Shift+Tab was undone.** Closing ran the focus-return effect, which dragged
  focus back to the launcher — one keystroke dismissed the panel, scrolled to
  the link reached, then took focus off it. WCAG 3.2.1, and since the widget is
  last in the document, Shift+Tab is the *only* way out. Focus is now returned
  only on an explicit dismissal.
- **The sheet's contents were never retuned for their new widths** — a reply ran
  103 characters per line at 1023. Bubbles gained `max-w-[46ch]`; header, log and
  input row are capped and centred together.
- **That cap made horizontal position meaningful, and it pointed backwards** —
  the assistant's bubble sat further right than the shopper's own. `justify-end`
  puts each turn on its own side.

## A reply that arrives after you tab away

Closing on focus-out unmounts the panel's `role="log"` mid-request, so the reply
landed in the reducer and was announced by nothing — and asking a question then
returning to the page is precisely what a non-modal panel is for. There's now an
`aria-live` region outside the panel, written where the reply lands rather than
from an effect watching state.

Greeting cancellation also moved out of `toggleChat` into one effect covering
every close path. Escape had the same double-greeting hole all along; focus-out
would have been a third way in.

## Verification

`next build`, `tsc --noEmit`, repo-wide ESLint all clean (exit codes read
directly — an earlier run hid an ESLint failure behind `tail`'s status). 126
vitest across 33 files; 42 Playwright.

Every new behaviour is mutation-verified: removing close-on-focus-out, reverting
the media query to 640, restoring the focus-return bug, deleting the announcer,
announcing unconditionally, and deleting the greeting cancellation each turn a
named test red.

Two false greens of my own were found and fixed along the way — an assertion of
`not.toBe('BODY')` that the launcher satisfied (which is *why* it couldn't see
the Shift+Tab bug), and a negative assertion that raced React's re-render and so
passed against a deliberately broken build.

## Known residual

- #187 — a mouse user still cannot reach 6–7 of 22 links at 1024/1440; a
  bare-page click fires no `focusin`, so this is keyboard-only, as is the
  criterion.
- #188 — the card at 1024 is untitled and still 54.6%; icon buttons are 36×36
  against Send's 44×44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)