### PR TITLE
fix(web): stop the product listings announcing each name twice

### DIFF
--- a/apps/web/e2e/browse.spec.ts
+++ b/apps/web/e2e/browse.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Locator } from '@playwright/test'
 
 /**
  * The anonymous shopping journey, end to end against the real stack.
@@ -159,4 +159,116 @@ test.describe('browsing', () => {
     ).toBeGreaterThan(0)
   })
 
+  test('a product card announces what it shows, once', async ({ page }) => {
+    // Both listings put `alt={product.name}` on an image inside a link whose
+    // own text already names the product, so the link's accessible name was
+    // the name twice -- 20 cards on the home page, and every card of every
+    // category, which runs from 18 to 47. The tents page this samples is 21,
+    // which is not the worst of them.
+    for (const path of ['/', '/products/category/tents']) {
+      await page.goto(path)
+
+      const cards = page.locator('a[href^="/products/"]:not([href^="/products/category/"])')
+      const count = await cards.count()
+      expect(count, `no product cards on ${path}`).toBeGreaterThan(1)
+
+      let withImage = 0
+      let firstName = ''
+
+      for (let index = 0; index < count; index += 1) {
+        const card = cards.nth(index)
+        if ((await card.locator('img').count()) > 0) withImage += 1
+
+        const name = await accessibleName(card)
+        expect(name, `card ${index} on ${path} has no accessible name`).not.toEqual('')
+        if (index === 0) firstName = name
+
+        // "The same thing twice in a row", and deliberately not "equal to the
+        // card's own visible text". Equality was the first version of this and
+        // it says something stronger than the defect: it rejects a badge image
+        // with a real `alt`, an `aria-hidden` separator, and CSS generated
+        // content, all of which are correct card designs that announce nothing
+        // twice. A rule that would reject the right answer to a later problem
+        // gets deleted on the day it matters rather than fixed.
+        //
+        // Swept over all 210 catalogue names paired with a price: none
+        // contains an adjacent repeat, and both pre-fix names do.
+        //
+        // What it does not catch: a duplicate that is not adjacent. Move the
+        // image below the price and restore its `alt` and the name reads
+        // `X $250.00 X`, which this passes. Both listings render the image
+        // first, so reaching that needs the defect and a reorder -- and the
+        // sampled check below still catches it on card 0 of each listing.
+        expect(
+          repeatedPhrase(name),
+          `card ${index} on ${path} announces the same thing twice: ${JSON.stringify(name)}`,
+        ).toBeNull()
+      }
+
+      // A card rendering no image cannot duplicate one, so without this the
+      // loop above passes on a listing that stopped rendering images at all.
+      // Counted across the listing rather than required of each card, because
+      // `image` is nullable on the category card and the empty state it falls
+      // back to is a legitimate render, not a failure.
+      expect(withImage, `no card on ${path} rendered an image`).toBeGreaterThan(0)
+
+      // What the loop cannot see: a card that announces nothing twice because
+      // it stopped naming its product at all. The name has to come from
+      // outside the card to check that, so it comes from the page the card
+      // links to, whose `h1` is the product's name.
+      //
+      // Sampled, since it costs a navigation and what it establishes is a
+      // property of the markup rather than of any one product.
+      const href = await cards.first().getAttribute('href')
+      expect(href, `first card on ${path} has no href`).toBeTruthy()
+      await page.goto(href ?? '')
+      const productName = (await page.getByRole('heading', { level: 1 }).innerText()).trim()
+      expect(productName, `${href} has no heading to take a name from`).not.toEqual('')
+      expect(
+        occurrences(firstName, productName),
+        `the first card on ${path} announces ${JSON.stringify(productName)} ${occurrences(firstName, productName)} times in ${JSON.stringify(firstName)}`,
+      ).toEqual(1)
+    }
+  })
 })
+
+/**
+ * The accessible name Chromium computes for an element.
+ *
+ * There is no getter for it, so this reads the first line of the ARIA
+ * snapshot — `- link "TrailMaster X4 Tent $250.00":` — which is Playwright's
+ * own implementation of the accname algorithm rather than a reading of the
+ * `alt` attribute that happens to feed it today. Callers pin the parse with
+ * `toHaveAccessibleName` so a snapshot format change cannot quietly turn every
+ * assertion below into one about the empty string.
+ */
+async function accessibleName(locator: Locator): Promise<string> {
+  const [first] = (await locator.ariaSnapshot()).split('\n')
+  // The quotes are optional so that an element with no accessible name comes
+  // back as `''` and fails the caller's assertion about the name, rather than
+  // throwing here and reporting a real defect as a parse failure. A line that
+  // is not `- <role>` at all still throws, which is the format change.
+  const match = /^-\s+[a-z][a-z-]*(?:\s+"(.*)")?\s*:?\s*$/.exec(first)
+  if (!match) {
+    throw new Error(`unreadable ARIA snapshot line ${JSON.stringify(first)}`)
+  }
+  const name = match[1] ?? ''
+  await expect(locator).toHaveAccessibleName(name)
+  return name
+}
+
+/** The first run of words that appears twice in a row, or null. */
+function repeatedPhrase(text: string): string | null {
+  const words = text.toLowerCase().split(/\s+/).filter(Boolean)
+  for (let length = 1; length <= Math.floor(words.length / 2); length += 1) {
+    for (let start = 0; start + 2 * length <= words.length; start += 1) {
+      const run = words.slice(start, start + length).join(' ')
+      if (run === words.slice(start + length, start + 2 * length).join(' ')) return run
+    }
+  }
+  return null
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.toLowerCase().split(needle.toLowerCase()).length - 1
+}

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { promises as fs } from 'fs'
+import Home from './page'
+import type { ProductGroup } from '@/lib/types'
+
+vi.mock('@/components/header', () => ({
+  __esModule: true,
+  default: () => <div data-testid="header" />,
+}))
+
+vi.mock('@/components/block', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe('Home page', () => {
+  // Against the real `public/categories.json`, which is what the page reads.
+  // The category page's equivalent test mocks its data source, so the two
+  // together cover the same property from both directions.
+  it('names a product card once', async () => {
+    const catalogue: ProductGroup[] = JSON.parse(
+      await fs.readFile(`${process.cwd()}/public/categories.json`, 'utf8'),
+    )
+    const product = catalogue[0].products[0]
+
+    render(await Home())
+
+    // The card is one link, so its image, if it describes itself, is read out
+    // as part of the link's name. `alt={product.name}` used to make that name
+    // the product's name twice; `getByRole` computes the name the way a
+    // screen reader does, which is the part `getByText` cannot see.
+    expect(screen.getByRole('link', { name: product.name })).toBeDefined()
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -112,7 +112,11 @@ export default async function Home() {
                 <div className="items-center">
                   <Image
                     src={product.images[0]}
-                    alt={product.name}
+                    // Decorative, because the link already says it. The card
+                    // is one link whose text is the product's name, so
+                    // `alt={product.name}` made its accessible name the name
+                    // twice. See e2e/browse.spec.ts.
+                    alt=""
                     width={350}
                     height={350}
                     // 350px is the cap, not the box. The `minmax(0, 350px)`

--- a/apps/web/src/app/products/category/[slug]/page.test.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.test.tsx
@@ -52,6 +52,46 @@ describe('Category Page', () => {
     expect(screen.getByText('Trail Boots')).toBeDefined()
   })
 
+  // The card is one link, so everything inside it is read out as that link's
+  // name. `getByRole('link', { name })` computes that name the way a screen
+  // reader does, which is the part `getByText` above cannot see: it passes
+  // just as happily when the name is announced twice.
+  //
+  // The e2e journey covers the image branch against the real catalogue. It
+  // cannot cover the branch below it, because every seeded product has an
+  // image -- these two are what make the empty state's wording checkable at
+  // all.
+  const categoryOf = (product: Record<string, unknown>) => ({
+    name: 'Hiking',
+    slug: 'hiking',
+    description: 'Explore the trails',
+    products: [{ id: '1', price: 120, slug: 'trail-boots', ...product }],
+  })
+
+  it('names a product card once when it has an image', async () => {
+    vi.mocked(getProductsByCategory).mockResolvedValue(
+      categoryOf({ name: 'Trail Boots', image: '/images/boots.webp' }) as any,
+    )
+
+    render(await CategoryPage({ params: Promise.resolve({ slug: 'hiking' }) }))
+
+    expect(
+      screen.getByRole('link', { name: 'Trail Boots $120.00' }),
+    ).toBeDefined()
+  })
+
+  it('names a product card once when it has no image', async () => {
+    vi.mocked(getProductsByCategory).mockResolvedValue(
+      categoryOf({ name: 'Trail Boots', image: null }) as any,
+    )
+
+    render(await CategoryPage({ params: Promise.resolve({ slug: 'hiking' }) }))
+
+    expect(
+      screen.getByRole('link', { name: 'No image available Trail Boots $120.00' }),
+    ).toBeDefined()
+  })
+
   it('calls notFound if category does not exist', async () => {
     vi.mocked(getProductsByCategory).mockResolvedValue(null)
 

--- a/apps/web/src/app/products/category/[slug]/page.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.tsx
@@ -48,7 +48,11 @@ export default async function CategoryPage({
                 {product.image ? (
                   <Image
                     src={product.image}
-                    alt={product.name}
+                    // Decorative, because the link already says it. The card
+                    // is one link whose heading is the product's name, so
+                    // `alt={product.name}` made its accessible name the name
+                    // twice. See e2e/browse.spec.ts.
+                    alt=""
                     width={350}
                     height={350}
                     // The card is the container split by the column count, less
@@ -103,9 +107,23 @@ export default async function CategoryPage({
                   // An empty state rather than a placeholder image: it costs no
                   // request, and it makes the missing data visible instead of
                   // papering over it.
+                  //
+                  // No `role="img"` and no `aria-label`. Removing them is not
+                  // neutral -- it is the fix on this branch. The label read
+                  // `No image available for ${product.name}`, and an
+                  // `aria-label` replaces the subtree it labels, so the words
+                  // reaching the link's name came from the label rather than
+                  // from the text node below. Measured on the card's markup:
+                  //
+                  //   with the pair:    No image available for X X $price
+                  //   without the pair: No image available X $price
+                  //
+                  // The text survives verbatim; what goes is the `for X`,
+                  // which repeated the heading two lines down. `role="img"`
+                  // named a region holding no image and bought nothing.
+                  // `page.test.tsx` pins the shorter name, and fails on the
+                  // longer one.
                   <div
-                    role="img"
-                    aria-label={`No image available for ${product.name}`}
                     className="flex h-full w-full items-center justify-center text-sm text-gray-500"
                   >
                     No image available


### PR DESCRIPTION
Closes #200.

Both listings put `alt={product.name}` on an image inside a link whose own text already names the product. Everything inside a link contributes to that link's accessible name, so every card announced its product twice. Read from Chromium's accessibility tree:

```
/                        link "TrailMaster X4 Tent TrailMaster X4 Tent"
/products/category/tents link "TrailMaster X4 Tent TrailMaster X4 Tent $250.00"
```

20 cards on the home page, and every card of every category — 18 to 47 of them. `alt=""` on both: the image adds nothing the link's name does not already carry, which is what decorative means.

## The no-image branch had the same defect in a different shape

The category card's placeholder carried `role="img"` with `aria-label="No image available for ${product.name}"`. An `aria-label` replaces the subtree it labels, so the words reaching the link came from the label rather than from the text node below it. Dropping the pair is the fix there, not a tidy-up:

| | link's accessible name |
|---|---|
| with the pair | `No image available for Trail Boots Trail Boots $120.00` |
| without it | `No image available Trail Boots $120.00` |

The text survives verbatim; the `for X` was the duplicate. `role="img"` named a region holding no image.

## The e2e guard is the second version of itself

The first asserted the link's accessible name **equalled** the card's visible text. That sounds like the defect and is not — the rule it encoded was "no image in a card may ever have a non-empty `alt`". `ui-review` built three card designs it rejects: an `aria-hidden` separator, CSS generated content, and a second image carrying a genuinely informative `alt`. All three announce nothing twice. A rule that rejects the right answer to a later problem gets deleted on the day it matters rather than fixed.

It now asserts that no run of words is repeated adjacently — swept over all 210 catalogue names paired with a price, zero false positives — plus a sampled check that the product name taken from the linked page's `h1` appears exactly once.

**Recorded rather than closed:** a *non*-adjacent duplicate defeats the per-card rule. Reaching it needs the defect plus a markup reorder, and the sampled check still catches it on card 0 of each listing. Written into the test's comment.

## Coverage

Six mutations, each caught by its intended assertion:

| mutation | caught by |
|---|---|
| home `alt={product.name}` restored | adjacent-repeat check |
| category `alt={product.name}` restored | adjacent-repeat check |
| `alt=""` kept, `aria-label={product.name}` added to the image | adjacent-repeat check — this is what proves the guard reads the computed name and not the attribute |
| card renders no image at all | "no card rendered an image" |
| card stops naming its product | "has no accessible name" |
| card names a different product | sampled `h1` occurrence check |

Route tests add the two the journey cannot reach, since no seeded product has a null image: restoring `alt={product.name}` fails the home and category with-image tests, and restoring `for ${product.name}` fails the no-image test.

## Two review findings were mine, and wrong

A comment claimed removing the ARIA pair left the accessible name unchanged. That was true only against an intermediate state of my own editing, and it would have argued a future reader into restoring the duplicate. And "up to 21 per category" was the one page I had open; the largest category is 47.

Both the same species: a number stated without measuring it against the data the code reads — which is what `AGENTS.md` step 4 is about, one level up.

## Disputed

`verifier` reported that no `.env` exists in the checkout. It does, at the repo root — it is gitignored, so a file search misses it. Nothing depended on it either way.

## Verification

- [x] `make -C apps/web ci` — lint, typecheck (app + `tsconfig.e2e.json` + journey coverage), 137 tests across 35 files, production build
- [x] `make test-scripts` — 151 tests
- [x] All 5 Playwright journeys against a production build served against the real seeded database (210 products)
- [x] `ui-review` — both listings at 390/834/1440, AX tree read at each; six findings, all addressed or filed
- [x] `verifier` — two rounds, green
- [x] `code-review` — two rounds; round 2 returned no defects

## Filed, not fixed

#209 (the header's profile link announces the signed-in user's name twice), #210 (this empty state's text is 3.91:1, failing WCAG 1.4.3), #211 (whether "No image available" should lead the link's name at all), #212 (`sync-env` copies from `apps/.env`, so it has always silently no-opped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)