### PR TITLE
fix(web): scale the home hero with the viewport

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -14,6 +14,11 @@ import { test, expect, type Page } from '@playwright/test'
  * any sweep that steps over it.
  */
 const WIDTHS = [
+  // 320 is the narrowest width worth supporting: iPhone SE 1st gen, and any
+  // browser at 200% zoom on a 640px viewport. The sweep started at 360 and the
+  // home hero had been overflowing the document by 30px below that the whole
+  // time, unseen. See #162.
+  320,
   360, 375, 390, 414, // phones
   639, 640, 641, // sm boundary
   767, 768, 769, // md boundary
@@ -173,6 +178,55 @@ test.describe('no vertical collision', () => {
       `widths where fewer than ${TEXT_BLOCKS_BEFORE_THE_FIRST_CATEGORY} text blocks were measured, so the check below is weaker than it looks`,
     ).toEqual({})
     expect(collisions, 'widths where the hero paints over the section below').toEqual({})
+  })
+
+  test('the home hero band is shorter than a landscape viewport', async ({ page }) => {
+    // Every width in WIDTHS is measured at height 900, so this suite had never
+    // varied the viewport's height. A phone held sideways is what that hides:
+    // at 667x375 the band stood 424px tall, 113% of the screen, and at 844x390
+    // it was 102%. The whole first screen was hero.
+    //
+    // Read the name literally -- it is the band's *height* against the
+    // viewport's, and that is deliberately weaker than "something below the
+    // hero is on screen". The band does not start at the top: `Header` puts a
+    // 48px block above it, so at 667x375 a 344px band ends at y=392 in a 375px
+    // viewport and the first category heading is still below the fold. #192
+    // carries that residual and the measurements; it needs `min-h-80`
+    // revisited, not a bigger type step.
+    //
+    // Both sizes earn their place -- reverting only the h1 is caught at 844x390
+    // and passes at 667x375; reverting only the subhead and body is caught at
+    // 667x375 and passes at 844x390.
+    const LANDSCAPE = [
+      { width: 667, height: 375 },
+      { width: 844, height: 390 },
+    ]
+
+    await page.goto('/')
+
+    const tooTall: Record<string, string> = {}
+    for (const { width, height } of LANDSCAPE) {
+      await page.setViewportSize({ width, height })
+      await page.waitForTimeout(120)
+      // Selected by the class that makes it the hero rather than by walking up
+      // from the h1. `closest('div').parentElement` resolves correctly today,
+      // but wrapping the heading in any div inside `Block` would silently move
+      // the measurement to the inner container -- which is smaller, so it would
+      // fail open.
+      const band = await page.evaluate(() => {
+        const hero = document.querySelector('[class*="bg-hero-image"]')
+        return hero ? Math.round(hero.getBoundingClientRect().height) : null
+      })
+      if (band === null) {
+        throw new Error(`no hero band found at ${width}x${height}`)
+      }
+      if (band >= height) tooTall[`${width}x${height}`] = `hero is ${band}px of ${height}px`
+    }
+
+    expect(
+      tooTall,
+      'landscape sizes where the hero band is taller than the whole viewport',
+    ).toEqual({})
   })
 })
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -30,17 +30,53 @@ export default async function Home() {
         // so the 1024x450 image tiled: already visible as a vertical seam past
         // 1024px wide, and a horizontal one as soon as the band grows taller
         // than 450px, which min-h-80 lets it do.
-        outerClassName="bg-blend-multiply bg-center bg-cover bg-no-repeat bg-hero-image min-h-80 pb-8 bg-neutral-600"
-        innerClassName=""
+        outerClassName="bg-blend-multiply bg-center bg-cover bg-no-repeat bg-hero-image min-h-80 bg-neutral-600"
+        // One owner for the band's vertical rhythm. It used to be two: `pt-12`
+        // on the h1 and `pb-8` out here on the full-bleed outer, which meant
+        // restyling the heading could silently take the top padding with it.
+        innerClassName="py-12"
       >
-        <h1 className="text-zinc-100 pt-12 text-7xl font-black subpixel-antialiased">
+        {/*
+          Fixed 72px type was the whole of #162. At 320 the word "Company"
+          alone is wider than the 296px content box, so the document itself
+          overflowed by 30px — and the band, growing to fit three lines of
+          unscaled copy, stood 672px tall in a 568px viewport. In landscape it
+          was 113% of the screen at 667x375: the entire first screen was hero
+          before you reached anything to buy.
+
+          Base is 5xl, not the 4xl that first fixed the overflow. 4xl is 36px
+          and the category `h2` below it is `text-5xl` at every width, so the
+          brand name rendered smaller than "Tents" — the page's own outline
+          inverted. 48px fits the 296px box at 320 with 70px to spare (the
+          widest word, "Company", inks 225.6px), and softens the step at the
+          `sm` boundary from 36->60 to 48->60.
+
+          7xl waits for `xl`, not `lg`. At 1024 the box is 1000px and 72px inks
+          973px — 2.7% of slack, and which side of that a client lands on
+          depends on the font it resolves from the stack: measured across
+          candidates, Arial and Verdana fit but DejaVu Sans inks 1088px and
+          wraps. At 1280 the box is 1256px, so the margin is 283px.
+        */}
+        <h1 className="text-zinc-100 text-5xl sm:text-6xl xl:text-7xl font-black subpixel-antialiased">
           Contoso Outdoor Company
         </h1>
-        <div className="text-zinc-100 mt-4 text-2xl">
+        <div className="text-zinc-100 mt-4 text-lg sm:text-xl lg:text-2xl text-balance">
           Embrace Adventure with Contoso Outdoors - Your Ultimate Partner in
           Exploring the Unseen!
         </div>
-        <div className="text-zinc-100 mt-2 text-lg w-2/3">
+        {/*
+          `w-2/3` applied at every width, so on a 320px screen this paragraph
+          was a 197px column — three words a line, and the tallest single
+          contributor to the band. The two-thirds measure is there to stop the
+          line running the full width of a desktop, which is not a problem a
+          phone has.
+
+          It comes back at `md` rather than `lg`. Held off to `lg`, the line
+          ran 95 characters at 768 and 131 at 1023 — the fraction was doing no
+          work exactly where the viewport had grown enough to need it. From
+          768 two thirds is 496px, about 55 characters.
+        */}
+        <div className="text-zinc-100 mt-2 text-base lg:text-lg w-full md:w-2/3">
           Choose from a variety of products to help you explore the outdoors.
           From camping to hiking, we have you covered with the best gear and the
           best prices.


### PR DESCRIPTION
Closes #162.

The hero `h1` was `text-7xl` — 72px — at every width from 320 to 1920. At 320 the
word "Company" alone inks wider than the 296px content box, so the **document
overflowed by 30px**, and the band stood 672px tall in a 568px viewport.

| viewport | before | after |
|---|---|---|
| 320×568 | 672px, **118%** of viewport, +30px overflow | **468px, 82%** |
| 390×844 | 616px, 73% | **444px, 53%** |
| 667×375 landscape | 424px, **113%** | **344px, 92%** |
| 1440×900 | 320px, 36% | unchanged |

The heading, subhead and body now step with the viewport, and the body paragraph
stops being a 197px column on a 320px screen.

## Not the sizes the issue proposed

The issue suggested `text-4xl sm:text-6xl lg:text-7xl`. Three measurements moved it:

- **`text-4xl` is 36px, and the category `h2` below is `text-5xl` (48px) at every
  width.** The brand name rendered smaller than "Tents" — the page's own outline
  inverted. 48px fits at 320 with 70px to spare.
- **A 36px base made the heading non-monotonic**: one line at 639, two at 641.
  Widening the window made the heading taller. 48→60 removes that.
- **`lg:text-7xl` had 2.7% of slack at 1024** — the box is 1000px and 72px inks
  973px — and which side of that a client lands on depends on the font it
  resolves from the stack. Arial and Verdana fit; DejaVu Sans inks 1088px and
  wraps. `7xl` now waits for `xl`, where the margin is 283px.

The body's two-thirds measure comes back at `md`, not `lg`: held to `lg` it ran
95 characters at 768 and **131 at 1023** — the fraction doing no work exactly
where the viewport had grown enough to need it.

## Vertical rhythm

`pt-12` lived on the `h1` and `pb-8` on the outer `Block`, so restyling the
heading could silently take the top padding with it. Both are now
`innerClassName="py-12"`. Bottom padding grows 32px → 48px as a result, which
`min-h-80` was already absorbing at most widths.

## Guards

`320` joins the `WIDTHS` sweep — it had been missing the whole time, which is why
nothing saw the overflow — plus a new test bounding the band against a landscape
viewport, since **every other width in that file is measured at height 900**.

Each half of the change is caught by mutation: reverting the `h1` alone fails at
844×390, reverting the subhead and body alone fails at 667×375. Neither landscape
size is redundant.

The landscape test asserts the **weaker** of two properties and says so in its
name and comment. The band starts 48px down because of the header, so being
shorter than the viewport is not the same as anything below it being on screen —
at 667×375 it still is not.

## Verification

`next build`, `tsc --noEmit`, repo-wide ESLint clean, exit codes read directly.
126 vitest across 33 files; 43 Playwright; 142 Python guardrails.

## Filed, not fixed

- #192 — nothing below the hero is on screen in landscape. Measured across nine
  sizes: **800×360 (Galaxy S20 landscape) fails at 368px, 48px above the `min-h-80`
  floor**, so padding is the lever, not the floor. Band height is also
  non-monotonic in width.
- #190 — the chat launcher paints over hero copy at 667×375 at 1.1:1 contrast.
- #191 — the body runs 95 characters at desktop, from the pre-existing `w-2/3`.
- Notes on #188 (header buttons under 44px) and #173 (a wrong LCP claim in
  `image-delivery.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)