### PR TITLE
docs: make the workflow measure, and give its gates a way out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,24 @@ Follow these steps in order for every change.
    argued rather than demonstrated is the defect the guard was added to
    prevent, one level up.
 
+   **Measure what was produced, not what was asked for.** A guard that reads a
+   declaration is measuring the request, and the two come apart constantly: a
+   colour Tailwind serialises as `lab()` reads as a different colour through a
+   regex for numbers; `ring-0` leaves its colour in the computed box-shadow
+   with no geometry to paint it; a zero-width border still reports a border
+   colour; a blurred shadow reports its source colour while every pixel it
+   paints is composited toward the background; `outlineWidth` reports the
+   user-agent default of `3px` for an outline whose style is `none`. Every one
+   of those passed a check that looked right and was measuring something
+   adjacent to the claim. Read the rendered pixels, the served bytes, the
+   accessibility tree — whatever the asserted thing actually is.
+
+   The same trap catches fixtures and samples. A surface in a spec labelled
+   "the hero photograph" was measuring white page copy, because the launcher it
+   sampled around cannot reach the hero at that viewport. Assert that the
+   sample is what its name says: a brightness band, an overlap, a count that
+   only the intended case produces.
+
    Point the guard at a fixture tree; do not damage the real one. These modules
    compute their paths at import, so rebind **every path constant the assertion
    dereferences** — found by reading the module, not guessed from its name.
@@ -177,6 +195,21 @@ Follow these steps in order for every change.
     How it signals is not obvious, and the part it does document is buried in
     a review body. See *The automated pull request reviewer* below before
     concluding it is done.
+
+    If no round arrives, that is a state to establish rather than assume, and
+    the file says why: `eyes` is only visible while a round lasts, so a pull
+    request twenty seconds after a push looks exactly like one the reviewer
+    will never touch. Establish it — pushed, polled past the latency recorded
+    below, `@codex review` requested, and no `eyes` appearing — and say what
+    was observed.
+
+    Then do the substitute work rather than pointing at work already done:
+    steps 6 through 8 ran before the pull request existed, so run `code-review`
+    once more against the pull request head, and go on to step 12 on that.
+    Silence is not approval, and it is also not a reason to leave a reviewed,
+    passing pull request unmerged indefinitely. What is never allowed is
+    recording silence as a clean round, or reaching this paragraph by not
+    waiting.
 
 12. **Merge only clean, passing pull requests.** Merge only after GitHub
     reports a clean merge state and every configured check passes. Never bypass
@@ -300,8 +333,30 @@ assumed square corners and failed a compliant rounded control by six pixels.
 ### Sub-agents this workflow depends on
 
 Steps 6 through 8 use `ui-review`, `verifier`, and `code-review`, defined in
-`.claude/agents/`. All three run unattended: they cannot ask a question and
-cannot modify the repository they assess.
+`.claude/agents/`. All three run unattended: they cannot ask a question, and
+they are instructed not to modify the repository they assess. That is an
+instruction rather than a sandbox — each of them has `Bash` — so if a review
+round is followed by working-tree changes you did not make, check `git status`
+before assuming they are yours.
+
+**Their findings are claims, not verdicts.** Check the ones a change depends
+on. This workflow has had a rendered review call a compliant focus indicator
+"completely invisible" — acted on, it produced a guard that rejected a correct
+design — and the same review quote a contrast ratio the running build measured
+differently, zinc-400 at 2.56:1 against a measured 2.62:1. Both were believed
+before they were checked. Address every finding, and where one is wrong, say so
+with the measurement rather than complying; step 11 sets that standard for the
+automated reviewer, and it is the same standard here.
+
+Record a disputed finding where someone else can audit it, and note when:
+carried into the body of the commit step 9 is about to make, or into the pull
+request body when the dispute arises after committing. Neither surface exists
+while step 8 is running, so this is a commitment about what gets written, not a
+precondition to satisfy first. Step 8's loop ends on a round returning no
+defects, and a defect disputed rather than fixed counts as cleared only if it
+is written down that way — a commit whose body omits it means step 8 did not
+clear. Otherwise "I checked, it was wrong" lives inside one agent's reasoning,
+and the gate opens with nothing to inspect.
 
 If one is unavailable — a different assistant, or a session started before the
 definitions landed — carry out that step's intent directly and say which agent

