### PR TITLE
fix(web): give the profile fields the boundary the rest of the app has

### DIFF
--- a/apps/web/e2e/form-fields.spec.ts
+++ b/apps/web/e2e/form-fields.spec.ts
@@ -1,13 +1,20 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { expectVisibleControls, type Boundary } from './support/boundary'
 
 /**
- * The text fields on `/login`, `/signup` and `/contact` are visible before
- * you touch them.
+ * Every text field the app renders on a page is visible before you touch it.
  *
- * Not every field in the app: `/profile` has eleven more behind its tabs, at
- * the same 1.41:1 and drawn with a `border` rather than a `ring`. They are
- * #220, and the staleness check below only walks the three routes named here.
+ * Twenty-one of them: two on `/login`, three on `/signup`, five on `/contact`,
+ * and eleven behind `/profile`'s Security and Shipping tabs. The chat panel's
+ * input is the twenty-second and is measured by `chat-controls.spec.ts`, which
+ * opens the panel.
+ *
+ * `/profile`'s third tab is not walked. General holds one control, the avatar
+ * `input[type=file]`, which is `sr-only` and carries no `id` — so the staleness
+ * check below would fail on its own "renders a field with no id" assertion
+ * rather than measure anything. It is 1.41:1 with a focus indicator of zero
+ * pixels, and it is #231. A *text* field added to that tab would go unmeasured
+ * and unflagged, which is the one hole in the claim above.
  *
  * WCAG 2.2 1.4.11 asks 3:1 of a control's visual boundary. These ten measured
  * 1.41:1 on the account pages and 1.21:1 to 1.28:1 on the contact form — a
@@ -50,6 +57,64 @@ import { expectVisibleControls, type Boundary } from './support/boundary'
  * here and do not read a narrow pass as a near-miss.
  */
 
