### PR TITLE
docs(agents): clarify scoped review rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,13 +12,21 @@ Paste command output snippets or concise summaries for what you actually ran.
 
 ### Required
 - [ ] `make quick-ci-changed`
+- [ ] Applicable merge-gate command(s) from the `AGENTS.md` validation matrix
 - [ ] `make test-scripts` (for runtime/scripts/docs automation changes)
 - [ ] `make docs-check` (for docs/runbook changes)
+- [ ] `ui-review`: rendered evidence, static fallback, or concrete not-applicable reason
+- [ ] `verifier`: verdict and exact commands
+- [ ] `code-review`: no defects; refinements recorded below
 
 ### Optional / Contextual
 - [ ] `make quick-ci`
-- [ ] `make ci` (run outside restricted sandbox if `next build` hits `listen EPERM`)
 - [ ] Manual UX/API validation
+
+### Before merge
+- [ ] Pull request head still matches the reviewed SHA
+- [ ] Codex final-head review is clear and every Codex thread is resolved
+- [ ] GitHub reports a clean merge state and all configured checks pass
 
 ## Release and Ops Impact
 - Env contract change: yes / no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,12 @@ Use this file as the default runbook for coding agents.
 
 ## Source of truth
 
-`AGENTS.md` is the single source of truth for agent instructions. Assistants that read
-their own context file get a pointer to `AGENTS.md` and nothing else:
+`AGENTS.md` is the canonical format for agent instructions. The root file defines
+repository-wide policy; a nested `AGENTS.md` adds authoritative instructions for
+its subtree. Apply both, from the root down to the file closest to the work.
+
+Assistant-specific context files are pointers only. They contain no independent
+instructions:
 
 | Assistant | Pointer file | Points at |
 | --- | --- | --- |
@@ -23,6 +27,7 @@ Scopes with their own runbook:
 - `AGENTS.md` (repo-wide)
 - `apps/web/AGENTS.md`
 - `services/chat/AGENTS.md`
+- `tests/scripts/AGENTS.md`
 
 Never add instructions to a pointer file. That includes memories captured by pressing
 `#` in Claude Code, which append to the nearest `CLAUDE.md` — move that text into the
@@ -35,6 +40,19 @@ moving the content across:
 ```bash
 make agent-docs-check FIX=1
 ```
+
+## Code Review Rules
+
+- Treat changes at system seams as one contract. When a change touches the web/chat
+  payload, Prisma schema and handwritten SQL, dependency manifests and constraints,
+  or container inputs and runtime files, inspect and validate both sides.
+- Require guards to measure effective behavior, not a nearby declaration. Reject
+  vacuous loops, mislabeled samples, or configuration checks that never exercise the
+  rendered pixels, served bytes, accessibility tree, resolved files, or tool output
+  named by the assertion.
+- For runtime and container changes, verify the built artifact and real integration
+  path. Unit tests cannot prove that a file was copied into an image, a service starts
+  with its deployed configuration, or the web/chat/database path works together.
 
 ## Development workflow
 
@@ -83,31 +101,10 @@ Follow these steps in order for every change.
    adjacent to the claim. Read the rendered pixels, the served bytes, the
    accessibility tree — whatever the asserted thing actually is.
 
-   The same trap catches fixtures and samples. A surface in a spec labelled
-   "the hero photograph" was measuring white page copy, because the launcher it
-   sampled around cannot reach the hero at that viewport. Assert that the
-   sample is what its name says: a brightness band, an overlap, a count that
-   only the intended case produces.
-
-   Point the guard at a fixture tree; do not damage the real one. These modules
-   compute their paths at import, so rebind **every path constant the assertion
-   dereferences** — found by reading the module, not guessed from its name.
-   That is more than the obvious one and is different per guard:
-   `test_image_encoding.py` reaches everything through `IMAGES_DIR`;
-   `test_image_references.py` also needs `PUBLIC_DIR`, which its `relative_to`
-   depends on, and `REPO_ROOT`, which it walks for references;
-   `test_page_headings.py` reads `REPO_ROOT` directly for the
-   component-supplied headings, so rebinding `APP_DIR` alone leaves that
-   assertion on the checkout. Rebinding a root that other constants were
-   derived from at import changes nothing they read.
-
-   Then confirm the run opened the fixture at all: a failure naming a path
-   inside it, or a vacuity guard reporting a count that matches what the
-   fixture holds. The count is the evidence, not the firing — a vacuity guard
-   fires on nothing found, which is equally what a mistyped fixture path
-   produces, and the assertions being demonstrated pass on the empty loop
-   either way. A green run that never opened the fixture looks exactly like a
-   guard that works.
+   The same trap catches fixtures and samples. Assert that a sample is what its
+   name says — for example, a brightness band, an overlap, or a count that only
+   the intended case produces. Fixture-isolation rules for the root guard suite
+   live in `tests/scripts/AGENTS.md`.
 
 5. **Inspect the complete diff.** Review the branch diff plus all staged,
    unstaged, and untracked files. Remove accidental or unrelated changes while
@@ -181,6 +178,9 @@ Follow these steps in order for every change.
       reopens here.
     - Do not repeat code review when the already-reviewed diff and worktree
       remain unchanged.
+    - Immediately before the push that creates or updates the pull request,
+      record the expected local `HEAD` SHA and a UTC cutoff. Carry both into
+      step 11 so an old review signal cannot satisfy the final-head gate.
     - Push and create the pull request only after local verification and any
       required code review are complete.
     - Open a normal, ready-for-review pull request by default. Do not open
@@ -192,16 +192,22 @@ Follow these steps in order for every change.
     thread. Treat its findings as real; when it is wrong, argue back with a
     measurement rather than complying, and say so in the reply.
 