--- a/tests/scripts/test_agent_definitions.py
+++ b/tests/scripts/test_agent_definitions.py
@@ -1,8 +1,9 @@
 """Guard AGENTS.md's claims about the workflow sub-agents against their definitions.
 
 AGENTS.md states that `ui-review`, `verifier`, and `code-review` are defined in
-`.claude/agents/`, that all three run unattended, and that none can modify the
-repository it assesses. Those claims are load-bearing: the first is why the
+`.claude/agents/`, that all three run unattended, and that each is *instructed*
+not to modify the repository it assesses — an instruction rather than a sandbox,
+because each of them has `Bash`. Those claims are load-bearing: the first is why the
 workflow can run without a human present, the second is why a review agent is
 trusted to look at uncommitted work.
 
@@ -83,6 +84,20 @@ def step_that_invokes(agent: str) -> int | None:
     return None
 
 
+def body_of(path: Path) -> str:
+    """Everything after the frontmatter.
+
+    The instruction being checked has to be in the agent's operating rules, not
+    in its `description:`. The description is a routing hint the caller reads
+    when picking an agent; it is not something the agent is told. Matching the
+    whole file passed on `description: ... does not modify code.` for two of the
+    three agents, so the check was live for exactly the one whose description
+    happened to omit the phrase.
+    """
+    parts = path.read_text(encoding="utf-8").split("---", 2)
+    return parts[2] if len(parts) > 2 else ""
+
+
 class AgentDefinitionTests(unittest.TestCase):
     def test_every_agent_the_docs_name_exists(self):
         for name in sorted(EXPECTED_STEP):
@@ -130,8 +145,15 @@ class AgentDefinitionTests(unittest.TestCase):
                         "AGENTS.md claims these agents run unattended",
                     )
 
-    def test_agents_cannot_modify_the_repository(self):
-        """AGENTS.md claims none of them can modify what they assess."""
+    def test_agents_have_no_direct_editing_tools(self):
+        """AGENTS.md claims none of them carries a tool whose purpose is editing.
+
+        Deliberately not "cannot modify": every one of them has `Bash` and could
+        write a file with it. AGENTS.md says so, and `test_agents_are_told_not_to_modify_and_could`
+        below guards the other half of that sentence. What this checks is the
+        weaker, true claim — that none of them is *equipped* to edit as a matter
+        of course.
+        """
         for name in sorted(defined_agents() | set(EXPECTED_STEP)):
             with self.subTest(agent=name):
                 tools = tools_of(frontmatter(AGENTS_DIR / f"{name}.md"))
@@ -140,9 +162,38 @@ class AgentDefinitionTests(unittest.TestCase):
                     self.assertNotIn(
                         banned,
                         tools,
-                        f"{name} has {banned}, so it can modify the repository it reviews; "
-                        "AGENTS.md claims it cannot",
+                        f"{name} has {banned}, an editing tool; AGENTS.md claims "
+                        "these agents carry none",
                     )
+
+    def test_agents_are_told_not_to_modify_and_could(self):
+        """Both halves of "an instruction rather than a sandbox".
+
+        AGENTS.md was corrected to say these agents are *instructed* not to
+        modify what they assess, rather than that they cannot — because each has
+        `Bash` and plainly could. That correction put two new factual claims into
+        the prose and neither was guarded: strip `Bash` from one agent, or drop
+        the instruction from its body, and the documentation goes wrong with the
+        suite green. That is the failure this module exists to prevent.
+        """
+        for name in sorted(defined_agents() | set(EXPECTED_STEP)):
+            with self.subTest(agent=name):
+                self.assertIn(
+                    "Bash",
+                    tools_of(frontmatter(AGENTS_DIR / f"{name}.md")),
+                    f"{name} has no Bash; AGENTS.md says each of them has it, and "
+                    "uses that to explain why not modifying is an instruction "
+                    "rather than a sandbox",
+                )
+                # `never modify` is a separate branch rather than redundant with
+                # `not modify` — it contains no "not".
+                self.assertRegex(
+                    body_of(AGENTS_DIR / f"{name}.md"),
+                    r"(?i)(?:do(?:es)? not|never) modify",
+                    f"{name} does not tell itself to leave the repository alone "
+                    "anywhere in its operating rules; AGENTS.md claims all three "
+                    "are instructed not to",
+                )
 
     def test_agent_description_matches_the_step_that_invokes_it(self):
         """The step number is read from AGENTS.md, not hardcoded.


