### PR TITLE
fix(web): describe each product gallery image instead of repeating its name

### DIFF
--- a/apps/web/e2e/browse.spec.ts
+++ b/apps/web/e2e/browse.spec.ts
@@ -105,4 +105,58 @@ test.describe('browsing', () => {
     ).toBeGreaterThan(0)
     expect(failed, 'image requests returned an error status').toEqual([])
   })
+
+  test('a product gallery does not announce the same thing twice', async ({ page }) => {
+    // Every gallery image carried `alt={product.name}`, so a screen reader
+    // heard the product's name once per picture -- five times for most
+    // products -- and could not tell any of them apart. `lib/gallery-alt.ts`
+    // is unit-tested against the whole catalogue; this is the part that check
+    // cannot see, which is whether the page uses it.
+    //
+    // Sampled from a category page rather than from the home page. The home
+    // page links exactly the twenty seeded products, and those twenty are
+    // precisely the ones whose filenames are UUIDs -- so "follow the first
+    // product link" is the one route guaranteed to miss all 190 products whose
+    // shot types this is meant to be checking. The first version of this test
+    // did that, and asserted that a one-element list had no duplicates.
+    await page.goto('/products/category/tents')
+    const links = (
+      await page
+        .locator('a[href^="/products/"]')
+        .evaluateAll((anchors) =>
+          anchors.map((anchor) => (anchor as HTMLAnchorElement).getAttribute('href') ?? ''),
+        )
+    ).filter((href) => href && !href.startsWith('/products/category'))
+
+    expect(links.length, 'no product links on the category page').toBeGreaterThan(1)
+
+    let described = 0
+    for (const href of links.slice(0, 5)) {
+      await page.goto(href)
+      const alts = await page
+        .locator('main img')
+        .evaluateAll((images) => images.map((image) => (image as HTMLImageElement).alt))
+
+      expect(alts.length, `no gallery images on ${href}`).toBeGreaterThan(2)
+
+      // Decorative images announce nothing, and any number of those is fine.
+      const spoken = alts.filter((alt) => alt !== '')
+      expect(
+        spoken.filter((alt, index) => spoken.indexOf(alt) !== index),
+        `${href} announces something already announced`,
+      ).toEqual([])
+      expect(spoken.length, `${href} has an entirely silent gallery`).toBeGreaterThan(0)
+
+      if (spoken.length > 1) described += 1
+    }
+
+    // Without this the whole test passes on unlabelled products, where a single
+    // non-empty alt cannot duplicate anything and the shot-type phrasing is
+    // never rendered at all.
+    expect(
+      described,
+      'every sampled product was an unlabelled one, so no gallery with described shots was checked',
+    ).toBeGreaterThan(0)
+  })
+
 })

--- a/apps/web/src/app/products/[slug]/page.tsx
+++ b/apps/web/src/app/products/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Product } from "@/lib/types";
 import { promises as fs } from "fs";
 import { marked } from "marked";
 import Header from "@/components/header";
+import { galleryAlt } from "@/lib/gallery-alt";
 import { notFound } from "next/navigation";
 
 // This function gets called at build time
