### PR TITLE
docs(agents): remove the automated pull request reviewer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,6 @@ Paste command output snippets or concise summaries for what you actually ran.
 
 ### Before merge
 - [ ] Pull request head still matches the reviewed SHA
-- [ ] Codex final-head review is clear and every Codex thread is resolved
 - [ ] GitHub reports a clean merge state and all configured checks pass
 
 ## Release and Ops Impact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,40 +178,12 @@ Follow these steps in order for every change.
       reopens here.
     - Do not repeat code review when the already-reviewed diff and worktree
       remain unchanged.
-    - Immediately before the push that creates or updates the pull request,
-      record the expected local `HEAD` SHA and a UTC cutoff. Carry both into
-      step 11 so an old review signal cannot satisfy the final-head gate.
     - Push and create the pull request only after local verification and any
       required code review are complete.
     - Open a normal, ready-for-review pull request by default. Do not open
       draft pull requests unless the user explicitly asks for a draft.
 
-11. **Let Codex review the pull request, and answer it.** Automatic Codex
-    review is expected after each push, and its verdict gates the merge.
-
-    - It reacts 👀 on the pull request while reading and 👍 when it is satisfied.
-      The reactions are on the pull request itself:
-      `gh api repos/<owner>/<repo>/issues/<pr>/reactions`.
-    - Findings are inline review threads, invisible to
-      `gh pr view --json comments`. Read them through GraphQL `reviewThreads`,
-      which gives the body, the `isResolved` state the merge gate turns on, and
-      the thread id needed to resolve it — the REST comments endpoint carries
-      none of the last two. Page it: a missed page reads as a finding that is
-      not there.
-    - The loop: address the findings, re-run steps 6 to 9 for what changed,
-      push, reply to each thread saying what changed, resolve it, wait for the
-      next verdict. Repeat until 👍. Treat P1 as blocking, and where a finding
-      is right about the problem but wrong about the fix, say so rather than
-      resolving quietly.
-    - **Only a 👍 you watched arrive counts.** The old one survives a push, and
-      survives a later review that had findings, so the reaction sitting there
-      may be about a commit two revisions back. Watch it go 👀 and then 👍
-      after your push; never read the one that was already there as approval.
-      Silence is pending, never approval. If no new review run starts, stop
-      before merging and report it as pending; do not post `@codex review`
-      unless the user explicitly requests it.
-
-12. **Merge only clean, passing pull requests.** Merge only after GitHub
+11. **Merge only clean, passing pull requests.** Merge only after GitHub
     reports a clean merge state and every configured check passes. Never bypass
     a failing or pending required check. Self-merges are allowed when these
     conditions are met. Use squash merge for short-lived development branches
@@ -254,91 +226,6 @@ it: a separate pull request is cheap, and an unscoped one is not.
 Sub-agents report findings; they do not file issues. Every finding they report
 that falls outside the current change needs the main agent to file it.
 