-    How it signals is not obvious, and the part it does document is buried in
-    a review body. See *The automated pull request reviewer* below before
-    concluding it is done.
+    Confirm the pull request head still equals the SHA recorded before the last
+    push. Unless a fresh round is already observed for that head, request one
+    with an exact `@codex review` pull request comment. Automatic rounds after
+    pushes have been observed here, but they are not a documented trigger and
+    are not evidence until their start or outcome is observed.
+
+    How the reviewer signals is not obvious, and the clean-round convention is
+    documented in its review body rather than the public product documentation.
+    See *The automated pull request reviewer* below before concluding it is done.
 
     If no round arrives, that is a state to establish rather than assume, and
     the file says why: `eyes` is only visible while a round lasts, so a pull
     request twenty seconds after a push looks exactly like one the reviewer
-    will never touch. Establish it — pushed, polled past the latency recorded
-    below, `@codex review` requested, and no `eyes` appearing — and say what
-    was observed.
+    will never touch. Establish it — expected head unchanged, polled past the
+    latency recorded below, exact `@codex review` requested, and no `eyes`
+    appearing — and say what was observed.
 
     Then do the substitute work rather than pointing at work already done:
     steps 6 through 8 ran before the pull request existed, so run `code-review`
@@ -256,16 +262,24 @@ that falls outside the current change needs the main agent to file it.
 
 ### The automated pull request reviewer
 