@@ -136,7 +137,11 @@ export default async function Page({
         >
           <Image
             src={image}
-            alt={product.name}
+            // Not `product.name` on all of them, which announced the same
+            // six words once per picture and told a screen-reader user
+            // nothing about any of them. See lib/gallery-alt.ts for why the
+            // wording stays as close to the filename's claim as it does.
+            alt={galleryAlt(product.name, image, i)}
             width={550}
             height={550}
             // `max-w-[550px]` caps the box, so it stops growing once the

--- a/apps/web/src/lib/gallery-alt.test.ts
+++ b/apps/web/src/lib/gallery-alt.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { galleryAlt, GALLERY_ROLES } from './gallery-alt'
+
+/**
+ * Alt text for the product gallery, checked against the real catalogue.
+ *
+ * Every image used to carry `alt={product.name}`, so a screen reader announced
+ * "TrailMaster X4 Tent" once per picture — five times in a row for most
+ * products, learning nothing about any of them.
+ *
+ * The catalogue names most of its files by shot type, and this turns that into
+ * words. It is a translation, not a description: nobody has looked at the
+ * pictures, and `angle.webp` is the catalogue's own label rather than an
+ * observation about what is in the frame.
+ *
+ * The sweep below runs over `public/products.json` itself rather than fixtures.
+ * The properties being asserted are about what 852 real images produce, and a
+ * fixture would only restate the mapping back at itself.
+ */
+
+type Product = { name: string; images: string[] }
+
+async function catalogue(): Promise<Product[]> {
+  const file = await fs.readFile(
+    path.join(process.cwd(), 'public/products.json'),
+    'utf8',
+  )
+  return JSON.parse(file) as Product[]
+}
+
+const stemOf = (image: string) => path.basename(image, path.extname(image))
+
+describe('galleryAlt', () => {
+  it('reads a catalogue big enough for the sweeps below to mean anything', async () => {
+    const products = await catalogue()
+    expect(products.length).toBeGreaterThan(200)
+    expect(products.flatMap((product) => product.images).length).toBeGreaterThan(800)
+  })
+
+  it('has a phrase for every shot type the catalogue uses', async () => {
+    // The point of failing here rather than falling through to decorative: a
+    // new role word arriving with new photography is a decision about what to
+    // say, and silence is the one answer nobody chose.
+    const products = await catalogue()
+    const unnamed = /^[0-9a-f-]{30,}$/
+    const stems = new Set(
+      products
+        .flatMap((product) => product.images)
+        .map(stemOf)
+        .filter((stem) => !unnamed.test(stem)),
+    )
+    // `Object.hasOwn`, matching the function. With `in` the sweep walks the
+    // prototype chain and the two disagree on the one input this exists to
+    // refuse: a catalogue file called `valueOf.webp` would be reported as
+    // covered here while `galleryAlt` finds no own property and announces it
+    // as nothing.
+    const missing = Array.from(stems)
+      .filter((stem) => !Object.hasOwn(GALLERY_ROLES, stem))
+      .sort()
+    expect(
+      missing,
+      'shot types in the catalogue with no phrase, which would be announced as nothing',
+    ).toEqual([])
+  })
+
+  it('never announces the same thing twice within a product', async () => {
+    // The bug itself. Empty alts are excluded because a decorative image
+    // announces nothing at all, and any number of those is fine.
+    const products = await catalogue()
+    const repeated: Record<string, string[]> = {}
+    for (const product of products) {
+      const spoken = product.images
+        .map((image, index) => galleryAlt(product.name, image, index))
+        .filter((alt) => alt !== '')
+      const duplicates = spoken.filter(
+        (alt, index) => spoken.indexOf(alt) !== index,
+      )
+      if (duplicates.length > 0) repeated[product.name] = duplicates
+    }
+    expect(repeated, 'products whose gallery repeats an announcement').toEqual({})
+  })
+
+  it('names the product exactly once in every gallery', async () => {
+    // Once, not zero: a gallery where every image is decorative would satisfy
+    // the check above and tell a screen-reader user nothing.
+    const products = await catalogue()
+    const wrong: Record<string, number> = {}
+    for (const product of products) {
+      const plain = product.images.filter(
+        (image, index) => galleryAlt(product.name, image, index) === product.name,
+      ).length
+      if (plain !== 1) wrong[product.name] = plain
+    }
+    expect(
+      wrong,
+      'products that name themselves other than exactly once across the gallery',
+    ).toEqual({})
+  })
+
+  it('describes the shot when the catalogue labels it', () => {
+    const name = 'TrailMaster X4 Tent'
+    expect(galleryAlt(name, '/images/products/tents/1/main.webp', 0)).toBe(name)
+    expect(galleryAlt(name, '/images/products/tents/1/angle.webp', 1)).toBe(
+      `${name}, another angle`,
+    )
+    expect(galleryAlt(name, '/images/products/tents/1/detail.webp', 2)).toBe(
+      `${name}, detail view`,
+    )
+    expect(galleryAlt(name, '/images/products/tents/1/lifestyle.webp', 3)).toBe(
+      `${name}, in use`,
+    )
+  })
+
+  it('falls back to decorative when the catalogue labels nothing', () => {
+    // The 20 products whose files are UUIDs. The first still names the product;
+    // the rest are marked decorative rather than described, because there is
+    // nothing here that knows what they show.
+    const name = 'Adventurer Pro Backpack'
+    const uuid = '/images/2/0b0e0e52-e3bf-4bf7-b1e1-3989c91d51a9.webp'
+    const other = '/images/2/5b73df27-5275-4437-b7cf-45b1eee175fb.webp'
+    expect(galleryAlt(name, uuid, 0)).toBe(name)
+    expect(galleryAlt(name, other, 1)).toBe('')
+    expect(galleryAlt(name, other, 4)).toBe('')
+  })
+
+  it('is not fooled by a filename matching an inherited property', () => {
+    // The lookup was `stem in GALLERY_ROLES`, and `in` walks the prototype
+    // chain, so an image called `toString.webp` announced "Widget, function
+    // toString() { [native code] }". No such file exists in the catalogue, and
+    // the sweep above used the same operator, so neither could have caught it.
+    expect(galleryAlt('Widget', '/images/x/toString.webp', 2)).toBe('')
+    expect(galleryAlt('Widget', '/images/x/constructor.webp', 0)).toBe('Widget')
+    expect(galleryAlt('Widget', '/images/x/hasOwnProperty.webp', 1)).toBe('')
+  })
+
+  it('describes a labelled shot wherever it sits in the gallery', () => {
+    // Position is not the signal, the label is. `main` is image 0 for all 190
+    // role-named products today, and nothing guarantees it stays that way.
+    const name = 'Alpine Explorer Tent'
+    expect(galleryAlt(name, '/images/products/tents/9/main.webp', 3)).toBe(name)
+    expect(galleryAlt(name, '/images/products/tents/9/angle.webp', 0)).toBe(
+      `${name}, another angle`,
+    )
+  })
+})

--- a/apps/web/src/lib/gallery-alt.ts
+++ b/apps/web/src/lib/gallery-alt.ts
@@ -1,0 +1,68 @@
+/**
+ * What a screen reader says about each image in a product gallery.
+ *
+ * Every image used to carry `alt={product.name}`, so a gallery of five
+ * announced the same six words five times and distinguished none of them.
+ *
+ * Most of the catalogue names its files by shot type — `main`, `angle`,
+ * `detail`, `lifestyle` — and this turns that label into words. It is mostly
+ * translation rather than description: nobody has looked at these pictures, so
+ * the phrasing stays close to what the filename claims. "another angle", not
+ * "side view" — the second asserts a viewpoint the label does not, and the
+ * first is the fact the listener actually needs, which is that this is the same
+ * product again.
+ *
+ * `lifestyle` is the one entry that infers rather than translates. It is a
+ * photography-genre label, and ", in use" says something about the content of
+ * the frame. It is the right inference and a mild one, but it is an inference,
+ * and the alternatives either over-claim or say nothing.
+ *
+ * Twenty of the 210 products have UUID filenames and no label at all. There is
+ * nothing to translate for those, so their images beyond the first are marked
+ * decorative rather than given a description invented here.
+ */
+
+/**
+ * Shot type to the phrase that follows the product name.
+ *
+ * An empty phrase means the image is the product plainly, and the name alone is
+ * the description.
+ *
+ * A shot type missing from this table *is* silently decorative as far as this
+ * function is concerned — there is nothing else it could safely do. What
+ * refuses is the sweep in `gallery-alt.test.ts`, which fails on any label the
+ * catalogue uses and this table lacks, because new photography arriving with a
+ * new label is a decision about what to say and silence is the one answer
+ * nobody chose. That guard only bites while the suite runs on catalogue
+ * changes.
+ */
+export const GALLERY_ROLES: Record<string, string> = {
+  main: '',
+  angle: 'another angle',
+  detail: 'detail view',
+  lifestyle: 'in use',
+  packed: 'packed for carrying',
+}
+
+export function galleryAlt(
+  productName: string,
+  imagePath: string,
+  index: number,
+): string {
+  const file = imagePath.split('/').pop() ?? ''
+  const stem = file.replace(/\.[^.]+$/, '')
+
+  // `Object.hasOwn`, not `in`: `in` walks the prototype chain, so an image
+  // called `toString.webp` would be announced as "…, function toString() {
+  // [native code] }". No such file exists, and the sweep uses the same lookup
+  // so it could not have seen one either.
+  if (Object.hasOwn(GALLERY_ROLES, stem)) {
+    const phrase = GALLERY_ROLES[stem]
+    return phrase ? `${productName}, ${phrase}` : productName
+  }
+
+  // Unlabelled. The first image still says what the product is, so the gallery
+  // is never entirely silent; the rest announce nothing, which is honest about
+  // how much is known about them.
+  return index === 0 ? productName : ''
+}


### PR DESCRIPTION
Closes #181.

Every gallery image carried `alt={product.name}`, so a screen reader announced
the same six words once per picture — five times for most products — and
distinguished none of them.

## What the catalogue actually holds

Measured before choosing an approach, because the issue's preferred option turned
out to cover only part of it:

| | products | images |
|---|---|---|
| labelled by shot type (`main`, `angle`, `detail`, `lifestyle`, one `packed`) | **190** | 749 |
| UUID filenames, no label | **20** | 102 |

No product mixes the two, and `main` is image[0] for all 190.

## The result

```
labelled     "NatureNest Shelter"
             "NatureNest Shelter, another angle"
             "NatureNest Shelter, detail view"
             "NatureNest Shelter, in use"

unlabelled   "TrailMaster X4 Tent"
             ""   ""   ""   ""      decorative
```

The phrasing stays close to what the filename claims. **"another angle", not "side
view"** — the second asserts a viewpoint the label does not, and the first carries
the fact a listener needs: this is the same product again. `lifestyle` → ", in
use" is the one entry that infers rather than translates, and the comment says so
rather than pretending the mapping is purely mechanical.

Unlabelled galleries name the product once and mark the rest decorative. Nothing
in this repository knows what those pictures show, and inventing a description is
worse than admitting that.

A shot type the table lacks is decorative as far as the function is concerned;
what refuses is the sweep, which fails on any label the catalogue uses and the
table does not have.

## Both bugs were in the guards, not the fix

- **The e2e reached a labelled product never.** All twenty home-page links are
  exactly the twenty UUID products, so following the first always landed on a
  gallery with one non-empty alt — and the test asserted that a one-element list
  had no duplicates. The phrasing this PR is about was never rendered by it. It
  samples a category page now and fails if nothing it sampled had more than one
  thing to say.
- **The table lookup used `in`**, which walks the prototype chain, so
  `toString.webp` would have announced *"Widget, function toString() { [native
  code] }"*. Function and sweep both use `Object.hasOwn` now; a catalogue seeded
  with `valueOf.webp` fails the sweep by name.

## Verification

`next build`, `tsc --noEmit`, repo-wide ESLint clean with exit codes read
directly. 134 vitest across 34 files; 53 Playwright; 142 Python guardrails.

Mutations: reverting the page fails the e2e duplicate check; pointing the e2e
back at the home page fails its vacuity guard; making labelled shots decorative
fails two unit tests; removing `packed` from the table fails the vocabulary sweep
naming the missing label.

## Filed, not folded in

- #200 — both listings put the product name in a link's text *and* in its image
  alt, so every card announces it twice. Higher volume than this fix, one word to
  correct, different surface.
- #201 — gallery images sit beside manual sections they have nothing to do with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)