-### The automated pull request reviewer
-
-Observed on 2026-08-09 across pull requests #195, #198, and #206. The
-[Codex GitHub review documentation](https://developers.openai.com/codex/integrations/github)
-guarantees the exact `@codex review` trigger and, when Automatic reviews are
-enabled for that event, review when a pull request is opened for review.
-Push-triggered rounds and the clean reaction behavior below are repository
-observations, not a public contract. This is vendor behavior and liable to drift,
-so re-check it if it stops matching.
-
-`chatgpt-codex-connector[bot]` signals through **reactions on the pull request**
-— `GET /repos/:owner/:repo/issues/:number/reactions`, the issue endpoint.
-`gh pr view --json reactionGroups` does return them, but only as a content and a
-count, with no reacting login, which is exactly the part the condition below
-turns on.
-
-GitHub spells the same identity differently across APIs. REST returns
-`chatgpt-codex-connector[bot]`; GraphQL review-thread `author.login` returns
-`chatgpt-codex-connector`. Account for both rather than filtering every response
-with one literal.
-
-- `eyes` means a round is running, and is removed when that round ends. It is
-  only visible while it lasts, so seeing no `eyes` says nothing.
-- Findings arrive as inline review comments. The review body carries none of
-  them, but it is not inert: it records `**Reviewed commit:**` for that round,
-  which is the field that says which head was actually reviewed, and it is
-  where the tool states the `+1` convention itself. What it does not document
-  is `eyes` or the persistence of `+1`, and its trigger list is incomplete —
-  pushes to an open pull request drove four of the five rounds on #198 and are
-  not on it.
-- A clean round posts **no review at all** — not an empty one — and leaves
-  `+1`, which persists. Its only other trace is `eyes` appearing and clearing.
-
-**Done means the pull request head still matches the recorded SHA, a `+1` from
-that login was created after both the recorded UTC cutoff and its newest inline
-comment, and every one of its threads is resolved.**
-
-Each clause is there because a simpler version is wrong:
-
-- *Later than the last push*, because `+1` persists once left. Its presence
-  alone cannot tell a clean round just finished from a clean round three pushes
-  ago.
-
-  This clause has a limit, and it is the one place the section is known to run
-  out. Adding a reaction is idempotent, so a second clean round leaves the
-  original `+1` with its original timestamp — the condition is satisfiable on a
-  pull request's first clean round and not on a later one, where it would say
-  "not done" forever. No pull request in the sample had two clean rounds, so
-  this is reasoned rather than observed.
-
-  If it happens, do not wait on a timestamp that cannot move, and do not look
-  for the round's `**Reviewed commit:**` line either — a clean round posts no
-  review to carry one, so the newest names an older head and reads as "not
-  done". What is observable is the round itself: comment `@codex review`, watch
-  `eyes` appear and clear, and take "cleared, no new inline comments" as the
-  signal. The `+1` is then confirmation rather than the clock.
-- *Later than the newest inline comment*, and **not** "no comments against
-  `HEAD`". GitHub advances a review comment's `commit_id` to the head it still
-  applies to, so on #198 a comment raised on `dd1d694` reports `commit_id`
-  `770f77e` — the head that was merged, in the state that was done. Filtering on
-  `commit_id`, on `position`, or on `isOutdated` all conclude "not done" on a
-  pull request that was. `original_commit_id` is the field that records where a
-  comment was actually raised.
-
-It does not mean "no new review appeared". On #195 two pushes drew neither a
-review nor a reaction, and that pull request has an empty reaction set to this
-day — so silence is not a pass, and a round that never arrives is not the same
-as a round that found nothing. On #198 every one of four pushes drew a round,
-which is why the two cannot be told apart by waiting alone. Poll for an outcome,
-and if none arrives within a few minutes of the usual latency, say that rather
-than reading it as approval.
-
-Rounds followed pushes by roughly five to ten minutes on #198, measured from
-commit timestamps. A commit is made at or before its push, so those intervals
-overstate the true latency rather than understating it.
-
-Resolving a thread is a GraphQL `resolveReviewThread` mutation. `gh` has no
-subcommand for it.
-
-Worth the loop: on #198 it raised nine findings across four rounds, eight of
-them P1. It repeatedly caught guards that measured a CSS declaration rather than
-what was painted, and it overturned a `ui-review` conclusion that measurement
-then settled in its favour. It was also wrong once, on a focus-area formula that
-assumed square corners and failed a compliant rounded control by six pixels.
-
 ### Sub-agents this workflow depends on
 
 Steps 6 through 8 use `ui-review`, `verifier`, and `code-review`, defined in
@@ -354,8 +241,7 @@ on. This workflow has had a rendered review call a compliant focus indicator
 design — and the same review quote a contrast ratio the running build measured
 differently, zinc-400 at 2.56:1 against a measured 2.62:1. Both were believed
 before they were checked. Address every finding, and where one is wrong, say so
-with the measurement rather than complying; step 11 sets that standard for the
-automated reviewer, and it is the same standard here.
+with the measurement rather than complying.
 
 Record a disputed finding where someone else can audit it, and note when:
 carried into the body of the commit step 9 is about to make, or into the pull

--- a/tests/scripts/test_agent_runbooks.py
+++ b/tests/scripts/test_agent_runbooks.py
@@ -38,8 +38,31 @@ def missing_required_runbooks(
     return sorted(REQUIRED_RUNBOOKS - discovered)
 
 
+def workflow_step_numbers(text: str) -> set[int]:
+    """The numbers of the workflow's own numbered steps."""
+
+    return {int(match.group(1)) for match in re.finditer(r"(?m)^(\d+)\.\s+\*\*", text)}
+
+
+def referenced_step_numbers(text: str) -> set[int]:
+    """Every step number the prose points at, ranges expanded.
+
+    `steps 6 through 8` asserts the existence of 7 as much as of its endpoints,
+    so a range contributes all of its members rather than only the two written
+    down.
+    """
+
+    numbers: set[int] = set()
+    pattern = r"(?i)\bsteps?\s+(\d+)(?:\s+(?:to|through|and)\s+(\d+))?"
+    for match in re.finditer(pattern, text):
+        first = int(match.group(1))
+        last = int(match.group(2)) if match.group(2) else first
+        numbers.update(range(min(first, last), max(first, last) + 1))
+    return numbers
+
+
 def code_review_rule_sections(path: Path) -> list[list[str]]:
-    """Return rule bullets from each exact Codex review-rules section."""
+    """Return rule bullets from each exact review-rules section."""
 
     text = path.read_text(encoding="utf-8")
     matches = re.finditer(
@@ -67,7 +90,7 @@ def review_contract_error(path: Path) -> str | None:
 
 class AgentRunbookTests(unittest.TestCase):
     def test_every_runbook_has_two_or_three_code_review_rules(self):
-        """Codex should receive a concise, explicitly scoped review contract."""
+        """A reviewer should get a concise, explicitly scoped contract."""
 
         runbooks = agent_runbooks()
         self.assertEqual(
@@ -80,6 +103,107 @@ class AgentRunbookTests(unittest.TestCase):
             with self.subTest(runbook=path.relative_to(REPO_ROOT)):
                 error = review_contract_error(path)
                 self.assertIsNone(error, error)
+
+    def test_every_referenced_workflow_step_exists(self):
+        """A renumbered workflow must not leave a reference pointing at nothing.
+
+        The steps are cross-referenced by number, from the runbook's own prose
+        and from the `description:` of each agent in `.claude/agents/`. Removing
+        a step renumbers every step after it, and nothing here read those
+        references — so `step 12` survived deletion as a pointer to a step that
+        no longer existed, in a file whose whole job is to be followed.
+
+        `test_agent_definitions.py` covers the three agents' own step numbers.
+        This is the rest: every other place a number is written down.
+        """
+
+        runbook = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        steps = workflow_step_numbers(runbook)
+
+        # Without this the comparison below passes when the parse finds no
+        # steps at all, which is also what a reformatted workflow produces.
+        self.assertGreaterEqual(
+            len(steps), 8, "found too few numbered workflow steps to be reading them"
+        )
+        self.assertEqual(
+            steps,
+            set(range(1, max(steps) + 1)),
+            f"workflow step numbers are not consecutive from 1: {sorted(steps)}",
+        )
+
+        # A floor on the reference side too. `refs - steps` is empty whenever
+        # `refs` is, so a helper that has stopped reading reports nothing wrong
+        # and the whole test below passes while checking nothing.
+        #
+        # Deliberately just "not empty" rather than a literal set of the
+        # numbers the runbook currently cites. `test_step_references_expand_ranges`
+        # proves the parsing against a fixture it owns; pinning it here as well
+        # would make a copyedit — "steps 6-8" for "steps 6 to 8" — fail a test
+        # whose subject is the workflow's numbering, not its wording.
+        self.assertTrue(
+            referenced_step_numbers(runbook),
+            "the runbook cites no step at all, so nothing below is being compared",
+        )
+
+        sources = {Path("AGENTS.md"): runbook}
+        for path in sorted((REPO_ROOT / ".claude/agents").glob("*.md")):
+            sources[path.relative_to(REPO_ROOT)] = path.read_text(encoding="utf-8")
+
+        # Same floor for the glob: no matches means the loop body never runs.
+        self.assertGreater(
+            len(sources), 1, "no agent definitions were read, so only the runbook was checked"
+        )
+
+        for relative, text in sources.items():
+            with self.subTest(source=relative):
+                referenced = referenced_step_numbers(text)
+                if relative != Path("AGENTS.md"):
+                    self.assertTrue(
+                        referenced,
+                        f"{relative} names no workflow step, so it cannot name a "
+                        "wrong one; every agent's description says which step "
+                        "invokes it",
+                    )
+
+                dangling = sorted(referenced - steps)
+                self.assertEqual(
+                    [],
+                    dangling,
+                    f"{relative} refers to workflow step(s) {dangling}, which the "
+                    f"runbook does not define; it has steps 1 to {max(steps)}",
+                )
+
+    def test_step_references_expand_ranges(self):
+        """The parsing behind the check above, against fixtures it owns.
+
+        Kept off the live runbook on purpose. Anchoring this to real prose
+        makes the demonstration hostage to a copyedit, and leaves the one
+        behaviour worth demonstrating — expansion — provable only for as long
+        as some sentence happens to be phrased as a range.
+        """
+
+        cases = {
+            "steps 3 through 5": {3, 4, 5},
+            "steps 3 to 5": {3, 4, 5},
+            # "and" joins a list rather than a range, and is expanded anyway.
+            # Over-expansion only adds members, and the check this feeds
+            # subtracts the real steps from them, so it can never hide a
+            # dangling reference -- it errs loudly rather than quietly. The
+            # interpolated numbers are real steps besides, since that check
+            # also asserts the steps run consecutively from 1. Prose whose
+            # second number is not a step at all ("step 9 and 12 other
+            # checks") would fail noisily; the runbook has none.
+            "steps 3 and 5": {3, 4, 5},
+            "step 9": {9},
+            "Step 9 and the pull request body": {9},
+            "steps 5 to 3": {3, 4, 5},
+            "stepping over 9 rungs": set(),
+            "no numbers here": set(),
+        }
+
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(expected, referenced_step_numbers(text))
 
     def test_each_invalid_contract_shape_is_rejected(self):
         """Demonstrate the missing, underspecified, and overlong branches."""
@@ -146,7 +270,7 @@ class AgentRunbookTests(unittest.TestCase):
             )
 
     def test_grouped_review_rules_are_counted(self):
-        """Codex supports H3 headings that group related review checks."""
+        """H3 headings may group related review checks without hiding them."""
 
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "grouped-AGENTS.md"


### PR DESCRIPTION
The repository no longer uses the Codex pull request reviewer, so the workflow should not tell the next agent to wait for it.

- Step 11 — *clear the automated review before merging* — is gone; the old step 12 becomes 11.
- The `### The automated pull request reviewer` section goes with it (~4,900 characters of observed bot protocol).
- Step 10 loses its bullet about recording a head SHA and a UTC cutoff, which existed only to feed that gate.
- `### Sub-agents this workflow depends on` stops deferring to step 11 for a standard it can state itself.
- The pull request template loses its Codex checkbox.

## This supersedes 9326080

`9326080` — *"Revise pull request review process with Codex integration"* — landed directly on `main` at 18:46 this evening, while this branch was already open, and rewrote the same step into a tighter Codex loop: 👀/👍 reaction semantics, reading findings through GraphQL `reviewThreads`, and the rule that only a 👍 you watched arrive counts.

The decision to stop using the reviewer came **after** that revision, so this supersedes it rather than disagreeing with it. This branch has been rebased onto it, and the deletion now takes the newer step 11 rather than the one written before it. Both versions stay in history.

## Deleted rather than parked

The removed observations were entirely about one vendor's bot — what `eyes` means, that a clean round posts no review at all, that `original_commit_id` is the field recording where a comment was raised. None of it applies to the local `code-review` sub-agent, and a runbook describing a tool nobody runs misleads whoever reads it as current. `f433f33` has it if it is ever wanted.

## Kept deliberately

Both checked rather than assumed:

| kept | why |
|---|---|
| `.codex/hooks.json`, `.codex/config.toml` | Entire CLI session hooks for the Codex **CLI** as a coding tool — `SessionStart`, `Stop`, `PostToolUse`, `UserPromptSubmit`. Nothing to do with `chatgpt-codex-connector[bot]`. Removing them would break a working local integration to tidy up a name. |
| The four `## Code Review Rules` sections | Written as Codex's review contract, but `code-review` reads `AGENTS.md` too — and one of them, *require guards to measure effective behaviour, not a nearby declaration*, is what most of this repository's recent work has been about. Only their framing named Codex. |

Both scope calls were put to `code-review` explicitly and endorsed.

## A renumbered workflow orphans cross-references, and nothing was watching

Steps are cited by number from the runbook's own prose and from each agent's `description:`. `test_agent_definitions.py` covered the three agents; nothing covered the rest — so `step 12` could have survived **this very deletion** as a pointer to nothing.

`test_every_referenced_workflow_step_exists` closes that, and took two corrections to get right:

1. Its first version had a vacuity floor on the step side and none on the reference side — which is the defect it exists to prevent, one level up. `referenced - steps` is empty whenever `referenced` is, so a helper that stops reading reports nothing wrong. Three ways of breaking it passed.
2. The fix for that pinned the live runbook to a literal `{6, 7, 8}`. Load-bearing — 7 appears in `AGENTS.md` only inside `steps 6 to 8` — and a violation of `tests/scripts/AGENTS.md`'s rule that a demonstration points at a fixture the test owns: a copyedit to `steps 6-8` would then fail a test whose subject is numbering, not wording.

Split in two. The live check asserts only that some step is cited; `test_step_references_expand_ranges` proves the parsing against eight fixtures of its own.

## Mutations

Six, each caught by the half that should catch it:

| mutation | caught by |
|---|---|
| pattern no longer matches plural `steps` | fixture test |
| pattern matches nothing at all | fixture test **and** the live-document floor |
| range expansion dropped | fixture test |
| `.claude/agents` glob resolves to nothing | `len(sources) > 1` |
| a planted `step 12` in prose | dangling-set assertion |
| a step deleted without renumbering | consecutive-from-1 check |

## Filed, not addressed here

#214. The deleted step carried one instruction that was never Codex-specific — address what a review raises, reply with what was measured, and argue back with a measurement rather than complying when it is wrong. The workflow now says that nowhere, for any reviewer. Writing it back is a new rule about how contributors handle feedback, which is not something to slip into a deletion.

## Verification

- [x] `make docs-check`
- [x] `make test-scripts` — 153 tests
- [x] `verifier` — two rounds, green
- [x] `code-review` — two rounds; round 2 returned no defects
- [x] `ui-review` — **not applicable**: Markdown and Python guard tests, no rendered surface

## One thing this cannot do

The Codex GitHub App is installed at the repository or organisation level, not configured from this tree. Removing it from the runbook stops us waiting on it; it does not stop it reviewing. Turning it off is a settings change in GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