### PR DESCRIPTION
Four changes to `AGENTS.md` from reading it against a long working session, plus
the guardrail that had to move with one of them.

Verified first, so the scope is clear: every documented `make` target and `npm`
script exists, #152 is cited correctly, all three path constants step 4 names
still exist, and every step cross-reference survived the last renumber. The file
was in good factual shape — these are gaps, not rot.

## 1. Step 4: measure what was produced, not what was asked for

The most-repeated defect in recent work, and it was not in the file. Guards that
read a declaration rather than what was painted:

| the guard read | what was true |
|---|---|
| a `lab()` colour through a regex for numbers | a different colour entirely — sky-700 as a near-black plum |
| `ring-0`'s colour | no geometry to paint it |
| a zero-width border's colour | nothing drawn |
| a blurred shadow's source colour | every painted pixel composited toward the background |
| `outlineWidth` | the UA default `3px` when `outlineStyle` is `none` |

Every one passed a check that looked right. A second paragraph makes the same
point about samples: a spec surface labelled "the hero photograph" was measuring
white page copy, because the control it sampled around cannot reach the hero at
that viewport.

## 2. Step 11 could deadlock

Step 12 requires step 11 cleared, and step 11's only guidance when no round
arrives was *report it*. A fork, a disabled bot, or an outage had no route to
merge — and the file already documents that state as reachable (#195 had two
pushes draw nothing).

It now requires **establishing** that state rather than assuming it, since the
file itself says absence of `eyes` carries no signal, and requires the substitute
work — a fresh `code-review` against the PR head — rather than pointing back at
steps 6–8, which ran before the PR existed.

## 3. "cannot modify the repository they assess" was false

All three sub-agents carry `Bash`. It is an instruction, not a sandbox.

`test_agent_definitions.py` exists to keep exactly that sentence true, so it moved
with it. **And reading the body matters:** matching the whole file passed on
`description: … does not modify code.` for two of three agents, so the check was
live only for the one whose description omits the phrase — and my first mutation
happened to be that one, proving nothing. Redacting the instruction from each body
now fails for all three, individually.

## 4. The deference was backwards

Step 11 told the agent to argue back at the vendor bot with a measurement. Steps
6–8 said only "address every actionable finding" — so the in-house reviewers got
*more* deference than the third-party tool. That cost real work: a rendered review
called a compliant focus indicator "completely invisible" (acted on, it produced a
guard that rejected a correct design) and quoted zinc-400 at 2.56:1 where the build
measures 2.62:1, overruling the correct number.

Disagreement now carries step 11's standard, and must be recorded in the commit or
PR body so it is auditable rather than internal to one agent's reasoning.

## Verification

`make docs-check` (7) and `make test-scripts` (**143**, up from 142) pass. The new
guard is mutation-verified in both directions: stripping `Bash` fails by name, and
redacting the body instruction fails for each of the three agents while leaving
the frontmatter untouched.

Three review rounds. Round 2 raised two claims I checked rather than accepted —
that `not modify` subsumed the regex alternation (it does not; "never modify"
contains no "not", and dropping the branches would have blinded the guard to two
of three agents), and that the contrast incident might have been the vendor bot
(it was the rendered review). Round 3 confirmed both corrections independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)