-Observed on 2026-08-09 across pull requests #195 and #198. Not taken from the
-tool's own description, which lists triggers that do not match what happened.
-This is vendor behaviour and liable to drift, so read it as what was seen rather
-than what is guaranteed, and re-check it if it stops matching.
+Observed on 2026-08-09 across pull requests #195, #198, and #206. The
+[Codex GitHub review documentation](https://developers.openai.com/codex/integrations/github)
+guarantees the exact `@codex review` trigger and, when Automatic reviews are
+enabled for that event, review when a pull request is opened for review.
+Push-triggered rounds and the clean reaction behavior below are repository
+observations, not a public contract. This is vendor behavior and liable to drift,
+so re-check it if it stops matching.
 
 `chatgpt-codex-connector[bot]` signals through **reactions on the pull request**
 — `GET /repos/:owner/:repo/issues/:number/reactions`, the issue endpoint.
 `gh pr view --json reactionGroups` does return them, but only as a content and a
 count, with no reacting login, which is exactly the part the condition below
 turns on.
+
+GitHub spells the same identity differently across APIs. REST returns
+`chatgpt-codex-connector[bot]`; GraphQL review-thread `author.login` returns
+`chatgpt-codex-connector`. Account for both rather than filtering every response
+with one literal.
 
 - `eyes` means a round is running, and is removed when that round ends. It is
   only visible while it lasts, so seeing no `eyes` says nothing.
@@ -279,8 +293,9 @@ turns on.
 - A clean round posts **no review at all** — not an empty one — and leaves
   `+1`, which persists. Its only other trace is `eyes` appearing and clearing.
 
-**Done means a `+1` from that login, created later than both the last push and
-the newest inline comment from it, with every one of its threads resolved.**
+**Done means the pull request head still matches the recorded SHA, a `+1` from
+that login was created after both the recorded UTC cutoff and its newest inline
+comment, and every one of its threads is resolved.**
 
 Each clause is there because a simpler version is wrong:
 
@@ -378,6 +393,7 @@ review that claims viewports it never rendered is worse than none.
   `scripts/e2e_smoke.py`, which runs against a real stack.
 - `services/chat/Makefile`: chat-owned dev/test command surface.
 - `services/chat/AGENTS.md`: chat-scoped agent runbook.
+- `tests/scripts/AGENTS.md`: fixture and mutation rules for root guard tests.
 - `apps/web/prisma/`: shared data model and migrations.
 - `infrastructure/`: deployment scripts and Terraform.
 - `docs/`: operator and architecture docs.
@@ -501,12 +517,23 @@ Copy templates to `.env` before local development.
 
 ## Validation expectations
 
-- Default agent loop: `make quick-ci-changed`
-- Range-scoped agent validation: `CHANGED_BASE=<base_sha> CHANGED_HEAD=<head_sha> make quick-ci-changed`
-- Web-only change: `make -C apps/web quick-ci`
-- Chat-only change: `make quick-ci-chat`
-- Scripts/tooling change: `make test-scripts`
-- Cross-surface change (web + chat + schema): `make ci`
+Use `make quick-ci-changed` during implementation, and rerun it against an
+explicit range when validating committed work:
+
+```bash
+CHANGED_BASE=<base-sha> CHANGED_HEAD=<head-sha> make quick-ci-changed
+```
+
+Before pushing, run the merge-gate command for every changed surface:
+
+- Web: `make -C apps/web ci` (includes lint, type-check, tests, and build)
+- Chat: `make -C services/chat ci`
+- Scripts/tooling: `make test-scripts`
+- Documentation/runbooks: `make docs-check`
+- Cross-surface or repository-wide: `make ci`
+
+Add integration confidence where the change crosses a runtime boundary:
+
 - Cross-surface integration confidence: `make e2e-smoke`
 - Contract-only integration confidence (minimal chat stack): `make e2e-smoke-lite`
 - Full local-provider integration confidence: `make e2e-smoke-full`
@@ -535,7 +562,9 @@ Copy templates to `.env` before local development.
 
 ## Building and running
 
-Before submitting any changes, it is crucial to validate them by running the full build and lint check. This command will build the repository and lint the code.
+Follow the validation matrix above. `make quick-ci-changed` is the iteration loop,
+not a substitute for the applicable merge-gate command. Web merge gates include a
+production build through `make -C apps/web ci` or `make ci`.
 
 When doing git operations use the GitHub CLI `gh` where possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If your change involves the database:
 
 Refer to:
 
-- `AGENTS.md` for coding agent runbooks and command conventions. It is the single source of truth for agent instructions; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are pointers only.
+- `AGENTS.md` files for coding agent runbooks and command conventions. The root policy combines with the nearest nested runbook; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are pointers only.
 - `docs/` for architecture, database, deployment, and release runbooks.
 
 ### Quick Troubleshooting

--- a/README.md
+++ b/README.md
@@ -215,9 +215,10 @@ make -C services/chat dev
 make -C services/chat ci
 ```
 
-For coding agents, see [AGENTS.md](./AGENTS.md). It is the single source of truth for
-agent instructions; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are
-pointers to it and must stay that way (CI enforces this via `make agent-docs-check`).
+For coding agents, start with [AGENTS.md](./AGENTS.md). `AGENTS.md` is the canonical
+instruction format: the root policy combines with the nearest nested runbook for a
+changed path. `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are
+pointers only, enforced by `make agent-docs-check`.
 
 PR CI uses changed-scope checks (same detector logic as `make quick-ci-changed`), while pushes to `main` run full `make ci`.
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,7 +1,8 @@
 # AGENTS (Web)
 
-Web app scope for coding agents. Source of truth for this scope: put instructions
-here, never in `apps/web/CLAUDE.md`. See the repo-root `AGENTS.md` for the policy.
+Web app scope for coding agents. This file adds authoritative instructions for
+`apps/web/`; apply it together with the repo-root `AGENTS.md`. Put instructions
+here, never in `apps/web/CLAUDE.md` or `apps/web/GEMINI.md`.
 
 ## Entry points
 
@@ -27,7 +28,7 @@ npm run dev:web
 npm run ci:web
 ```
 
-From web app directory:
+From the web app directory:
 
 ```bash
 make help
@@ -42,7 +43,8 @@ make ci
 - Web proxy route: `src/app/api/chat/service/route.ts`
 - Web chat client: `src/lib/messaging.ts`
 
-When changing request/response shape, update chat service and tests in `services/chat/` as part of the same change.
+When changing a request or response shape, update the chat service and its tests
+in `services/chat/` as part of the same change.
 
 ## Database access
 
@@ -58,126 +60,34 @@ The production image builds with `NEXT_BUILD_SKIP_DB=1`, so anything Next
 prerenders at build time captures the no-database response permanently. Route
 handlers that read the database must opt out of static prerendering.
 
-## Guardrails
+## Code Review Rules
 
-- Keep environment usage centralized and explicit.
-- Avoid hard-coding service URLs in component code.
-- Prefer tests alongside changed route modules and lib functions.
+- A route that reads the database must remain dynamic under the production
+  `NEXT_BUILD_SKIP_DB=1` build. Flag a change that can bake a build-time empty or
+  fallback response into the deployed route instead of evaluating it at request time.
+- Treat the web proxy, `src/lib/messaging.ts`, and the FastAPI request/response
+  models as one contract. A payload change is incomplete unless both surfaces and
+  their contract tests agree, including error and degraded responses.
+- For UI changes, review the rendered behavior rather than class names alone.
+  Preserve keyboard/focus semantics and responsive states; when `srcset` or source
+  dimensions change, require evidence at representative 1x and 2x densities.
 
-## JavaScript/TypeScript
+## JavaScript, TypeScript, and React conventions
 
-When contributing to this Next, React, Node, and TypeScript codebase, please prioritize the use of plain JavaScript objects with accompanying TypeScript interface or type declarations over JavaScript class syntax. This approach offers significant advantages, especially concerning interoperability with React and overall code maintainability.
-
-### Preferring Plain Objects over Classes
-
-JavaScript classes, by their nature, are designed to encapsulate internal state and behavior. While this can be useful in some object-oriented paradigms, it often introduces unnecessary complexity and friction when working with React's component-based architecture. Here's why plain objects are preferred:
-
-- Seamless React Integration: React components thrive on explicit props and state management. Classes' tendency to store internal state directly within instances can make prop and state propagation harder to reason about and maintain. Plain objects, on the other hand, are inherently immutable (when used thoughtfully) and can be easily passed as props, simplifying data flow and reducing unexpected side effects.
-
-- Reduced Boilerplate and Increased Conciseness: Classes often promote the use of constructors, this binding, getters, setters, and other boilerplate that can unnecessarily bloat code. TypeScript interface and type declarations provide powerful static type checking without the runtime overhead or verbosity of class definitions. This allows for more succinct and readable code, aligning with JavaScript's strengths in functional programming.
-
-- Enhanced Readability and Predictability: Plain objects, especially when their structure is clearly defined by TypeScript interfaces, are often easier to read and understand. Their properties are directly accessible, and there's no hidden internal state or complex inheritance chains to navigate. This predictability leads to fewer bugs and a more maintainable codebase.
-
-- Simplified Immutability: While not strictly enforced, plain objects encourage an immutable approach to data. When you need to modify an object, you typically create a new one with the desired changes, rather than mutating the original. This pattern aligns perfectly with React's reconciliation process and helps prevent subtle bugs related to shared mutable state.
-
-- Better Serialization and Deserialization: Plain JavaScript objects are naturally easy to serialize to JSON and deserialize back, which is a common requirement in web development (e.g., for API communication or local storage). Classes, with their methods and prototypes, can complicate this process.
-
-### Embracing ES Module Syntax for Encapsulation
-
-Rather than relying on Java-esque private or public class members, which can be verbose and sometimes limit flexibility, we strongly prefer leveraging ES module syntax (`import`/`export`) for encapsulating private and public APIs.
-
-- Clearer Public API Definition: With ES modules, anything that is exported is part of the public API of that module, while anything not exported is inherently private to that module. This provides a very clear and explicit way to define what parts of your code are meant to be consumed by other modules.
-
-- Enhanced Testability (Without Exposing Internals): By default, unexported functions or variables are not accessible from outside the module. This encourages you to test the public API of your modules, rather than their internal implementation details. If you find yourself needing to spy on or stub an unexported function for testing purposes, it's often a "code smell" indicating that the function might be a good candidate for extraction into its own separate, testable module with a well-defined public API. This promotes a more robust and maintainable testing strategy.
-
-- Reduced Coupling: Explicitly defined module boundaries through import/export help reduce coupling between different parts of your codebase. This makes it easier to refactor, debug, and understand individual components in isolation.
-
-### Avoiding `any` Types and Type Assertions; Preferring `unknown`
-
-TypeScript's power lies in its ability to provide static type checking, catching potential errors before your code runs. To fully leverage this, it's crucial to avoid the `any` type and be judicious with type assertions.
-
-- **The Dangers of `any`**: Using any effectively opts out of TypeScript's type checking for that particular variable or expression. While it might seem convenient in the short term, it introduces significant risks:
-  - **Loss of Type Safety**: You lose all the benefits of type checking, making it easy to introduce runtime errors that TypeScript would otherwise have caught.
-  - **Reduced Readability and Maintainability**: Code with `any` types is harder to understand and maintain, as the expected type of data is no longer explicitly defined.
-  - **Masking Underlying Issues**: Often, the need for any indicates a deeper problem in the design of your code or the way you're interacting with external libraries. It's a sign that you might need to refine your types or refactor your code.
-
-- **Preferring `unknown` over `any`**: When you absolutely cannot determine the type of a value at compile time, and you're tempted to reach for any, consider using unknown instead. unknown is a type-safe counterpart to any. While a variable of type unknown can hold any value, you must perform type narrowing (e.g., using typeof or instanceof checks, or a type assertion) before you can perform any operations on it. This forces you to handle the unknown type explicitly, preventing accidental runtime errors.
-
-  ```
-  function processValue(value: unknown) {
-     if (typeof value === 'string') {
-        // value is now safely a string
-        console.log(value.toUpperCase());
-     } else if (typeof value === 'number') {
-        // value is now safely a number
-        console.log(value * 2);
-     }
-     // Without narrowing, you cannot access properties or methods on 'value'
-     // console.log(value.someProperty); // Error: Object is of type 'unknown'.
-  }
-  ```
-
-- **Type Assertions (`as Type`) - Use with Caution**: Type assertions tell the TypeScript compiler, "Trust me, I know what I'm doing; this is definitely of this type." While there are legitimate use cases (e.g., when dealing with external libraries that don't have perfect type definitions, or when you have more information than the compiler), they should be used sparingly and with extreme caution.
-  - **Bypassing Type Checking**: Like `any`, type assertions bypass TypeScript's safety checks. If your assertion is incorrect, you introduce a runtime error that TypeScript would not have warned you about.
-  - **Code Smell in Testing**: A common scenario where `any` or type assertions might be tempting is when trying to test "private" implementation details (e.g., spying on or stubbing an unexported function within a module). This is a strong indication of a "code smell" in your testing strategy and potentially your code structure. Instead of trying to force access to private internals, consider whether those internal details should be refactored into a separate module with a well-defined public API. This makes them inherently testable without compromising encapsulation.
-
-### Embracing JavaScript's Array Operators
-
-To further enhance code cleanliness and promote safe functional programming practices, leverage JavaScript's rich set of array operators as much as possible. Methods like `.map()`, `.filter()`, `.reduce()`, `.slice()`, `.sort()`, and others are incredibly powerful for transforming and manipulating data collections in an immutable and declarative way.
-
-Using these operators:
-
-- Promotes Immutability: Most array operators return new arrays, leaving the original array untouched. This functional approach helps prevent unintended side effects and makes your code more predictable.
-- Improves Readability: Chaining array operators often lead to more concise and expressive code than traditional for loops or imperative logic. The intent of the operation is clear at a glance.
-- Facilitates Functional Programming: These operators are cornerstones of functional programming, encouraging the creation of pure functions that take inputs and produce outputs without causing side effects. This paradigm is highly beneficial for writing robust and testable code that pairs well with React.
-
-By consistently applying these principles, we can maintain a codebase that is not only efficient and performant but also a joy to work with, both now and in the future.
-
-## React (mirrored and adjusted from [react-mcp-server](https://github.com/facebook/react/blob/4448b18760d867f9e009e810571e7a3b8930bb19/compiler/packages/react-mcp-server/src/index.ts#L376C1-L441C94))
-
-### Role
-
-You are a React assistant that helps users write more efficient and optimizable React code. You specialize in identifying patterns that enable React Compiler to automatically apply optimizations, reducing unnecessary re-renders and improving application performance.
-
-### Follow these guidelines in all code you produce and suggest
-
-Use functional components with Hooks: Do not generate class components or use old lifecycle methods. Manage state with useState or useReducer, and side effects with useEffect (or related Hooks). Always prefer functions and Hooks for any new component logic.
-
-Keep components pure and side-effect-free during rendering: Do not produce code that performs side effects (like subscriptions, network requests, or modifying external variables) directly inside the component's function body. Such actions should be wrapped in useEffect or performed in event handlers. Ensure your render logic is a pure function of props and state.
-
-Respect one-way data flow: Pass data down through props and avoid any global mutations. If two components need to share data, lift that state up to a common parent or use React Context, rather than trying to sync local state or use external variables.
-
-Never mutate state directly: Always generate code that updates state immutably. For example, use spread syntax or other methods to create new objects/arrays when updating state. Do not use assignments like state.someValue = ... or array mutations like array.push() on state variables. Use the state setter (setState from useState, etc.) to update state.
-
-Accurately use useEffect and other effect Hooks: whenever you think you could useEffect, think and reason harder to avoid it. useEffect is primarily only used for synchronization, for example synchronizing React with some external state. IMPORTANT - Don't setState (the 2nd value returned by useState) within a useEffect as that will degrade performance. When writing effects, include all necessary dependencies in the dependency array. Do not suppress ESLint rules or omit dependencies that the effect's code uses. Structure the effect callbacks to handle changing values properly (e.g., update subscriptions on prop changes, clean up on unmount or dependency change). If a piece of logic should only run in response to a user action (like a form submission or button click), put that logic in an event handler, not in a useEffect. Where possible, useEffects should return a cleanup function.
-
-Follow the Rules of Hooks: Ensure that any Hooks (useState, useEffect, useContext, custom Hooks, etc.) are called unconditionally at the top level of React function components or other Hooks. Do not generate code that calls Hooks inside loops, conditional statements, or nested helper functions. Do not call Hooks in non-component functions or outside the React component rendering context.
-
-Use refs only when necessary: Avoid using useRef unless the task genuinely requires it (such as focusing a control, managing an animation, or integrating with a non-React library). Do not use refs to store application state that should be reactive. If you do use refs, never write to or read from ref.current during the rendering of a component (except for initial setup like lazy initialization). Any ref usage should not affect the rendered output directly.
-
-Prefer composition and small components: Break down UI into small, reusable components rather than writing large monolithic components. The code you generate should promote clarity and reusability by composing components together. Similarly, abstract repetitive logic into custom Hooks when appropriate to avoid duplicating code.
-
-Optimize for concurrency: Assume React may render your components multiple times for scheduling purposes (especially in development with Strict Mode). Write code that remains correct even if the component function runs more than once. For instance, avoid side effects in the component body and use functional state updates (e.g., setCount(c => c + 1)) when updating state based on previous state to prevent race conditions. Always include cleanup functions in effects that subscribe to external resources. Don't write useEffects for "do this when this changes" side effects. This ensures your generated code will work with React's concurrent rendering features without issues.
-
-Optimize to reduce network waterfalls - Use parallel data fetching wherever possible (e.g., start multiple requests at once rather than one after another). Leverage Suspense for data loading and keep requests co-located with the component that needs the data. In a server-centric approach, fetch related data together in a single request on the server side (using Server Components, for example) to reduce round trips. Also, consider using caching layers or global fetch management to avoid repeating identical requests.
-
-Rely on React Compiler - useMemo, useCallback, and React.memo can be omitted if React Compiler is enabled. Avoid premature optimization with manual memoization. Instead, focus on writing clear, simple components with direct data flow and side-effect-free render functions. Let the React Compiler handle tree-shaking, inlining, and other performance enhancements to keep your code base simpler and more maintainable.
-
-Design for a good user experience - Provide clear, minimal, and non-blocking UI states. When data is loading, show lightweight placeholders (e.g., skeleton screens) rather than intrusive spinners everywhere. Handle errors gracefully with a dedicated error boundary or a friendly inline message. Where possible, render partial data as it becomes available rather than making the user wait for everything. Suspense allows you to declare the loading states in your component tree in a natural way, preventing "flash" states and improving perceived performance.
-
-### Process
-
-1. Analyze the user's code for optimization opportunities:
-   - Check for React anti-patterns that prevent compiler optimization
-   - Look for component structure issues that limit compiler effectiveness
-   - Think about each suggestion you are making and consult React docs for best practices
-
-2. Provide actionable guidance:
-   - Explain specific code changes with clear reasoning
-   - Show before/after examples when suggesting changes
-   - Only suggest changes that meaningfully improve optimization potential
-
-### Optimization Guidelines
-
-- State updates should be structured to enable granular updates
-- Side effects should be isolated and dependencies clearly defined
+- Prefer functions, plain objects, and ES module boundaries when no instance identity
+  or lifecycle is required. Plain objects are mutable; never mutate React state, and
+  use a class when an external API or a test double genuinely requires one.
+- Avoid `any` and unchecked type assertions at application boundaries. Accept
+  `unknown`, validate or narrow it, and keep unavoidable assertions local with a
+  reason the compiler cannot establish the type itself.
+- Prefer non-mutating collection operations. `sort()` mutates; use `toSorted()` when
+  supported or sort a deliberate copy such as `[...items].sort(...)`.
+- Keep rendering pure and use functional components and Hooks. Effects synchronize
+  with external systems; derive values during render or update them in event handlers
+  when no external synchronization is involved. Clean up subscriptions and include
+  the dependencies the effect reads.
+- Do not assume React Compiler is enabled. Check the current Next configuration before
+  relying on compiler memoization, and add `useMemo`, `useCallback`, or `React.memo`
+  only when referential identity or measured performance makes it necessary.
+- Keep environment access centralized, avoid service URLs in components, and prefer
+  focused tests beside changed routes, components, and library modules.

--- a/scripts/check_agent_docs.py
+++ b/scripts/check_agent_docs.py
@@ -15,6 +15,7 @@ import argparse
 import difflib
 import os
 import posixpath
+import subprocess
 import sys
 from pathlib import Path
 
@@ -110,6 +111,36 @@ def normalize(text: str) -> list[str]:
 def find_agent_directories(root: Path) -> list[Path]:
     directories: set[Path] = set()
     tracked = {AGENTS_FILENAME, *SIBLING_POINTER_FILENAMES}
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "-z",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        result = None
+
+    if result is not None and result.returncode == 0:
+        for relative in result.stdout.split("\0"):
+            if not relative:
+                continue
+            path = Path(relative)
+            if SKIP_DIRECTORIES.intersection(path.parts):
+                continue
+            if path.name in tracked:
+                directories.add(root / path.parent)
+        return sorted(directories)
 
     for current_dir, dir_names, file_names in os.walk(root):
         dir_names[:] = [name for name in dir_names if name not in SKIP_DIRECTORIES]

--- a/services/chat/AGENTS.md
+++ b/services/chat/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS (Chat Service)
 
-FastAPI chat service scope for coding agents. Source of truth for this scope: put
-instructions here, never in `services/chat/CLAUDE.md`. See the repo-root `AGENTS.md`
-for the policy.
+FastAPI chat service scope for coding agents. This file adds authoritative
+instructions for `services/chat/`; apply it together with the repo-root
+`AGENTS.md`. Put instructions here, never in `services/chat/CLAUDE.md` or
+`services/chat/GEMINI.md`.
 
 ## Entry points
 
@@ -98,8 +99,14 @@ and migrations. When it changes, update the SQL in `db.py` to match — the
 queries name tables and columns explicitly and nothing verifies them at build
 time.
 
-## Guardrails
+## Code Review Rules
 
-- Preserve API compatibility for web callers in `apps/web/src/lib/messaging.ts`.
-- If request or response schema changes, update both unit tests and web proxy behavior.
-- Keep external provider configuration behind environment variables.
+- Treat `apps/web/prisma/schema.prisma` and the handwritten `asyncpg` queries as
+  one data contract. Schema changes must update affected SQL and exercise the
+  real migration/query path; a successful Python build cannot detect drift.
+- Preserve the web/chat API contract across FastAPI models, the web proxy, and
+  `apps/web/src/lib/messaging.ts`. Request, success, validation, degraded, and
+  error shapes must change together with unit and contract coverage.
+- Keep provider choice and credentials behind environment variables. Core chat
+  paths must not import optional local-LLM/vector dependencies unless the full
+  profile is selected, and dependency versions belong in `constraints.txt`.

--- a/tests/scripts/AGENTS.md
+++ b/tests/scripts/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS (Script Guardrails)
+
+Root script-test scope for coding agents. This file adds authoritative
+instructions for `tests/scripts/`; apply it together with the repo-root
+`AGENTS.md`. Put instructions here, never in the sibling pointer files.
+
+## Local commands
+
+Run from the repository root:
+
+```bash
+make test-scripts
+.venv/bin/python -m unittest tests.scripts.<module> -v
+```
+
+## Code Review Rules
+
+- Point a guard demonstration at a fixture tree, never the checkout it protects.
+  Rebind every imported path constant the assertion dereferences; changing a root
+  after derived constants were created does not redirect those constants.
+- Prove that the intended assertion catches its named mistake, and separately prove
+  the fixture was opened. A vacuity failure on an empty or mistyped path is not
+  evidence that the behavioral assertion ran.
+- Compare effective sets and outputs from the owning tool where practical. Parsing
+  one declaration is insufficient when includes, excludes, defaults, comments, or
+  other configuration can change what the compiler, runner, or hook actually uses.
+
+## Fixture isolation
+
+These modules compute path constants at import, so read the module and rebind every
+constant the demonstrated assertion reaches:
+
+- `test_image_encoding.py` reaches its files through `IMAGES_DIR`.
+- `test_image_references.py` also needs `PUBLIC_DIR`, which `relative_to` depends on,
+  and `REPO_ROOT`, which it walks for references.
+- `test_page_headings.py` reads `REPO_ROOT` directly for component-supplied headings,
+  so rebinding `APP_DIR` alone leaves that assertion pointed at the checkout.
+
+Confirm the run opened the fixture with a failure that names a fixture path or a
+vacuity guard whose count matches what the fixture contains. The count is the
+evidence: a vacuity guard also fires when a fixture path is mistyped, while every
+assertion inside the resulting empty loop passes.

--- a/tests/scripts/CLAUDE.md
+++ b/tests/scripts/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+`AGENTS.md` is the single source of truth for agent instructions in this scope.
+This file is a pointer only; it intentionally carries no instructions of its own.
+
+Read and follow [AGENTS.md](./AGENTS.md).
+
+<!--
+Do not add content to this file. Agent instructions belong in AGENTS.md, including
+memories captured by pressing `#` in Claude Code. `make agent-docs-check` fails
+when this pointer drifts.
+-->

--- a/tests/scripts/GEMINI.md
+++ b/tests/scripts/GEMINI.md
@@ -1,0 +1,12 @@
+# GEMINI.md
+
+`AGENTS.md` is the single source of truth for agent instructions in this scope.
+This file is a pointer only; it intentionally carries no instructions of its own.
+
+Read and follow [AGENTS.md](./AGENTS.md).
+
+<!--
+Do not add content to this file. Agent instructions belong in AGENTS.md, including
+memories captured by pressing `#` in Claude Code. `make agent-docs-check` fails
+when this pointer drifts.
+-->

--- a/tests/scripts/test_agent_runbooks.py
+++ b/tests/scripts/test_agent_runbooks.py
@@ -11,6 +11,12 @@ from scripts.check_agent_docs import SKIP_DIRECTORIES, find_agent_directories
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_RUNBOOKS = {
+    Path("AGENTS.md"),
+    Path("apps/web/AGENTS.md"),
+    Path("services/chat/AGENTS.md"),
+    Path("tests/scripts/AGENTS.md"),
+}
 
 
 def agent_runbooks(root: Path = REPO_ROOT) -> list[Path]:
@@ -23,25 +29,35 @@ def agent_runbooks(root: Path = REPO_ROOT) -> list[Path]:
     )
 
 
-def code_review_rules(path: Path) -> list[str] | None:
-    """Return bullets in the exact Codex review-rules section."""
+def missing_required_runbooks(
+    runbooks: list[Path], root: Path = REPO_ROOT
+) -> list[Path]:
+    """Return canonical runbook paths absent from the discovered repository set."""
+
+    discovered = {path.relative_to(root) for path in runbooks}
+    return sorted(REQUIRED_RUNBOOKS - discovered)
+
+
+def code_review_rule_sections(path: Path) -> list[list[str]]:
+    """Return rule bullets from each exact Codex review-rules section."""
 
     text = path.read_text(encoding="utf-8")
-    match = re.search(
+    matches = re.finditer(
         r"(?ms)^## Code Review Rules\s*$\n(?P<body>.*?)(?=^##\s|\Z)", text
     )
-    if match is None:
-        return None
-    return re.findall(r"(?m)^- .+$", match.group("body"))
+    return [re.findall(r"(?m)^- .+$", match.group("body")) for match in matches]
 
 
 def review_contract_error(path: Path) -> str | None:
     """Describe why one runbook does not provide a concise review contract."""
 
-    rules = code_review_rules(path)
+    sections = code_review_rule_sections(path)
     relative = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
-    if rules is None:
+    if not sections:
         return f"{relative} has no ## Code Review Rules section"
+    if len(sections) > 1:
+        return "runbooks should contain exactly one ## Code Review Rules section"
+    rules = sections[0]
     if len(rules) < 2:
         return "review guidance should name at least two durable checks"
     if len(rules) > 3:
@@ -54,10 +70,10 @@ class AgentRunbookTests(unittest.TestCase):
         """Codex should receive a concise, explicitly scoped review contract."""
 
         runbooks = agent_runbooks()
-        self.assertGreaterEqual(
-            len(runbooks),
-            4,
-            "expected root, web, chat, and script-guardrail agent runbooks",
+        self.assertEqual(
+            [],
+            missing_required_runbooks(runbooks),
+            "missing a canonical root, web, chat, or script-guardrail runbook",
         )
 
         for path in runbooks:
@@ -78,6 +94,11 @@ class AgentRunbookTests(unittest.TestCase):
                 "# AGENTS\n\n## Code Review Rules\n\n"
                 "- One.\n- Two.\n- Three.\n- Four.\n",
                 "keep review guidance concise",
+            ),
+            "duplicate-sections": (
+                "# AGENTS\n\n## Code Review Rules\n\n- One.\n- Two.\n\n"
+                "## Notes\n\nText.\n\n## Code Review Rules\n\n- Three.\n- Four.\n",
+                "exactly one ## Code Review Rules section",
             ),
         }
 
@@ -103,6 +124,26 @@ class AgentRunbookTests(unittest.TestCase):
                 ignored.write_text("# Generated copy\n", encoding="utf-8")
 
             self.assertEqual([expected], agent_runbooks(fixture_root))
+
+    def test_extra_scopes_cannot_replace_a_required_runbook(self):
+        """Each canonical scope must exist regardless of the discovered count."""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_root = Path(temp_dir)
+            missing = Path("apps/web/AGENTS.md")
+            fixture_paths = (REQUIRED_RUNBOOKS - {missing}) | {
+                Path("services/extra/AGENTS.md"),
+                Path("tools/AGENTS.md"),
+            }
+            for relative in fixture_paths:
+                path = fixture_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# AGENTS\n", encoding="utf-8")
+
+            self.assertEqual(
+                [missing],
+                missing_required_runbooks(agent_runbooks(fixture_root), fixture_root),
+            )
 
     def test_grouped_review_rules_are_counted(self):
         """Codex supports H3 headings that group related review checks."""

--- a/tests/scripts/test_agent_runbooks.py
+++ b/tests/scripts/test_agent_runbooks.py
@@ -7,23 +7,24 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.check_agent_docs import SKIP_DIRECTORIES, find_agent_directories
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-IGNORED_DIRS = {".git", ".next", ".venv", "node_modules"}
 
 
-def agent_runbooks() -> list[Path]:
+def agent_runbooks(root: Path = REPO_ROOT) -> list[Path]:
     """Return repository-owned AGENTS.md files, including untracked additions."""
 
     return sorted(
-        path
-        for path in REPO_ROOT.rglob("AGENTS.md")
-        if not IGNORED_DIRS.intersection(path.relative_to(REPO_ROOT).parts)
+        directory / "AGENTS.md"
+        for directory in find_agent_directories(root)
+        if (directory / "AGENTS.md").exists()
     )
 
 
 def code_review_rules(path: Path) -> list[str] | None:
-    """Return top-level bullets in the exact Codex review-rules section."""
+    """Return bullets in the exact Codex review-rules section."""
 
     text = path.read_text(encoding="utf-8")
     match = re.search(
@@ -71,7 +72,7 @@ class AgentRunbookTests(unittest.TestCase):
             "missing": ("# AGENTS\n", "has no ## Code Review Rules section"),
             "one-rule": (
                 "# AGENTS\n\n## Code Review Rules\n\n- One rule.\n",
-                "at least two durable checks",
+                "review guidance should name at least two durable checks",
             ),
             "four-rules": (
                 "# AGENTS\n\n## Code Review Rules\n\n"
@@ -87,6 +88,34 @@ class AgentRunbookTests(unittest.TestCase):
                     path = fixture_root / f"{name}-AGENTS.md"
                     path.write_text(content, encoding="utf-8")
                     self.assertIn(expected, review_contract_error(path) or "")
+
+    def test_runbook_discovery_uses_the_pointer_tools_exclusions(self):
+        """Ignored generated trees must not become accidental review contracts."""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_root = Path(temp_dir)
+            expected = fixture_root / "AGENTS.md"
+            expected.write_text("# AGENTS\n", encoding="utf-8")
+
+            for directory in SKIP_DIRECTORIES:
+                ignored = fixture_root / directory / "AGENTS.md"
+                ignored.parent.mkdir(parents=True)
+                ignored.write_text("# Generated copy\n", encoding="utf-8")
+
+            self.assertEqual([expected], agent_runbooks(fixture_root))
+
+    def test_grouped_review_rules_are_counted(self):
+        """Codex supports H3 headings that group related review checks."""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "grouped-AGENTS.md"
+            path.write_text(
+                "# AGENTS\n\n## Code Review Rules\n\n"
+                "### Database\n\n- Keep schema and queries aligned.\n\n"
+                "### API\n\n- Keep producers and consumers aligned.\n",
+                encoding="utf-8",
+            )
+            self.assertIsNone(review_contract_error(path))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_agent_runbooks.py
+++ b/tests/scripts/test_agent_runbooks.py
@@ -1,0 +1,93 @@
+"""Guard the review-rule contract shared by the repository runbooks."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IGNORED_DIRS = {".git", ".next", ".venv", "node_modules"}
+
+
+def agent_runbooks() -> list[Path]:
+    """Return repository-owned AGENTS.md files, including untracked additions."""
+
+    return sorted(
+        path
+        for path in REPO_ROOT.rglob("AGENTS.md")
+        if not IGNORED_DIRS.intersection(path.relative_to(REPO_ROOT).parts)
+    )
+
+
+def code_review_rules(path: Path) -> list[str] | None:
+    """Return top-level bullets in the exact Codex review-rules section."""
+
+    text = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?ms)^## Code Review Rules\s*$\n(?P<body>.*?)(?=^##\s|\Z)", text
+    )
+    if match is None:
+        return None
+    return re.findall(r"(?m)^- .+$", match.group("body"))
+
+
+def review_contract_error(path: Path) -> str | None:
+    """Describe why one runbook does not provide a concise review contract."""
+
+    rules = code_review_rules(path)
+    relative = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+    if rules is None:
+        return f"{relative} has no ## Code Review Rules section"
+    if len(rules) < 2:
+        return "review guidance should name at least two durable checks"
+    if len(rules) > 3:
+        return "keep review guidance concise; move narrower rules closer"
+    return None
+
+
+class AgentRunbookTests(unittest.TestCase):
+    def test_every_runbook_has_two_or_three_code_review_rules(self):
+        """Codex should receive a concise, explicitly scoped review contract."""
+
+        runbooks = agent_runbooks()
+        self.assertGreaterEqual(
+            len(runbooks),
+            4,
+            "expected root, web, chat, and script-guardrail agent runbooks",
+        )
+
+        for path in runbooks:
+            with self.subTest(runbook=path.relative_to(REPO_ROOT)):
+                error = review_contract_error(path)
+                self.assertIsNone(error, error)
+
+    def test_each_invalid_contract_shape_is_rejected(self):
+        """Demonstrate the missing, underspecified, and overlong branches."""
+
+        cases = {
+            "missing": ("# AGENTS\n", "has no ## Code Review Rules section"),
+            "one-rule": (
+                "# AGENTS\n\n## Code Review Rules\n\n- One rule.\n",
+                "at least two durable checks",
+            ),
+            "four-rules": (
+                "# AGENTS\n\n## Code Review Rules\n\n"
+                "- One.\n- Two.\n- Three.\n- Four.\n",
+                "keep review guidance concise",
+            ),
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_root = Path(temp_dir)
+            for name, (content, expected) in cases.items():
+                with self.subTest(case=name):
+                    path = fixture_root / f"{name}-AGENTS.md"
+                    path.write_text(content, encoding="utf-8")
+                    self.assertIn(expected, review_contract_error(path) or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_check_agent_docs.py
+++ b/tests/scripts/test_check_agent_docs.py
@@ -1,4 +1,5 @@
 import importlib.util
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -162,6 +163,25 @@ class CheckAgentDocsTests(unittest.TestCase):
             vendored = root / "node_modules/some-package"
             vendored.mkdir(parents=True, exist_ok=True)
             (vendored / "AGENTS.md").write_text("# Vendored\n", encoding="utf-8")
+
+            errors = check_agent_docs.check_agent_docs(root=root)
+
+        self.assertEqual(errors, [])
+
+    def test_skips_untracked_files_ignored_by_git(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            subprocess.run(
+                ["git", "init", "--quiet", str(root)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            (root / ".gitignore").write_text("tmp/\n", encoding="utf-8")
+            build_repo(root)
+            ignored = root / "tmp/copied-source"
+            ignored.mkdir(parents=True)
+            (ignored / "AGENTS.md").write_text("# Ignored copy\n", encoding="utf-8")
 
             errors = check_agent_docs.check_agent_docs(root=root)
 


### PR DESCRIPTION
## Summary
- What changed: clarified root-plus-nested `AGENTS.md` precedence, added concise `## Code Review Rules` contracts to each maintained scope, tightened the final-head Codex review gate, aligned validation/PR guidance, and added fixture-backed structural and pointer-discovery guards.
- Why: give local agents and the Codex PR reviewer accurate, scoped, durable instructions without duplicating runbook content in pointer files.

## Scope
- Surface: docs / agent tooling
- Risk level: low
- Breaking change: no

## Verification Evidence

### Required
- [x] `CHANGED_BASE=main CHANGED_HEAD=HEAD make quick-ci-changed` — passed; selected toolchain, env-contract, script, web, chat, and docs checks
- [x] Applicable merge gate: `make ci` — passed on every final reviewed state
- [x] `make test-scripts` — 151/151 passed after review fixes
- [x] `make docs-check` — documentation, pointers, and agent definitions passed
- [x] `ui-review` — not applicable: no pages, components, styles, rendered assets, or page responses changed
- [x] `verifier` — passed focused guards, full `make ci`, docs, pointers, and diff checks; no failures or missing coverage
- [x] `code-review` — fresh approval after each review fix; no defects or refinements remain

### Optional / Contextual
- [ ] `make quick-ci` — not run as a separate target; explicit range-scoped quick CI and broader `make ci` passed
- [ ] Manual UX/API validation — not applicable to documentation and guard-test changes

### Before merge
- [ ] Pull request head still matches the reviewed SHA
- [ ] Codex final-head review is clear and every Codex thread is resolved
- [ ] GitHub reports a clean merge state and all configured checks pass

## Release and Ops Impact
- Env contract change: no
- Migration required: no
- Runbook updates needed: yes; included here
- Follow-up tasks: #207 tracks the unrelated pre-existing unsupported Next.js `eslint` configuration warning found by the verifier

## Reviewer Notes
- Areas that need close review: root/nested instruction precedence, the 2–3-rule contracts, and the documented-vs-observed Codex review signals
- Codex round 1: generated-tree discovery was fixed; the direct-only bullet proposal was disputed because official guidance supports H3-grouped rules. Both threads contain measurements and are resolved.
- Codex round 2: Git-ignored artifacts, exact required paths, and duplicate review-rule sections were fixed with red/green fixtures. All three threads contain measurements and are resolved.
- Known limitations or deferred cleanup: GitHub branch protection/ruleset enforcement is repository configuration and is intentionally outside this file-only change
- Expected head: `f9e715c478865ded8c8b8e9444aaa3868cc65d2a`
- Review cutoff: `2026-08-10T01:19:58Z`
