### PR TITLE
fix(web): give every account and contact field a boundary you can see

### DIFF
--- a/apps/web/e2e/chat-controls.spec.ts
+++ b/apps/web/e2e/chat-controls.spec.ts
@@ -1,35 +1,26 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+import { expectVisibleControls, type Boundary } from './support/boundary'
 
 /**
  * The controls inside the chat panel are visible before you touch them.
  *
- * WCAG 2.2 1.4.11 Non-text Contrast, Level AA, asks 3:1 of the visual boundary
- * of a user interface component. The message input's resting ring and the send
- * button's border both measured 1.48:1 against the white panel — declared
- * boundaries that are not boundaries, which is worse than having none, because
- * the layout is built as though the outline were doing the work.
+ * WCAG 2.2 1.4.11 asks 3:1 of a control's visual boundary. The message input's
+ * resting ring and the send button's border both measured 1.48:1 against the
+ * white panel -- a declared boundary that is not one, which is worse than
+ * having none, because the layout is built as though the outline were doing
+ * the work.
  *
- * The resting state is the whole point. Both controls switch to sky-700 on
- * focus and are comfortably past 3:1 there, so a check that did not blur first
- * would read 5.86:1 and report the bug as fixed. Opening the panel moves focus
- * into the input, so this is not a hypothetical: it is what the first
- * measurement of this did.
+ * The resting state is the whole point. Both controls are comfortably past 3:1
+ * once focused, so a check that did not blur first would read 5.86:1 and report
+ * the bug as fixed. Opening the panel moves focus into the input, so this is
+ * not hypothetical: it is what the first measurement of this did.
  *
- * Both states are measured from screenshots. The reference white is read from
- * the panel's CSS and resolved by painting it on a canvas rather than parsing
- * it — Tailwind v4 serialises this palette as `lab()`, and a regex for numbers
- * drops the minus signs, so `lab(41.6% -9.1 -42.6)` reads as rgb(42,9,43).
- * That turned a sibling spec into a check of something else entirely; see the
- * comment in `chat-launcher.spec.ts`.
+ * The measurement itself lives in `support/boundary.ts`, shared with
+ * `form-fields.spec.ts` since #196. Everything it warns about was paid for
+ * here first.
  *
- * Everything else comes from pixels, and did not always. The first several
- * versions of this file read declarations — box-shadow, border colour,
- * background, outline width — and each one was wrong in the same direction,
- * crediting something CSS had been asked for rather than something a person
- * could see. The helpers below say which mistake each replaced.
- *
- * Not covered here, having been measured and found fine: the clear and close
- * buttons carry no boundary at all, and what identifies them is their glyph,
+ * Not covered, having been measured and found fine: the clear and close buttons
+ * carry no boundary at all, and what identifies them is their glyph,
  * `stroke-zinc-500` at 4.83:1 against the panel.
  */
 
@@ -39,275 +30,16 @@ const WIDTHS = [
   { width: 1440, height: 900, shape: 'card' },
 ]
 