+const SEEDED_EMAIL = 'johnsmith@example.com'
+const SEEDED_PASSWORD = 'password'
+
+/**
+ * Sign in and open one of `/profile`'s tabs.
+ *
+ * The credentials are `auth.spec.ts`'s, which are `prisma/seed.ts`'s, so this
+ * fails for the same reason that spec does if the seed stops producing usable
+ * accounts. Going through the real form rather than planting a cookie is the
+ * slower option and the honest one: a session this suite forged would not
+ * prove the fields are reachable by a person.
+ *
+ * The cost of that honesty: the Security tab measured below can change this
+ * password, so exercising it for real breaks every test here. It has happened
+ * — a review submitted the form, and nine tests then failed at
+ * `toHaveURL(/\/$/)` with an error pointing at sign-in rather than at the
+ * cause. If they all fail that way at once, check the account before the code.
+ */
+async function openProfileTab(page: Page, tab: string) {
+  // Signing in lands on the home page, which asks the Next image optimiser for
+  // twenty product images at once. On a cold cache those take minutes, and the
+  // navigation to `/profile` queues behind them on a saturated server — the
+  // request is issued and simply never answered, which surfaces as
+  // `net::ERR_ABORTED` when the test gives up. Measured: still pending after
+  // 21 seconds, and `networkidle` never reached inside two minutes.
+  //
+  // None of the fields measured here is an image, so the transit does not need
+  // them. Dropped for the duration of the sign-in and restored afterwards, so
+  // that nothing else in the test runs against a page with its images blocked.
+  await page.route('**/_next/image**', (route) => route.abort())
+
+  await page.goto('/login')
+  await page.getByLabel('Email address').fill(SEEDED_EMAIL)
+  await page.getByLabel('Password').fill(SEEDED_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  // Wait for the redirect to land before touching anything. Signing in
+  // navigates home on its own, and the header renders the profile link as soon
+  // as the session exists — which is before that navigation finishes. A `goto`
+  // issued in that window aborts the one already running, and a click in it is
+  // undone by the redirect that follows.
+  await expect(page).toHaveURL(/\/$/, { timeout: 15_000 })
+
+
+  // The header renders the profile link once the session exists, which is the
+  // signal that signing in worked. Navigating is then a `goto` rather than a
+  // click on it: a Next `<Link>` needs the client bundle to have taken over,
+  // and a click that arrives first does nothing at all — six tests sat on
+  // `http://127.0.0.1:3100/` waiting for a navigation that was never going to
+  // happen. `goto` is safe here in a way it was not a moment ago, because the
+  // redirect this waited for has already landed.
+  await expect(page.getByTitle('Profile Settings')).toBeVisible()
+  await page.goto('/profile')
+  await expect(page).toHaveURL(/\/profile/)
+  await page.unroute('**/_next/image**')
+
+  await page.getByRole('button', { name: tab }).click()
+}
+
 const SURFACES = [
   {
     path: '/login',
@@ -76,7 +141,42 @@ const SURFACES = [
       { name: 'the message field', selector: '#message' },
     ],
   },
-] satisfies { path: string; fields: Boundary[] }[]
+  {
+    path: '/profile',
+    tab: 'Security',
+    fields: [
+      { name: 'the current password field', selector: '#current-password' },
+      { name: 'the new password field', selector: '#new-password' },
+      { name: 'the confirm password field', selector: '#confirm-password' },
+    ],
+  },
+  {
+    path: '/profile',
+    tab: 'Shipping',
+    fields: [
+      { name: 'the full name field', selector: '#name' },
+      { name: 'the address line 1 field', selector: '#addressLine1' },
+      { name: 'the address line 2 field', selector: '#addressLine2' },
+      { name: 'the city field', selector: '#city' },
+      { name: 'the state field', selector: '#state' },
+      { name: 'the postcode field', selector: '#zipCode' },
+      { name: 'the country field', selector: '#country' },
+      { name: 'the phone number field', selector: '#phoneNumber' },
+    ],
+  },
+] satisfies { path: string; tab?: string; fields: Boundary[] }[]
+
+/** Reach a surface, signing in first when it is behind one. */
+async function reach(page: Page, surface: { path: string; tab?: string }) {
+  if (surface.tab) {
+    await openProfileTab(page, surface.tab)
+  } else {
+    await page.goto(surface.path)
+  }
+}
+
+const label = (surface: { path: string; tab?: string }) =>
+  surface.tab ? `${surface.path} (${surface.tab})` : surface.path
 
 /**
  * Phone and desktop, because the contact card's background is a `bg-cover`
@@ -112,10 +212,12 @@ for (const scheme of ['light', 'dark'] as const) {
   test.describe(`form field boundaries in forced colors (${scheme})`, () => {
     test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })
 
-    for (const { path, fields } of SURFACES) {
-      test(`the fields on ${path} keep a boundary`, async ({ page }) => {
+    for (const surface of SURFACES) {
+      test(`the fields on ${label(surface)} keep a boundary`, async ({ page }) => {
+        if (surface.tab) test.slow()
         await page.setViewportSize({ width: 1440, height: 900 })
-        await page.goto(path)
+        await reach(page, surface)
+        const fields = surface.fields
         await expect(page.locator(fields[0].selector)).toBeVisible()
         await page.keyboard.press('Tab')
         await page.mouse.move(2, 2)
@@ -127,13 +229,19 @@ for (const scheme of ['light', 'dark'] as const) {
 }
 
 test.describe('form field boundaries', () => {
-  for (const { path, fields } of SURFACES) {
+  for (const surface of SURFACES) {
     for (const { width, height } of WIDTHS) {
-      test(`the fields on ${path} are visible at rest at ${width}x${height}`, async ({
+      test(`the fields on ${label(surface)} are visible at rest at ${width}x${height}`, async ({
         page,
       }) => {
+        // Signing in and crossing two navigations eats a real share of the 30s
+        // default before any pixel is read — one of these timed out at 30.2s
+        // under load and passed in 6.3s on retry. `test.slow()` triples it for
+        // the surfaces that pay that cost and leaves the others alone.
+        if (surface.tab) test.slow()
         await page.setViewportSize({ width, height })
-        await page.goto(path)
+        await reach(page, surface)
+        const fields = surface.fields
         await expect(page.locator(fields[0].selector)).toBeVisible()
 
       // One real keypress before anything is measured. Chromium grants
@@ -153,11 +261,15 @@ test.describe('form field boundaries', () => {
   }
 
   test('every field on these pages is one of the ones checked', async ({ page }) => {
+    // This one walks every surface, so it pays the sign-in cost twice.
+    test.slow()
     // The lists above are written by hand, so they go stale silently: a sixth
     // field added to the contact form would be unmeasured and nothing here
     // would say so. This walks the rendered forms instead and compares.
-    for (const { path, fields } of SURFACES) {
-      await page.goto(path)
+    for (const surface of SURFACES) {
+      const { fields } = surface
+      const path = label(surface)
+      await reach(page, surface)
       const rendered = await page
         .locator('input:not([type="hidden"]):not([type="submit"]), textarea, select')
         .evaluateAll((nodes) =>

--- a/apps/web/e2e/support/boundary.ts
+++ b/apps/web/e2e/support/boundary.ts
@@ -88,14 +88,46 @@ export async function boundaryContrast(
   // contamination rather than a wrong answer — no arrangement was found where
   // the reported number moved, and the claim here is only that the sampler no
   // longer reads a control and calls it a background.
+  //
+  // Held in *document* coordinates, not viewport ones. `boundingBox` is
+  // relative to the viewport and the loop below scrolls each control to centre
+  // before reading it, so a map captured once at some other offset compares
+  // fresh y values against stale ones. Past a field's height the overlap test
+  // stops matching, every clearance comes back Infinity, and the filtering
+  // quietly turns itself off — the probes go back to landing on the neighbour,
+  // which is the whole thing this map exists to stop.
+  const documentBox = async (selector: string) =>
+    page.locator(selector).evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      return {
+        x: rect.x + window.scrollX,
+        y: rect.y + window.scrollY,
+        width: rect.width,
+        height: rect.height,
+      }
+    })
+
   const boxes = new Map<string, { x: number; y: number; width: number; height: number }>()
   for (const { selector } of boundaries) {
-    const box = await page.locator(selector).boundingBox()
-    if (box) boxes.set(selector, box)
+    boxes.set(selector, await documentBox(selector))
   }
 
   for (const { name, selector } of boundaries) {
     const control = page.locator(selector)
+    // Scrolled into view before its box is read. `boundingBox` is relative to
+    // the viewport, so a control below the fold reports coordinates outside it
+    // and every clamp below goes negative — on `/profile` at 390 the last
+    // shipping field sat 34px past the bottom edge and the reading refused.
+    // Focusing would scroll it anyway, which is the worse version of the same
+    // problem: the resting screenshot would be taken at one scroll offset and
+    // the focused one at another.
+    //
+    // Centred, not `scrollIntoViewIfNeeded`, which scrolls the minimum and
+    // leaves the control flush against the edge it came from — the same field
+    // then reported 0.0px of clearance and refused for the opposite reason.
+    await control.evaluate((element) =>
+      element.scrollIntoView({ block: 'center', inline: 'center' }),
+    )
     const box = await control.boundingBox()
     if (!box) throw new Error(`${selector} has no box`)
 
@@ -148,14 +180,17 @@ export async function boundaryContrast(
     // same row. Only controls that overlap vertically can be in the way; one
     // stacked above or below is behind the label, which is why sampling is
     // horizontal in the first place.
+    // Compared in the same document coordinates the map holds, so the scroll
+    // above cannot put the two out of step.
+    const here = boxes.get(selector) ?? (await documentBox(selector))
     const clearance = (towards: 'left' | 'right') => {
       let nearest = Infinity
       for (const [other, box2] of boxes) {
         if (other === selector) continue
-        const overlaps = box2.y < box.y + box.height && box.y < box2.y + box2.height
+        const overlaps = box2.y < here.y + here.height && here.y < box2.y + box2.height
         if (!overlaps) continue
         const gap =
-          towards === 'left' ? box.x - (box2.x + box2.width) : box2.x - (box.x + box.width)
+          towards === 'left' ? here.x - (box2.x + box2.width) : box2.x - (here.x + here.width)
         if (gap >= 0) nearest = Math.min(nearest, gap)
       }
       return nearest
@@ -306,6 +341,12 @@ export async function boundaryContrast(
  */
 export async function focusChange(page: Page, selector: string) {
   const control = page.locator(selector)
+  // Before the box, and before either screenshot: `focus()` scrolls a control
+  // that is off screen, and the two images are only comparable if nothing
+  // moves between them.
+  await control.evaluate((element) =>
+    element.scrollIntoView({ block: 'center', inline: 'center' }),
+  )
   const box = await control.boundingBox()
   if (!box) throw new Error(`${selector} has no box`)
 

--- a/apps/web/src/components/password-change-form.tsx
+++ b/apps/web/src/components/password-change-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 export default function PasswordChangeForm() {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -60,7 +61,7 @@ export default function PasswordChangeForm() {
           required
           value={currentPassword}
           onChange={(e) => setCurrentPassword(e.target.value)}
-          className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
         />
       </div>
       <div>
@@ -76,7 +77,7 @@ export default function PasswordChangeForm() {
           required
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
-          className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
         />
       </div>
       <div>
@@ -92,7 +93,7 @@ export default function PasswordChangeForm() {
           required
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
-          className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
         />
       </div>
 

--- a/apps/web/src/components/shipping-address-form.tsx
+++ b/apps/web/src/components/shipping-address-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FIELD_BOUNDARY } from "@/lib/field-classes";
 
 interface ShippingAddress {
   addressLine1?: string;
@@ -62,7 +63,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.name || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -74,7 +75,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.addressLine1 || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -86,7 +87,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.addressLine2 || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -98,7 +99,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.city || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -110,7 +111,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.state || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -122,7 +123,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.zipCode || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -134,7 +135,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.country || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -146,7 +147,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.phoneNumber || ""}
             onChange={handleChange}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-xs p-2"
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
           />
         </div>
       </div>

--- a/apps/web/src/lib/field-classes.ts
+++ b/apps/web/src/lib/field-classes.ts
@@ -3,10 +3,13 @@
  * `/signup`, `/contact` and the chat panel.
  *
  * Eleven fields used to choose this for themselves, and they did not agree.
- * They are not all of them: `/profile` renders eleven more, behind its tabs,
- * which draw a `border` rather than a `ring` and fail the same criterion at
- * the same 1.41:1. See #220 — this constant does not drop into them unchanged,
- * and nothing here covers them.
+ * `/profile` renders eleven more behind its tabs. They drew a `border` rather
+ * than a `ring` and failed the same criterion at the same 1.41:1, and #220
+ * converted them to this constant — which did drop in unchanged, contrary to
+ * what this comment said while that was still unmeasured. What it cost was 2px
+ * of height each, since a `border` occupies layout and an inset `ring` does
+ * not, and nothing in forced colors, where `forced-colors:border` puts the
+ * same border back.
  * The ten on `/login`, `/signup` and `/contact` drew `ring-gray-300`, which
  * measured 1.41:1 on the account pages and 1.21:1 to 1.28:1 on the contact
  * card; the chat input was fixed separately in #184 and drew `ring-zinc-500`.


### PR DESCRIPTION
Closes #220.

The eleven text fields behind `/profile`'s tabs drew `border border-gray-300` — **1.41:1** against the page's rgb(250,250,250), where WCAG 2.2 1.4.11 asks 3:1. They now take `FIELD_BOUNDARY`.

That finishes what #196 started: **twenty-two text fields, one definition** — ten account and contact fields, eleven here, and the chat input.

## They failed a second criterion nobody had noticed

With no designed focus treatment they had only Chromium's default ring:

| | before | after |
|---|---|---|
| resting, normal | 1.41:1 | **4.62:1** |
| focus, normal | 1920 / 1939 — fail by 19 | 1945 / 1931 — pass |
| focus, forced-colors light | 1013 / 1939 — fail by 926 | 1979 / 1939 — pass |
| height | 42px | 40px normal, 42px forced-colors |

So the constant is *supplying* the focus indicator here, not recolouring one — which was not true of the ten fields #196 converted.

## How those numbers were obtained

By reverting the source and rebuilding the image. Three attempts to reproduce the old treatment on a live element all left the new outline in place and reported the fix passing. The first rebuild that was meant to settle it **silently served the old image**: reverting left `FIELD_BOUNDARY` imported but unused, `noUnusedLocals` failed the build, and the build output was going to `/dev/null`. A step that doesn't run looks exactly like a step that passes.

## A comment this change made false

`field-classes.ts` said of these fields that the constant *"does not drop into them unchanged, and nothing here covers them"*. It dropped in unchanged. That was written during #196 while it was still a guess, and survived two PRs after it became checkable. What the conversion actually cost is 2px of height each — a `border` occupies layout, an inset `ring` does not — and nothing in forced colors, where `forced-colors:border` puts the same border back.

## Reaching the surface took more work than changing it

These are the first fields behind both a sign-in and a tab. Every hazard was in the harness, not the product:

- a `goto` racing the post-login redirect
- a click racing Next `<Link>` hydration
- a scroll that did the minimum where the measurement needed margin either side

The last wasn't a race at all. Landing on the home page fires twenty `/_next/image` optimisations that block the next navigation for **minutes** on a cold cache (#230). Four fixes diagnosed `ERR_ABORTED` from the error string before one probe of the navigation sequence found it — the request was issued and simply never answered. The sign-in transit now drops those requests, since none of the fields measured here is an image.

## Two findings in the guard, both mine

- **The neighbour-clearance filter added in #196 reads viewport coordinates**, and the scroll added in *this* change moves them between capturing the map and reading each box. Past a field's height every clearance returns `Infinity` and the filtering turns itself off, putting the probes back on the neighbour it exists to avoid. Held in document coordinates now. Neither half was wrong alone.
- **Ten profile tests spend a real share of the 30s budget signing in** before any pixel is read; one timed out at 30.2s under load and passed in 6.3s on retry. Those surfaces are `test.slow()`. `storageState` is the better answer if this goes flaky again.

## Follow-ups filed, none addressed here

- **#230** — the image optimiser blocks navigation for minutes on a cold cache.
- **#231** — the avatar control is still 1.41:1, and its focus indicator measures **zero pixels**. Not a near miss.
- **#232** — both submit buttons give **2 qualifying pixels** against 728 and 616 required, in *ordinary* rendering, because Chromium's dark default ring on `indigo-600` is 2.44:1.
- **#233** — tabs carry no `role="tab"`/`aria-selected`; error text 3.65:1, success text 2.12:1.

The spec's coverage claim now names its own hole: `/profile`'s General tab isn't walked, because its only control is the `sr-only` file input with no `id`, which the staleness check would reject rather than measure.

## Verification

- [x] 77 Playwright journeys against a composed production stack, one clean run, exit 0
- [x] The two affected specs re-run after each round of edits — 25 passed
- [x] `verifier` — `make -C apps/web ci`: lint, both typechecks, journey coverage, 137 vitest, `next build`
- [x] `ui-review` — three viewports, 2×, forced colors both palettes
- [x] `code-review` — no defects; the one refinement is fixed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)