-const REQUIRED_RATIO = 3
-
 /**
  * Controls that have to be tellable from the panel they sit on.
  *
- * Which CSS property carries that is deliberately not stated. The input draws a
- * ring, which Tailwind compiles to a box-shadow; the send button is filled, so
- * its edge is its background; a third control could use a border. Naming the
- * property per control would assert the shape of today's fix rather than the
- * property — a white send button with a compliant 1px border is a perfectly
- * legal answer to 1.4.11, and a check pinned to `backgroundColor` would fail
- * it. So all three are read and the best is taken.
+ * Which CSS property carries that is deliberately not stated -- the input draws
+ * a ring, the send button is filled, a third control could use a border.
  */
 const BOUNDARIES = [
   { name: 'the message input', selector: '#chat' },
   { name: 'the send button', selector: '[aria-label="Send message"]' },
-]
-
-type Reading = { name: string; resting: number; focused: number }
-
-/**
- * How far the control's edge stands out from the panel, measured from pixels.
- *
- * This used to read the declaration — box-shadow, border colour, background —
- * and it kept being wrong in the same direction. A border with zero width still
- * reports a colour. A ring set to `ring-0` still reports a colour. A shadow
- * with a blur reports its source colour while every pixel it actually paints is
- * composited half-way to the panel. And a boundary drawn with `outline` was not
- * read at all, so a compliant refactor would have failed CI.
- *
- * Each of those was a separate finding and a separate patch. They are one bug:
- * a declaration is not a boundary. What a boundary is, is pixels near the edge
- * that differ from the surface behind them, so that is what is measured — and
- * the property no longer cares which of the four ways CSS was asked to draw it.
- *
- * The reference is the panel's own flat white, read from CSS rather than
- * sampled. Sampling it risks catching a neighbour: the send button sits 12px
- * from the input, and a probe reaching outward for "the background" finds the
- * other control's ring.
- */
-async function boundaryContrast(page: Page): Promise<Reading[]> {
-  const readings: Reading[] = []
-
-  for (const { name, selector } of BOUNDARIES) {
-    const control = page.locator(selector)
-    const box = await control.boundingBox()
-    if (!box) throw new Error(`${selector} has no box`)
-
-    const PAD = 8
-    const clip = {
-      x: Math.max(0, box.x - PAD),
-      y: Math.max(0, box.y - PAD),
-      width: box.width + PAD * 2,
-      height: box.height + PAD * 2,
-    }
-
-    const measure = async () => {
-      const shot = (await page.screenshot({ clip })).toString('base64')
-      return page.evaluate(
-        async ({ shot, pad, width, height }) => {
-          const image = new Image()
-          image.src = `data:image/png;base64,${shot}`
-          await image.decode()
-          const canvas = document.createElement('canvas')
-          canvas.width = image.width
-          canvas.height = image.height
-          const context = canvas.getContext('2d')!
-          context.drawImage(image, 0, 0)
-          const data = context.getImageData(0, 0, canvas.width, canvas.height).data
-          const at = (x: number, y: number) => {
-            const px = Math.min(Math.max(Math.round(x), 0), canvas.width - 1)
-            const py = Math.min(Math.max(Math.round(y), 0), canvas.height - 1)
-            const i = (py * canvas.width + px) * 4
-            return [data[i], data[i + 1], data[i + 2]] as [number, number, number]
-          }
-
-          const panel = document.querySelector('[role="dialog"]')
-          if (!panel) throw new Error('the chat panel is not open')
-          const surface = getComputedStyle(panel).backgroundColor
-          const probe = document.createElement('canvas')
-          probe.width = 1
-          probe.height = 1
-          const probeContext = probe.getContext('2d')!
-          probeContext.fillStyle = surface
-          probeContext.fillRect(0, 0, 1, 1)
-          const [br, bg, bb] = probeContext.getImageData(0, 0, 1, 1).data
-          const background: [number, number, number] = [br, bg, bb]
-
-          const luminance = ([r, g, b]: [number, number, number]) => {
-            const channel = (value: number) => {
-              const v = value / 255
-              return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
-            }
-            return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
-          }
-          const ratio = (a: [number, number, number], b: [number, number, number]) => {
-            const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x)
-            return (high + 0.05) / (low + 0.05)
-          }
-
-          // Points along each edge, kept away from the rounded corners, and a
-          // band running from just outside the control to just inside it so
-          // that a boundary drawn either way round is seen.
-          const fractions = [0.25, 0.5, 0.75]
-          const band = [-5, -4, -3, -2, -1, 0, 1, 2, 3]
-          const edges: [number, number, number, number][] = []
-          for (const f of fractions) {
-            edges.push([pad + width * f, pad, 0, 1])
-            edges.push([pad + width * f, pad + height, 0, -1])
-            edges.push([pad, pad + height * f, 1, 0])
-            edges.push([pad + width, pad + height * f, -1, 0])
-          }
-
-          // The weakest edge, not the strongest: a control that is obvious on
-          // three sides and invisible on the fourth has an invisible side.
-          let weakest = Infinity
-          for (const [x, y, dx, dy] of edges) {
-            let best = 0
-            for (const offset of band) {
-              best = Math.max(best, ratio(at(x + dx * offset, y + dy * offset), background))
-            }
-            weakest = Math.min(weakest, best)
-          }
-          return weakest
-        },
-        { shot, pad: PAD, width: box.width, height: box.height },
-      )
-    }
-
-    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
-    const resting = await measure()
-    await page.evaluate(
-      (sel) => (document.querySelector(sel) as HTMLElement).focus(),
-      selector,
-    )
-    const focused = await measure()
-    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
-
-    readings.push({ name, resting, focused })
-  }
-
-  return readings
-}
-
-/**
- * What focusing a control actually changes on screen.
- *
- * WCAG 2.2 2.4.13 is about the indicator *area*: the pixels that change
- * between the unfocused and focused states must contrast by 3:1, and must
- * amount to at least the area of a 2px perimeter around the control. So this
- * takes two screenshots and compares them, rather than reasoning from computed
- * style about whether an outline "should" be visible.
- *
- * That is deliberate, and it settled a disagreement. Reading style alone, an
- * outline the same colour as the control's own fill looks invisible — one
- * review called `outline-offset: 0` on the filled send button "completely
- * invisible" — while by the criterion it paints a new 2px perimeter over pixels
- * that were white, which is a 5.86:1 change and compliant. Both arguments are
- * plausible and neither is a measurement. The pixels are.
- */
-async function focusChange(page: Page, selector: string) {
-  const control = page.locator(selector)
-  const box = await control.boundingBox()
-  if (!box) throw new Error(`${selector} has no box`)
-
-  // Wide enough to contain an outline drawn outside the border box, offset
-  // included.
-  const PAD = 10
-  const clip = {
-    x: Math.max(0, box.x - PAD),
-    y: Math.max(0, box.y - PAD),
-    width: box.width + PAD * 2,
-    height: box.height + PAD * 2,
-  }
-
-  // The corner radius, because the perimeter of a rounded rectangle is shorter
-  // than that of a sharp one and the threshold below is derived from it.
-  const radius = await control.evaluate((element) =>
-    parseFloat(getComputedStyle(element).borderTopLeftRadius),
-  )
-
-  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
-  const unfocused = (await page.screenshot({ clip })).toString('base64')
-  await page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).focus(), selector)
-  const focused = (await page.screenshot({ clip })).toString('base64')
-  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
-
-  return page.evaluate(
-    async ({ unfocused, focused, width, height, radius, required: minimumRatio }) => {
-      const read = async (data: string) => {
-        const image = new Image()
-        image.src = `data:image/png;base64,${data}`
-        await image.decode()
-        const canvas = document.createElement('canvas')
-        canvas.width = image.width
-        canvas.height = image.height
-        const context = canvas.getContext('2d')!
-        context.drawImage(image, 0, 0)
-        return {
-          data: context.getImageData(0, 0, canvas.width, canvas.height).data,
-          w: canvas.width,
-          h: canvas.height,
-        }
-      }
-      const before = await read(unfocused)
-      const after = await read(focused)
-
-      const luminance = (r: number, g: number, b: number) => {
-        const channel = (value: number) => {
-          const v = value / 255
-          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
-        }
-        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
-      }
-
-      const ratios: number[] = []
-      for (let i = 0; i < before.data.length; i += 4) {
-        const [r1, g1, b1] = [before.data[i], before.data[i + 1], before.data[i + 2]]
-        const [r2, g2, b2] = [after.data[i], after.data[i + 1], after.data[i + 2]]
-        // Ignore the faint edges antialiasing leaves either side of a real
-        // change; a channel has to move meaningfully to count.
-        if (Math.abs(r1 - r2) + Math.abs(g1 - g2) + Math.abs(b1 - b2) < 30) continue
-        const [high, low] = [luminance(r1, g1, b1), luminance(r2, g2, b2)].sort(
-          (a, b) => b - a,
-        )
-        ratios.push((high + 0.05) / (low + 0.05))
-      }
-
-      ratios.sort((a, b) => a - b)
-      return {
-        changed: ratios.length,
-        // Only the pixels that actually changed by enough count toward the
-        // area. The two used to be separate assertions -- total area, and the
-        // median ratio -- and that let one cover for the other: the input's
-        // change is a mixture, its inset ring going zinc-500 to sky-700 at
-        // 1.21:1 and its outline appearing against white at 5.86:1. The dim
-        // ring pixels inflated the area while the bright outline pixels
-        // carried the median, so an outline regression could leave too little
-        // qualifying area and still pass both.
-        qualifying: ratios.filter((value) => value >= minimumRatio).length,
-        // Kept for the failure message rather than asserted on.
-        median: ratios.length ? ratios[Math.floor(ratios.length / 2)] : 0,
-        // A 2px-thick perimeter of the unfocused control, which is the
-        // minimum area 2.4.13 describes.
-        //
-        // Derived from the actual shape rather than from `4 * (w + h)`, which
-        // is the perimeter of a *sharp* rectangle. These controls are
-        // `rounded-md`, and squaring off their corners overstates the ideal by
-        // just enough to matter: the shipped design measured 1410 qualifying
-        // pixels against a demanded 1416, failing by six on a corner radius
-        // rather than on anything a user could see. Each corner replaces two
-        // radius-length straight runs with a quarter circle.
-        required: (() => {
-          const r = Math.min(radius, width / 2, height / 2)
-          const perimeter = 2 * (width + height) - 8 * r + 2 * Math.PI * r
-          return perimeter * 2
-        })(),
-      }
-    },
-    {
-      unfocused,
-      focused,
-      width: box.width,
-      height: box.height,
-      radius,
-      required: REQUIRED_RATIO,
-    },
-  )
-}
+] satisfies Boundary[]
 
 test.describe('chat panel controls', () => {
   for (const { width, height, shape } of WIDTHS) {
@@ -337,50 +69,13 @@ test.describe('chat panel controls', () => {
       // measurement.
       await page.mouse.move(2, 2)
 
-      const readings = await boundaryContrast(page)
-
-      // Not `readings.length === BOUNDARIES.length`, which was the first
-      // version of this and holds by construction: the walk is a `map` over
-      // BOUNDARIES, so no state of the page makes it false. What can be true
-      // and useless is a reading of zero, so that is what is checked.
-      expect(
-        readings.filter((reading) => reading.resting > 0).length,
-        'no control boundary produced a measurement',
-      ).toBe(BOUNDARIES.length)
-
-      const failing = readings
-        .filter((reading) => reading.resting < REQUIRED_RATIO)
-        .map((reading) => `${reading.name} ${reading.resting.toFixed(2)}:1`)
-
-      expect(
-        failing,
-        `controls whose resting boundary is invisible against the panel ` +
-          `(WCAG 1.4.11 asks ${REQUIRED_RATIO}:1)`,
-      ).toEqual([])
-
-      const weakFocus = readings
-        .filter((reading) => reading.focused < REQUIRED_RATIO)
-        .map((reading) => `${reading.name} ${reading.focused.toFixed(2)}:1`)
-
-      expect(weakFocus, 'controls whose focused boundary is invisible').toEqual([])
-
-      // WCAG 2.4.13, measured rather than inferred. Raising the resting
-      // boundary to clear 1.4.11 moved it to within 1.21:1 of the focus colour
-      // -- the same lightness in two hues, identical in greyscale -- so the fix
-      // for one criterion silently broke the other. Nothing caught that,
-      // because every assertion above compares a state to the panel and never
-      // the two states to each other.
-      for (const { selector, name } of BOUNDARIES) {
-        const change = await focusChange(page, selector)
-        expect(
-          change.qualifying,
-          `${name}'s focus indicator covers ${change.qualifying} pixels that ` +
-            `change by ${REQUIRED_RATIO}:1 or more, against the ` +
-            `${Math.round(change.required)} a 2px perimeter needs ` +
-            `(${change.changed} changed at all, median ` +
-            `${change.median.toFixed(2)}:1)`,
-        ).toBeGreaterThanOrEqual(change.required)
-      }
+      // Read from the panel's own flat white rather than sampled: the send
+      // button sits 12px from the input, so a probe reaching outward for the
+      // background finds the other control's ring.
+      await expectVisibleControls(page, BOUNDARIES, {
+        kind: 'css',
+        selector: '[role="dialog"]',
+      })
     })
   }
 })

--- a/apps/web/e2e/form-fields.spec.ts
+++ b/apps/web/e2e/form-fields.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+import { expectVisibleControls, type Boundary } from './support/boundary'
+
+/**
+ * The text fields on `/login`, `/signup` and `/contact` are visible before
+ * you touch them.
+ *
+ * Not every field in the app: `/profile` has eleven more behind its tabs, at
+ * the same 1.41:1 and drawn with a `border` rather than a `ring`. They are
+ * #220, and the staleness check below only walks the three routes named here.
+ *
+ * WCAG 2.2 1.4.11 asks 3:1 of a control's visual boundary. These ten measured
+ * 1.41:1 on the account pages and 1.21:1 to 1.28:1 on the contact form — a
+ * declared boundary that is not one, which is worse than having none, because
+ * the layout is built as though the outline were doing the work.
+ *
+ * The chat panel's input was fixed for the same reason in #184 and left the
+ * app with two input treatments. That was the real cost of doing it piecemeal,
+ * so the colour now lives in one place; see `src/lib/field-classes.ts`.
+ *
+ * Both surfaces are read per field rather than assumed. `/login` and `/signup`
+ * sit on rgb(250,250,250), not white, and the contact card is `bg-white/90`
+ * over a blurred photograph — measured, it runs rgb(233,233,234) to
+ * rgb(240,239,238) between fields on the same form. Against pure white these
+ * would all read a little better than they are.
+ *
+ * The card cannot hide a worse spot than it shows here: `bg-white/90` over
+ * `backdrop-blur-xs` flattens the photograph to a 228-243 band, fifteen levels
+ * of range across the whole card, so there is no busy region for a boundary to
+ * disappear into. Swept over fifteen widths from 360 to 1920, the worst
+ * perimeter pixel on any field is 3.80:1.
+ *
+ * ## What the focus half of this does not catch
+ *
+ * Deleting the designed outline from `FIELD_BOUNDARY`. Chromium then paints
+ * its own `auto 1px rgb(16,16,16)` ring, which satisfies 2.4.13 by itself:
+ * measured, `/login`'s email field gives 1662 qualifying pixels against 1659
+ * required without the outline, and 1673 with it. Only the contact textarea
+ * notices, and by three pixels.
+ *
+ * That is the check being right rather than weak — the criterion asks whether
+ * focus is visible, not whose CSS made it so, and a browser default is a real
+ * indicator. But it means a green run here is not evidence that the designed
+ * outline is doing anything, and the reason to keep it is cross-engine
+ * consistency, which one Chromium project cannot test. See the note in
+ * `src/lib/field-classes.ts`.
+ *
+ * Both numbers sit near the threshold because a 2px outline and a 2px
+ * perimeter are nearly the same area by construction. Expect small margins
+ * here and do not read a narrow pass as a near-miss.
+ */
+
+const SURFACES = [
+  {
+    path: '/login',
+    fields: [
+      { name: 'the email field', selector: '#email' },
+      { name: 'the password field', selector: '#password' },
+    ],
+  },
+  {
+    path: '/signup',
+    fields: [
+      { name: 'the name field', selector: '#name' },
+      { name: 'the email field', selector: '#email' },
+      { name: 'the password field', selector: '#password' },
+    ],
+  },
+  {
+    path: '/contact',
+    fields: [
+      { name: 'the name field', selector: '#name' },
+      { name: 'the email field', selector: '#email' },
+      { name: 'the subject field', selector: '#subject' },
+      { name: 'the order number field', selector: '#orderNumber' },
+      { name: 'the message field', selector: '#message' },
+    ],
+  },
+] satisfies { path: string; fields: Boundary[] }[]
+
+/**
+ * Phone and desktop, because the contact card's background is a `bg-cover`
+ * photograph: what sits behind a given field changes with the viewport, and a
+ * single width samples one crop of it. The floor quoted above was found by
+ * sweeping fifteen widths by hand, which is evidence and not a regression
+ * test — this is the part of that sweep CI can keep.
+ */
+const WIDTHS = [
+  { width: 390, height: 844 },
+  { width: 1440, height: 900 },
+]
+
+test.describe('form field boundaries', () => {
+  for (const { path, fields } of SURFACES) {
+    for (const { width, height } of WIDTHS) {
+      test(`the fields on ${path} are visible at rest at ${width}x${height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({ width, height })
+        await page.goto(path)
+        await expect(page.locator(fields[0].selector)).toBeVisible()
+
+      // One real keypress before anything is measured. Chromium grants
+      // `:focus-visible` to a programmatically focused text input regardless,
+      // but the pages are reached by `goto` with no interaction at all, and a
+      // control whose indicator is `focus-visible` only should be measured the
+      // way a keyboard user meets it.
+        await page.keyboard.press('Tab')
+
+      // And the pointer parked somewhere harmless: a field measured under the
+      // cursor reports its hover state, which is not a resting measurement.
+        await page.mouse.move(2, 2)
+
+        await expectVisibleControls(page, fields, { kind: 'sample' })
+      })
+    }
+  }
+
+  test('every field on these pages is one of the ones checked', async ({ page }) => {
+    // The lists above are written by hand, so they go stale silently: a sixth
+    // field added to the contact form would be unmeasured and nothing here
+    // would say so. This walks the rendered forms instead and compares.
+    for (const { path, fields } of SURFACES) {
+      await page.goto(path)
+      const rendered = await page
+        .locator('input:not([type="hidden"]):not([type="submit"]), textarea, select')
+        .evaluateAll((nodes) =>
+          nodes.map((node) => ({ id: node.id, tag: node.tagName.toLowerCase() })),
+        )
+
+      expect(rendered.length, `no fields found on ${path}`).toBeGreaterThan(0)
+
+      // Before the comparison, not filtered out of it. `.filter(Boolean)` on
+      // the ids was the first version, and it dropped the one case this test
+      // exists to catch: a field added without an `id` disappeared from the
+      // list and the comparison below still matched. Every field here happens
+      // to carry one because each is wired to a `<label for>`, but nothing
+      // makes that true, and a field named by `aria-label` -- which is how the
+      // chat input names itself -- would have slipped straight through.
+      expect(
+        rendered.filter((field) => !field.id).map((field) => field.tag),
+        `${path} renders a field with no id, which this spec cannot address`,
+      ).toEqual([])
+      expect(
+        rendered.map((field) => field.id).sort(),
+        `${path} renders fields this spec does not measure`,
+      ).toEqual(fields.map((field) => field.selector.replace('#', '')).sort())
+    }
+  })
+})

--- a/apps/web/e2e/support/boundary.ts
+++ b/apps/web/e2e/support/boundary.ts
@@ -1,0 +1,441 @@
+import { expect, type Page } from '@playwright/test'
+
+/**
+ * How visible a control's edge is, and what focusing it changes, from pixels.
+ *
+ * Extracted from `chat-controls.spec.ts` when #196 needed the same two
+ * measurements for the ten text fields on `/login`, `/signup` and `/contact`.
+ * Every warning below was paid for once already in that file; the history is
+ * kept here because it is the reason the code looks like this.
+ *
+ * The measurements read rendered pixels, never a declaration. Earlier versions
+ * read box-shadow, border colour, background and outline width, and each was
+ * wrong in the same direction — crediting something CSS had been asked for
+ * rather than something a person could see. A border with zero width still
+ * reports a colour; `ring-0` still reports a colour; a blurred shadow reports
+ * its source colour while every pixel it paints is composited toward the
+ * surface; `outlineWidth` reports the user-agent default of 3px for an outline
+ * whose style is `none`.
+ */
+
+/** WCAG 2.2 1.4.11 Non-text Contrast, Level AA. */
+export const REQUIRED_RATIO = 3
+
+/**
+ * Where the colour behind a control comes from.
+ *
+ * `css` reads it off an ancestor and resolves it by painting, for surfaces that
+ * are one flat opaque colour. It is the right choice when a probe reaching
+ * outward would find a neighbour instead of the background — the chat panel's
+ * send button sits 12px from its input.
+ *
+ * `sample` reads the real painted pixels beside the control, which is the only
+ * option when the surface is not a colour anyone declared. The contact form is
+ * `bg-white/90` over a blurred photograph, so its computed `backgroundColor` is
+ * `rgba(255,255,255,0.9)` — a value that is not what is on screen, and that
+ * paints differently again depending on what a canvas composites it over.
+ * Measured, that card runs rgb(233,233,234) to rgb(240,239,238) *between
+ * fields on the same form*, because the photo behind it differs.
+ */
+export type Surface =
+  | { kind: 'css'; selector: string }
+  | { kind: 'sample' }
+
+export type Boundary = { name: string; selector: string }
+export type Reading = { name: string; resting: number; focused: number }
+
+/**
+ * Sampled horizontally only, never vertically.
+ *
+ * A form stacks label, field, label, field, so a probe reaching up or down
+ * finds text and reports the label's contrast as the background. Left and
+ * right of a `w-full` field is the form's own side padding, which is clear.
+ */
+const SAMPLE_OFFSETS = [12, 16, 20]
+
+
+/**
+ * How far each control's edge stands out from the surface behind it.
+ *
+ * A boundary is pixels near the edge that differ from what is behind them, so
+ * that is what is measured, and the property no longer cares which of border,
+ * box-shadow, background or outline CSS was asked to draw it. Naming one would
+ * assert the shape of today's fix: a white field with a compliant 1px border is
+ * a legal answer to 1.4.11, and a check pinned to `boxShadow` would fail it.
+ *
+ * The weakest edge is reported, not the strongest. A control that is obvious on
+ * three sides and invisible on the fourth has an invisible side.
+ */
+export async function boundaryContrast(
+  page: Page,
+  boundaries: Boundary[],
+  surface: Surface,
+): Promise<Reading[]> {
+  const readings: Reading[] = []
+
+  // Every *measured* control's box up front, so a reading can tell where its
+  // neighbours are. A control absent from `boundaries` is not seen: pass only
+  // the text fields on a form with a button beside one of them and the sampler
+  // probes into the button exactly as it used to probe into `#orderNumber`. Sampling reaches sideways, and on a two-column form row the next
+  // field is closer than the widest offset: measured on `/contact` at 1440,
+  // `#subject` and `#orderNumber` sit in a `gap-4` grid whose gap is exactly
+  // 16px, so probes at 16 and 20 landed on that neighbour's ring and inside
+  // its white interior.
+  //
+  // The median absorbed it: `#subject` reads 4.005:1 with the probes excluded,
+  // with them included, and with the grid gap narrowed to 4px so that every
+  // right-hand probe lands inside the neighbour. So this removes a latent
+  // contamination rather than a wrong answer — no arrangement was found where
+  // the reported number moved, and the claim here is only that the sampler no
+  // longer reads a control and calls it a background.
+  const boxes = new Map<string, { x: number; y: number; width: number; height: number }>()
+  for (const { selector } of boundaries) {
+    const box = await page.locator(selector).boundingBox()
+    if (box) boxes.set(selector, box)
+  }
+
+  for (const { name, selector } of boundaries) {
+    const control = page.locator(selector)
+    const box = await control.boundingBox()
+    if (!box) throw new Error(`${selector} has no box`)
+
+    // The margin the reading needs around the control: 5px for the band walk
+    // either side of the edge, and room for the widest surface sample when the
+    // background is being read from pixels.
+    const NEEDED = surface.kind === 'sample' ? Math.max(...SAMPLE_OFFSETS) + 2 : 7
+    const PAD = NEEDED + 4
+
+    const viewport = page.viewportSize()
+    if (!viewport) throw new Error('no viewport to clamp a screenshot to')
+
+    // Clamped to the viewport, and the offsets derived from the clip that
+    // resulted rather than assumed to be PAD. They come apart whenever the
+    // control sits closer to an edge than PAD, and then every sample point is
+    // shifted by the difference: at 390 the chat input starts 12px from the
+    // left, so a PAD of 24 read 12px into the control and called the control
+    // its own background, for a flat 1.00:1. That is not hypothetical — it is
+    // what this file did when it was first extracted.
+    //
+    // Two separate defences, and worth knowing which does the work. At the PAD
+    // above nothing clamps, so the refusal below is what fires when a control
+    // is tight against an edge. The derivation only bites in the window where
+    // the clip clamps but there is still enough surface to read — forced by
+    // raising PAD past the gap, assuming the offset fails at 1.00:1 and
+    // deriving it passes.
+    const left = Math.max(0, box.x - PAD)
+    const top = Math.max(0, box.y - PAD)
+    const right = Math.min(viewport.width, box.x + box.width + PAD)
+    const bottom = Math.min(viewport.height, box.y + box.height + PAD)
+    const clip = { x: left, y: top, width: right - left, height: bottom - top }
+
+    const padLeft = box.x - left
+    const padTop = box.y - top
+    const padRight = right - (box.x + box.width)
+    const padBottom = bottom - (box.y + box.height)
+
+    // Loudly, rather than measuring whatever happens to be in range. A control
+    // pressed against a viewport edge cannot be read this way, and a number
+    // produced anyway would look exactly like a real one.
+    const tight = Math.min(padLeft, padTop, padRight, padBottom)
+    if (tight < NEEDED) {
+      throw new Error(
+        `${selector} sits ${tight.toFixed(1)}px from a viewport edge, and this ` +
+          `reading needs ${NEEDED}px of surface around it`,
+      )
+    }
+
+    // How far each side can be probed before reaching another control on the
+    // same row. Only controls that overlap vertically can be in the way; one
+    // stacked above or below is behind the label, which is why sampling is
+    // horizontal in the first place.
+    const clearance = (towards: 'left' | 'right') => {
+      let nearest = Infinity
+      for (const [other, box2] of boxes) {
+        if (other === selector) continue
+        const overlaps = box2.y < box.y + box.height && box.y < box2.y + box2.height
+        if (!overlaps) continue
+        const gap =
+          towards === 'left' ? box.x - (box2.x + box2.width) : box2.x - (box.x + box.width)
+        if (gap >= 0) nearest = Math.min(nearest, gap)
+      }
+      return nearest
+    }
+
+    // Minus one, so a probe stops short of the neighbour's first painted pixel
+    // rather than landing on it.
+    const usable = (towards: 'left' | 'right') =>
+      SAMPLE_OFFSETS.filter((offset) => offset <= clearance(towards) - 1)
+    const leftOffsets = surface.kind === 'sample' ? usable('left') : []
+    const rightOffsets = surface.kind === 'sample' ? usable('right') : []
+
+    if (surface.kind === 'sample' && leftOffsets.length + rightOffsets.length === 0) {
+      throw new Error(
+        `${selector} has no clear surface either side to sample: nearest ` +
+          `controls are ${clearance('left').toFixed(1)}px and ` +
+          `${clearance('right').toFixed(1)}px away`,
+      )
+    }
+
+    const measure = async () => {
+      const shot = (await page.screenshot({ clip })).toString('base64')
+      return page.evaluate(
+        async ({ shot, padLeft, padTop, width, height, surface, leftOffsets, rightOffsets }) => {
+          const image = new Image()
+          image.src = `data:image/png;base64,${shot}`
+          await image.decode()
+          const canvas = document.createElement('canvas')
+          canvas.width = image.width
+          canvas.height = image.height
+          const context = canvas.getContext('2d')!
+          context.drawImage(image, 0, 0)
+          const data = context.getImageData(0, 0, canvas.width, canvas.height).data
+          const at = (x: number, y: number): [number, number, number] => {
+            const px = Math.min(Math.max(Math.round(x), 0), canvas.width - 1)
+            const py = Math.min(Math.max(Math.round(y), 0), canvas.height - 1)
+            const i = (py * canvas.width + px) * 4
+            return [data[i], data[i + 1], data[i + 2]]
+          }
+          const luminance = ([r, g, b]: [number, number, number]) => {
+            const channel = (value: number) => {
+              const v = value / 255
+              return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+            }
+            return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+          }
+          const ratio = (a: [number, number, number], b: [number, number, number]) => {
+            const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+            return (high + 0.05) / (low + 0.05)
+          }
+
+          const fractions = [0.25, 0.5, 0.75]
+
+          let background: [number, number, number]
+          if (surface.kind === 'css') {
+            const host = document.querySelector(surface.selector)
+            if (!host) throw new Error(`no ${surface.selector} to read a surface from`)
+            // Painted on a 1x1 canvas rather than parsed. Tailwind v4
+            // serialises this palette as `lab()`, and a regex for numbers drops
+            // the minus signs, so `lab(41.6 -9.1 -42.6)` reads as rgb(42,9,43).
+            const probe = document.createElement('canvas')
+            probe.width = 1
+            probe.height = 1
+            const probeContext = probe.getContext('2d')!
+            probeContext.fillStyle = getComputedStyle(host).backgroundColor
+            probeContext.fillRect(0, 0, 1, 1)
+            const [r, g, b] = probeContext.getImageData(0, 0, 1, 1).data
+            background = [r, g, b]
+          } else {
+            const samples: [number, number, number][] = []
+            for (const f of fractions) {
+              for (const dx of leftOffsets) samples.push(at(padLeft - dx, padTop + height * f))
+              for (const dx of rightOffsets) {
+                samples.push(at(padLeft + width + dx, padTop + height * f))
+              }
+            }
+            // Median per channel, so one stray pixel — an antialiased glyph
+            // edge, a speck of the photograph — cannot move the reference.
+            const median = (values: number[]) =>
+              values.slice().sort((a, b) => a - b)[Math.floor(values.length / 2)]
+            background = [0, 1, 2].map((k) => median(samples.map((s) => s[k]))) as [
+              number,
+              number,
+              number,
+            ]
+          }
+
+          const band = [-5, -4, -3, -2, -1, 0, 1, 2, 3]
+          const edges: [number, number, number, number][] = []
+          for (const f of fractions) {
+            edges.push([padLeft + width * f, padTop, 0, 1])
+            edges.push([padLeft + width * f, padTop + height, 0, -1])
+            edges.push([padLeft, padTop + height * f, 1, 0])
+            edges.push([padLeft + width, padTop + height * f, -1, 0])
+          }
+
+          let weakest = Infinity
+          for (const [x, y, dx, dy] of edges) {
+            let best = 0
+            for (const offset of band) {
+              best = Math.max(best, ratio(at(x + dx * offset, y + dy * offset), background))
+            }
+            weakest = Math.min(weakest, best)
+          }
+          return weakest
+        },
+        {
+          shot,
+          padLeft,
+          padTop,
+          width: box.width,
+          height: box.height,
+          surface,
+          leftOffsets,
+          rightOffsets,
+        },
+      )
+    }
+
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+    const resting = await measure()
+    await page.evaluate(
+      (sel) => (document.querySelector(sel) as HTMLElement).focus(),
+      selector,
+    )
+    const focused = await measure()
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+
+    readings.push({ name, resting, focused })
+  }
+
+  return readings
+}
+
+/**
+ * What focusing a control actually changes on screen.
+ *
+ * WCAG 2.2 2.4.13 is about the indicator *area*: the pixels that change between
+ * unfocused and focused must contrast by 3:1, and must amount to at least a 2px
+ * perimeter of the control. Two screenshots, compared — not a reading of
+ * computed style about whether an outline "should" be visible.
+ *
+ * That distinction settled a disagreement once. By style alone, an outline the
+ * same colour as the control's own fill looks invisible, and one review called
+ * it "completely invisible"; by the criterion it paints a new 2px perimeter
+ * over pixels that were background, which is compliant. Both arguments were
+ * plausible and neither was a measurement.
+ */
+export async function focusChange(page: Page, selector: string) {
+  const control = page.locator(selector)
+  const box = await control.boundingBox()
+  if (!box) throw new Error(`${selector} has no box`)
+
+  const PAD = 10
+  const clip = {
+    x: Math.max(0, box.x - PAD),
+    y: Math.max(0, box.y - PAD),
+    width: box.width + PAD * 2,
+    height: box.height + PAD * 2,
+  }
+
+  const radius = await control.evaluate((element) =>
+    parseFloat(getComputedStyle(element).borderTopLeftRadius),
+  )
+
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+  const unfocused = (await page.screenshot({ clip })).toString('base64')
+  await page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).focus(), selector)
+  const focused = (await page.screenshot({ clip })).toString('base64')
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+
+  return page.evaluate(
+    async ({ unfocused, focused, width, height, radius, required }) => {
+      const read = async (encoded: string) => {
+        const image = new Image()
+        image.src = `data:image/png;base64,${encoded}`
+        await image.decode()
+        const canvas = document.createElement('canvas')
+        canvas.width = image.width
+        canvas.height = image.height
+        const context = canvas.getContext('2d')!
+        context.drawImage(image, 0, 0)
+        return context.getImageData(0, 0, canvas.width, canvas.height).data
+      }
+      const before = await read(unfocused)
+      const after = await read(focused)
+      const luminance = ([r, g, b]: [number, number, number]) => {
+        const channel = (value: number) => {
+          const v = value / 255
+          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+      }
+      const ratio = (a: [number, number, number], b: [number, number, number]) => {
+        const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+        return (high + 0.05) / (low + 0.05)
+      }
+
+      const ratios: number[] = []
+      for (let i = 0; i < before.length; i += 4) {
+        const a: [number, number, number] = [before[i], before[i + 1], before[i + 2]]
+        const b: [number, number, number] = [after[i], after[i + 1], after[i + 2]]
+        // Ignore the faint edges antialiasing leaves either side of a real
+        // change; a channel has to move meaningfully to count.
+        if (Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]) + Math.abs(a[2] - b[2]) < 30) continue
+        ratios.push(ratio(a, b))
+      }
+
+      ratios.sort((a, b) => a - b)
+      return {
+        changed: ratios.length,
+        // Only pixels that changed by enough count toward the area. These were
+        // once two assertions -- total area, and median ratio -- which let one
+        // cover for the other: a ring recolouring at 1.21:1 inflated the area
+        // while a bright outline carried the median, so an outline regression
+        // could leave too little qualifying area and still pass both.
+        qualifying: ratios.filter((value) => value >= required).length,
+        median: ratios.length ? ratios[Math.floor(ratios.length / 2)] : 0,
+        // A 2px perimeter of the control, derived from its actual shape rather
+        // than `2 * (w + h)`, which is the perimeter of a *sharp* rectangle.
+        // These controls are rounded, and squaring the corners overstates the
+        // ideal by enough to matter: a shipped design once measured 1410
+        // qualifying pixels against a demanded 1416, failing by six on a corner
+        // radius rather than on anything a user could see.
+        required: (() => {
+          const r = Math.min(radius, width / 2, height / 2)
+          const perimeter = 2 * (width + height) - 8 * r + 2 * Math.PI * r
+          return perimeter * 2
+        })(),
+      }
+    },
+    {
+      unfocused,
+      focused,
+      width: box.width,
+      height: box.height,
+      radius,
+      required: REQUIRED_RATIO,
+    },
+  )
+}
+
+/** Both criteria, for every control on one surface. */
+export async function expectVisibleControls(
+  page: Page,
+  boundaries: Boundary[],
+  surface: Surface,
+) {
+  const readings = await boundaryContrast(page, boundaries, surface)
+
+  // Not `readings.length === boundaries.length`, which holds by construction:
+  // the walk is a loop over `boundaries`, so no state of the page makes it
+  // false. What can be true and useless is a reading of zero.
+  expect(
+    readings.filter((reading) => reading.resting > 0).length,
+    'no control boundary produced a measurement',
+  ).toBe(boundaries.length)
+
+  expect(
+    readings
+      .filter((reading) => reading.resting < REQUIRED_RATIO)
+      .map((reading) => `${reading.name} ${reading.resting.toFixed(2)}:1`),
+    `controls whose resting boundary is invisible (WCAG 1.4.11 asks ${REQUIRED_RATIO}:1)`,
+  ).toEqual([])
+
+  expect(
+    readings
+      .filter((reading) => reading.focused < REQUIRED_RATIO)
+      .map((reading) => `${reading.name} ${reading.focused.toFixed(2)}:1`),
+    'controls whose focused boundary is invisible',
+  ).toEqual([])
+
+  for (const { selector, name } of boundaries) {
+    const change = await focusChange(page, selector)
+    expect(
+      change.qualifying,
+      `${name}'s focus indicator covers ${change.qualifying} pixels that change ` +
+        `by ${REQUIRED_RATIO}:1 or more, against the ${Math.round(change.required)} ` +
+        `a 2px perimeter needs (${change.changed} changed at all, median ` +
+        `${change.median.toFixed(2)}:1)`,
+    ).toBeGreaterThanOrEqual(change.required)
+  }
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -53,7 +54,7 @@ export default function LoginPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -76,7 +77,7 @@ export default function LoginPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 export default function SignUpPage() {
   const [name, setName] = useState("");
@@ -61,7 +62,7 @@ export default function SignUpPage() {
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -82,7 +83,7 @@ export default function SignUpPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -105,7 +106,7 @@ export default function SignUpPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -11,6 +11,7 @@ import Turn from "./turn";
 import { ChatTurn } from "@/lib/types";
 import { useSession } from "next-auth/react";
 import { sendChatMessage } from "@/lib/messaging";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 interface ChatAction {
   type: "add" | "clear" | "resolve";
@@ -595,23 +596,11 @@ export const Chat = () => {
                 // input row some structure, and on the sheet this outline is
                 // the only thing separating the field from the surface.
                 //
-                // 1px, not 2. The contrast is in the colour, so a hairline
-                // scores the same 4.83:1 at half the weight, and every other
-                // field in the app is 1px — see #196, which is the same failure
-                // in ten more of them.
-                //
-                // And the focus indicator is now an outline rather than a
-                // recolour of this ring. It had been `focus:ring-sky-700` with
-                // `focus:outline-none`, which was fine while the resting ring
-                // was pale: 1.48:1 to 5.86:1 is a visible jump. Against
-                // zinc-500 it is not — sky-700 and zinc-500 differ by 1.21:1,
-                // the same lightness in two hues, indistinguishable in
-                // greyscale. That is WCAG 2.4.13, and no colour fixes it:
-                // resting and focused both have to be dark to clear 3:1 against
-                // a white panel, so they cannot also differ 3:1 from each
-                // other. The indicator has to change shape, which is what every
-                // other control in this widget already does.
-                className="block p-2 grow rounded-md text-zinc-700 placeholder:text-zinc-500 placeholder:opacity-100 shadow-xs ring-1 ring-inset ring-zinc-500 focus:ring-sky-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+                // The boundary and focus indicator come from the shared
+                // constant, which is where the reasoning behind them now lives:
+                // this input and the ten in #196 had drifted apart, and having
+                // one definition is the point of that change.
+                className={`block p-2 grow rounded-md text-zinc-700 placeholder:text-zinc-500 placeholder:opacity-100 shadow-xs ${FIELD_BOUNDARY}`}
               />
               <button
                 type="button"

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 export default function ContactForm() {
   const [formData, setFormData] = useState({
@@ -68,7 +69,7 @@ export default function ContactForm() {
           required
           value={formData.name}
           onChange={handleChange}
-          className="block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
           placeholder="Your name"
         />
       </div>
@@ -87,7 +88,7 @@ export default function ContactForm() {
           required
           value={formData.email}
           onChange={handleChange}
-          className="block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
           placeholder="you@example.com"
         />
       </div>
@@ -107,7 +108,7 @@ export default function ContactForm() {
             required
             value={formData.subject}
             onChange={handleChange}
-            className="block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
             placeholder="How can we help?"
           />
         </div>
@@ -124,7 +125,7 @@ export default function ContactForm() {
             name="orderNumber"
             value={formData.orderNumber}
             onChange={handleChange}
-            className="block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
             placeholder="Optional"
           />
         </div>
@@ -144,7 +145,7 @@ export default function ContactForm() {
           required
           value={formData.message}
           onChange={handleChange}
-          className="block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
           placeholder="Write your message here..."
         ></textarea>
       </div>

--- a/apps/web/src/lib/field-classes.ts
+++ b/apps/web/src/lib/field-classes.ts
@@ -1,0 +1,71 @@
+/**
+ * The boundary and focus indicator shared by the text fields on `/login`,
+ * `/signup`, `/contact` and the chat panel.
+ *
+ * Eleven fields used to choose this for themselves, and they did not agree.
+ * They are not all of them: `/profile` renders eleven more, behind its tabs,
+ * which draw a `border` rather than a `ring` and fail the same criterion at
+ * the same 1.41:1. See #220 — this constant does not drop into them unchanged,
+ * and nothing here covers them.
+ * The ten on `/login`, `/signup` and `/contact` drew `ring-gray-300`, which
+ * measured 1.41:1 on the account pages and 1.21:1 to 1.28:1 on the contact
+ * card; the chat input was fixed separately in #184 and drew `ring-zinc-500`.
+ * After this, the same fields measure 4.62:1 on the account pages and no worse
+ * than 3.80:1 anywhere on the contact card — that floor swept across fifteen
+ * viewport widths and every pixel of each field's perimeter, rather than the
+ * three points an edge that a first pass sampled and read as 3.98:1.
+ * WCAG 2.2 1.4.11 asks 3:1 of a control's visual boundary, so ten of the
+ * eleven had a boundary that was declared rather than visible — which is worse
+ * than none, because the layout is built as though the outline were doing the
+ * work.
+ *
+ * Only the boundary lives here. Radius, padding and type scale stay with each
+ * field: `/login` is `rounded-md py-1.5`, the contact card is `rounded-lg
+ * px-4 py-3`, and pulling those together would be a redesign rather than a
+ * fix. What is shared is the part that has a correct answer.
+ *
+ * ## Why focus adds an outline instead of recolouring the ring
+ *
+ * The old fields recoloured their ring to `indigo-600` on focus, which is
+ * 6.46:1 against white and looks like a strong indicator. It stops working the
+ * moment the resting ring is dark enough to satisfy 1.4.11: zinc-500 against
+ * indigo-600 is 1.34:1, and zinc-500 against sky-700 is 1.21:1 — the same
+ * lightness in two hues, identical in greyscale.
+ *
+ * That is not a colour that was chosen badly. Both states have to be dark to
+ * clear 3:1 against a light surface, so they cannot also differ 3:1 from each
+ * other. No pair of colours fixes it, which #184 established by trying: the
+ * indicator has to change *shape*. So focus keeps the ring and adds an offset
+ * outline, painting a new perimeter over pixels that were background.
+ *
+ * The ring still recolours to sky-700 as well. It contributes almost nothing —
+ * `e2e/support/boundary.ts` measures those pixels changing at 1.21:1, below
+ * the 3:1 that counts toward the indicator area — and it is here because the
+ * chat panel does it, and having eleven fields that are actually identical is
+ * the point of this file.
+ *
+ * `focus-visible`, not `focus`, for the outline: a pointer user who clicks
+ * into a field has not lost track of where they are, and does not need a
+ * second marker on top of the caret.
+ *
+ * ## What the outline is actually buying, measured
+ *
+ * Not Chromium compliance. Strip these three classes and Chromium paints its
+ * own `auto 1px rgb(16,16,16)` ring, which passes 2.4.13 on its own — measured
+ * at 1662 qualifying pixels against the 1659 a 2px perimeter of `/login`'s
+ * email field needs. With the outline the same field measures 1673. Both
+ * clear it; the browser's does so by three pixels.
+ *
+ * What the outline buys is that the indicator is ours: a known 2px sky-700 at
+ * a known offset, the same in every engine, rather than a default that differs
+ * between Chromium, Firefox and Safari and that the suite only ever sees one
+ * of. It is also what keeps the *change* visible, since the ring recolour it
+ * sits beside is a 1.21:1 change that no one would notice.
+ *
+ * Both margins are thin because the criterion's floor is a 2px perimeter and
+ * the indicator is a 2px outline, so the two are nearly the same number by
+ * construction. That is a property of the measurement, not of this design.
+ */
+export const FIELD_BOUNDARY =
+  'ring-1 ring-inset ring-zinc-500 focus:ring-sky-700 ' +
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700'


### PR DESCRIPTION
Closes #196.

Ten text fields drew `ring-gray-300`. WCAG 2.2 1.4.11 asks 3:1 of a control's visual boundary; read from pixels:

| surface | before | after |
|---|---|---|
| `/login`, `/signup` — on rgb(250,250,250) | 1.41:1 | **4.62:1** |
| `/contact` — a `bg-white/90` card over a blurred photo | 1.21–1.28:1 | **3.80:1 floor** |

Neither surface is white, which is why these are not the 1.47:1 the issue quotes. The contact card measures differently **per field** — rgb(233,233,234) to rgb(240,239,238) — so the guard samples the surface beside each field rather than assuming one reference.

## One definition for eleven fields

These ten plus the chat input, fixed alone in #184, now share `FIELD_BOUNDARY`. Two input treatments was the real cost of doing #184 piecemeal; choosing the colour once is the point. Only the boundary is shared — radius, padding and type scale differ per surface, and unifying those would be a redesign.

Focus adds an offset outline rather than recolouring the ring, because **no colour pair works**: both states must be dark to clear 3:1 against a light surface, so they cannot also differ 3:1 from each other. zinc-500 against sky-700 is 1.21:1, identical in greyscale. The indicator has to change shape.

## Disputed, shipped as chosen

`ui-review` argued for `outline-indigo-600` — the page accent — over `sky-700`, the chat widget's internal colour. Measured, they are **45° of hue and 27 points of lightness** apart, and tabbing email → password → Sign in now changes the colour of the focus indicator itself at the third stop. The argument is real. The user was offered exactly that trade-off and chose to match the chat panel, so it stays; the measurement is recorded so it can be reopened on evidence rather than taste.

## What the outline is not buying

Chromium compliance. Strip it and Chromium paints `auto 1px rgb(16,16,16)`, which passes 2.4.13 on its own:

| | qualifying pixels | needed |
|---|---|---|
| designed outline | 1673 | 1659 |
| Chromium's ring alone | 1662 | 1659 |

The guard cannot tell them apart, and shouldn't — the criterion asks whether focus is visible, not whose CSS made it so. What the outline buys is an indicator that is ours in every engine, which one Chromium project cannot test. Both files say so, rather than letting a green run imply more.

## The extraction broke the spec it came from

The measurement moved to `e2e/support/boundary.ts` so `chat-controls.spec.ts` and the new `form-fields.spec.ts` share it. Raising `PAD` from 8 to 24 for the surface samples meant that at 390 the chat input — 12px from the left edge — had its clip clamped while the pixel maths still assumed `PAD`. It read 12px *into* the control, called that the background, and reported a flat **1.00:1**.

Now the clip is clamped on all four sides, the offsets are derived from what resulted, and a reading with too little surface refuses rather than producing a number. Only the composed stack renders the chat panel, so a dev server alone would have shipped this to CI.

Review also caught the sampler probing into the neighbouring field: the `/contact` grid gap is exactly 16.0px at 1440 and the offsets were 12/16/20. It is now sibling-aware. **I could not show it ever produced a wrong answer** — `#subject` reads 4.005:1 with the probes excluded, included, and with the gap narrowed to 4px — so the comment claims a latent contamination removed, not a fix.

## Filed, not fixed

- **#220** — `/profile` has eleven more fields at the same 1.41:1. The comments here claimed "every text field in the app"; narrowed to what they cover. Those fields use `border` not `ring`, so the constant does not drop in — which collides with #216.
- **#216** — `ring-*` is an inset box-shadow, stripped under `forced-colors`; with `border-0` everywhere, all eleven lose their boundary in high-contrast mode.
- **#217** — contact placeholders are 2.23:1, so the border is 1.9× the contrast of the text inside it.
- **#218** — an invalid field is pixel-identical to a focused valid one, and announces nothing.
- **#219** — no `autocomplete` on the contact fields; two `<main>` elements on that page.

## Verification

- [x] 61 Playwright journeys against a **composed production stack**, one clean run — which is also what proves the classes survive Tailwind's purge from inside a `.ts` constant
- [x] `make -C apps/web ci`, `make test-scripts` (153)
- [x] `ui-review` — three viewports plus a 15-width sweep, 1× and 2×, greyscale, forced-colors
- [x] `verifier` — green; independently grepped the compiled CSS bundle for the class tokens
- [x] `code-review` — two rounds; round 2 returned no defects

`ui-review` also reported the contact form doing a native GET submit with values leaking into the URL. Checked against both servers: a dev-server hydration artifact, the composed stack submits correctly to `/contact/thanks`. Not filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)