### PR TITLE
fix(web): give every button an edge and a focus indicator

### DIFF
--- a/apps/web/e2e/action-controls.spec.ts
+++ b/apps/web/e2e/action-controls.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from '@playwright/test'
+import { focusChange, REQUIRED_RATIO, boundaryContrast } from './support/boundary'
+import { openProfileTab } from './support/session'
+
+/**
+ * Every button, and every link shaped like one, can be seen and can be focused.
+ *
+ * Two defects, on overlapping but different populations.
+ *
+ * **Resting, in forced colors.** A filled control's edge *is* its background,
+ * and forced-colors replaces every background with a system colour. Measured at
+ * 1440x900 before `ACTION_BOUNDARY`: `Sign in`, `Create account`, `Contact
+ * Support` and the header's `Sign In` all read 6.19:1 normally and **1.00:1**
+ * there; `Send Message` 5.28:1 and 1.09:1. The header's `Sign Up` is the
+ * control that proves the mechanism — outlined rather than filled, so it read
+ * 13.99:1 in both. That was #227.
+ *
+ * **Focus, in ordinary rendering.** Six controls carried no focus treatment at
+ * all: both `/profile` submits, the FAQ's `Contact Support`, and all three in
+ * the header. They fell back to Chromium's default ring, which against
+ * `indigo-600` is 2.44:1, and measured 2 qualifying pixels against the 728 a
+ * 2px perimeter needs. That was #232.
+ *
+ * Two controls sharing the constant are absent from the list below. The chat
+ * send button is measured by `chat-controls.spec.ts`, which opens the panel.
+ * The header's `Sign Out` is measured nowhere: it renders only for an
+ * authenticated session, on a surface this list does not otherwise visit. A
+ * regression in the constant is still caught by the nine measured here; what
+ * would slip is a regression in that one call site's own classes.
+ *
+ * The measurement waits for the indicator to stop moving. Several of these
+ * carry `transition-colors` or `transition-all`, and Tailwind v4 transitions
+ * `outline-color` — so the indicator fades in from `currentColor`, which on a
+ * white-on-indigo button is white. Screenshotting immediately after `focus()`
+ * read `Contact Support` at 0 qualifying pixels; the same control reads 892
+ * once settled. `support/boundary.ts` handles that; it is recorded here because
+ * a zero from this spec is far more likely to be that than a real regression.
+ */
+
+type Control = {
+  name: string
+  selector: string
+  /** Where it lives. `tab` means `/profile`, behind a sign-in. */
+  path?: string
+  tab?: string
+}
+
+const CONTROLS: Control[] = [
+  { name: 'the sign-in submit', selector: 'button[type=submit]', path: '/login' },
+  { name: 'the sign-up submit', selector: 'button[type=submit]', path: '/signup' },
+  { name: 'the contact submit', selector: 'button[type=submit]', path: '/contact' },
+  { name: "the FAQ's Contact Support", selector: 'a[href="/contact"]', path: '/faq' },
+  // Not `header a[...]` — the header component renders a `Block` and divs,
+  // with no `header` element anywhere, so that selector matched nothing and
+  // four tests failed on the locator rather than on the control.
+  { name: "the header's Sign In", selector: 'a[href="/login"]', path: '/' },
+  { name: "the header's Sign Up", selector: 'a[href="/signup"]', path: '/' },
+  { name: "the thanks page's Return to Shop", selector: 'a[href="/"]', path: '/contact/thanks' },
+  // Class-qualified because the signed-out `/profile` renders two links to
+  // `/login` — the header's and this one — and the measurement helpers take a
+  // CSS selector, so `.first()` is not available to them.
+  {
+    name: "the signed-out profile's Sign in CTA",
+    selector: 'a[href="/login"].bg-zinc-800',
+    path: '/profile',
+  },
+  { name: 'the password submit', selector: 'button[type=submit]', tab: 'Security' },
+  { name: 'the address submit', selector: 'button[type=submit]', tab: 'Shipping' },
+]
+
+async function reach(page: Page, control: Control) {
+  if (control.tab) {
+    await openProfileTab(page, control.tab)
+  } else {
+    await page.route('**/_next/image**', (route) => route.abort())
+    await page.goto(control.path ?? '/')
+  }
+  await expect(page.locator(control.selector).first()).toBeVisible()
+}
+
+test.describe('action controls', () => {
+  for (const control of CONTROLS) {
+    test(`${control.name} has a focus indicator`, async ({ page }) => {
+      if (control.tab) test.slow()
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await reach(page, control)
+
+      // Pointer parked first, keypress second, and the order is the whole
+      // point. Chromium grants `:focus-visible` to a programmatically focused
+      // button or link only when the *last* interaction was a keyboard one, so
+      // moving the mouse after the Tab withdraws it again — the contact submit
+      // then measured 0 qualifying pixels at a median of 1.21:1, which is the
+      // default ring on `indigo-600` and not this change's outline at all.
+      // Text inputs match `:focus-visible` regardless, which is why the field
+      // specs never noticed the same ordering.
+      await page.mouse.move(2, 2)
+      await page.keyboard.press('Tab')
+
+      const change = await focusChange(page, control.selector)
+      expect(
+        change.qualifying,
+        `${control.name}'s focus indicator covers ${change.qualifying} pixels changing by ` +
+          `${REQUIRED_RATIO}:1 or more, against the ${Math.round(change.required)} a 2px ` +
+          `perimeter needs (${change.changed} changed at all, median ${change.median.toFixed(2)}:1)`,
+      ).toBeGreaterThanOrEqual(change.required)
+    })
+  }
+})
+
+for (const scheme of ['light', 'dark'] as const) {
+  test.describe(`action controls in forced colors (${scheme})`, () => {
+    test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })
+
+    for (const control of CONTROLS) {
+      test(`${control.name} keeps an edge`, async ({ page }) => {
+        if (control.tab) test.slow()
+        await page.setViewportSize({ width: 1440, height: 900 })
+        await reach(page, control)
+        await page.mouse.move(2, 2)
+        await page.keyboard.press('Tab')
+
+        // Sampled, not read from an ancestor's CSS: in forced colors every
+        // background is a system colour, so the declared value of whatever sits
+        // behind a control says nothing about what is painted there.
+        const [reading] = await boundaryContrast(
+          page,
+          [{ name: control.name, selector: control.selector }],
+          { kind: 'sample' },
+        )
+
+        expect(
+          reading.resting,
+          `${control.name} has no visible edge at rest (WCAG 1.4.11 asks ${REQUIRED_RATIO}:1)`,
+        ).toBeGreaterThanOrEqual(REQUIRED_RATIO)
+      })
+    }
+  })
+}

--- a/apps/web/e2e/chat-controls.spec.ts
+++ b/apps/web/e2e/chat-controls.spec.ts
@@ -90,16 +90,17 @@ test.describe('chat panel controls', () => {
  * this one is `grow` inside a row stretched by a `size-11` button, so the
  * border has somewhere else to come from. Measured rather than predicted.
  *
- * The send button is measured too and is expected to be the weaker of the two:
- * it is filled rather than outlined, and forced-colors replaces its background
- * with a system colour. That is #227, which this does not fix — if it fails
- * here, that is the finding rather than a flake.
+ * Both controls, since #227 gave the send button `ACTION_BOUNDARY`. It is the
+ * one that needed it: filled rather than outlined, so forced colors replaced
+ * its background and left nothing at all, measured at 1.00:1 before. An
+ * earlier version of this block asserted on the input alone while this comment
+ * claimed both were covered.
  */
 for (const scheme of ['light', 'dark'] as const) {
   test.describe(`chat panel controls in forced colors (${scheme})`, () => {
     test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })
 
-    test('the message input keeps a boundary', async ({ page }) => {
+    test('the input and send button keep a boundary', async ({ page }) => {
       await page.setViewportSize({ width: 1440, height: 900 })
       await page.goto('/')
       await page.getByRole('button', { name: 'Open chat' }).click()
@@ -107,7 +108,7 @@ for (const scheme of ['light', 'dark'] as const) {
       await page.keyboard.press('Tab')
       await page.mouse.move(2, 2)
 
-      await expectVisibleControls(page, [BOUNDARIES[0]], {
+      await expectVisibleControls(page, BOUNDARIES, {
         kind: 'css',
         selector: '[role="dialog"]',
       })

--- a/apps/web/e2e/form-fields.spec.ts
+++ b/apps/web/e2e/form-fields.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import { expectVisibleControls, type Boundary } from './support/boundary'
+import { openProfileTab } from './support/session'
 
 /**
  * Every text field the app renders on a page is visible before you touch it.
@@ -23,7 +24,7 @@ import { expectVisibleControls, type Boundary } from './support/boundary'
  *
  * The chat panel's input was fixed for the same reason in #184 and left the
  * app with two input treatments. That was the real cost of doing it piecemeal,
- * so the colour now lives in one place; see `src/lib/field-classes.ts`.
+ * so the colour now lives in one place; see `src/lib/control-classes.ts`.
  *
  * Both surfaces are read per field rather than assumed. `/login` and `/signup`
  * sit on rgb(250,250,250), not white, and the contact card is `bg-white/90`
@@ -50,70 +51,12 @@ import { expectVisibleControls, type Boundary } from './support/boundary'
  * indicator. But it means a green run here is not evidence that the designed
  * outline is doing anything, and the reason to keep it is cross-engine
  * consistency, which one Chromium project cannot test. See the note in
- * `src/lib/field-classes.ts`.
+ * `src/lib/control-classes.ts`.
  *
  * Both numbers sit near the threshold because a 2px outline and a 2px
  * perimeter are nearly the same area by construction. Expect small margins
  * here and do not read a narrow pass as a near-miss.
  */
-
-const SEEDED_EMAIL = 'johnsmith@example.com'
-const SEEDED_PASSWORD = 'password'
-
-/**
- * Sign in and open one of `/profile`'s tabs.
- *
- * The credentials are `auth.spec.ts`'s, which are `prisma/seed.ts`'s, so this
- * fails for the same reason that spec does if the seed stops producing usable
- * accounts. Going through the real form rather than planting a cookie is the
- * slower option and the honest one: a session this suite forged would not
- * prove the fields are reachable by a person.
- *
- * The cost of that honesty: the Security tab measured below can change this
- * password, so exercising it for real breaks every test here. It has happened
- * — a review submitted the form, and nine tests then failed at
- * `toHaveURL(/\/$/)` with an error pointing at sign-in rather than at the
- * cause. If they all fail that way at once, check the account before the code.
- */
-async function openProfileTab(page: Page, tab: string) {
-  // Signing in lands on the home page, which asks the Next image optimiser for
-  // twenty product images at once. On a cold cache those take minutes, and the
-  // navigation to `/profile` queues behind them on a saturated server — the
-  // request is issued and simply never answered, which surfaces as
-  // `net::ERR_ABORTED` when the test gives up. Measured: still pending after
-  // 21 seconds, and `networkidle` never reached inside two minutes.
-  //
-  // None of the fields measured here is an image, so the transit does not need
-  // them. Dropped for the duration of the sign-in and restored afterwards, so
-  // that nothing else in the test runs against a page with its images blocked.
-  await page.route('**/_next/image**', (route) => route.abort())
-
-  await page.goto('/login')
-  await page.getByLabel('Email address').fill(SEEDED_EMAIL)
-  await page.getByLabel('Password').fill(SEEDED_PASSWORD)
-  await page.getByRole('button', { name: /sign in/i }).click()
-  // Wait for the redirect to land before touching anything. Signing in
-  // navigates home on its own, and the header renders the profile link as soon
-  // as the session exists — which is before that navigation finishes. A `goto`
-  // issued in that window aborts the one already running, and a click in it is
-  // undone by the redirect that follows.
-  await expect(page).toHaveURL(/\/$/, { timeout: 15_000 })
-
-
-  // The header renders the profile link once the session exists, which is the
-  // signal that signing in worked. Navigating is then a `goto` rather than a
-  // click on it: a Next `<Link>` needs the client bundle to have taken over,
-  // and a click that arrives first does nothing at all — six tests sat on
-  // `http://127.0.0.1:3100/` waiting for a navigation that was never going to
-  // happen. `goto` is safe here in a way it was not a moment ago, because the
-  // redirect this waited for has already landed.
-  await expect(page.getByTitle('Profile Settings')).toBeVisible()
-  await page.goto('/profile')
-  await expect(page).toHaveURL(/\/profile/)
-  await page.unroute('**/_next/image**')
-
-  await page.getByRole('button', { name: tab }).click()
-}
 
 const SURFACES = [
   {
@@ -196,7 +139,7 @@ const WIDTHS = [
  * All ten measured 1.00:1 before `forced-colors:border` was added to the
  * shared constant — the boundary this file exists to protect was not weakened
  * there, it was absent. Why, and why the fix takes the shape it does, is in
- * `src/lib/field-classes.ts`.
+ * `src/lib/control-classes.ts`.
  *
  * Both palettes, because they are not the same test. Chromium picks its system
  * colours from the colour scheme, so the border is black on white in light and
@@ -205,8 +148,8 @@ const WIDTHS = [
  *
  * Not covered here: the chat panel input, which carries the same constant but
  * whose journeys need the composed stack, and every filled button on these
- * pages, which is the same defect on a population with no shared constant and
- * is #227.
+ * pages — the same defect on a different population, closed by #227 and
+ * measured in `action-controls.spec.ts`.
  */
 for (const scheme of ['light', 'dark'] as const) {
   test.describe(`form field boundaries in forced colors (${scheme})`, () => {

--- a/apps/web/e2e/support/boundary.ts
+++ b/apps/web/e2e/support/boundary.ts
@@ -168,11 +168,23 @@ export async function boundaryContrast(
     // Loudly, rather than measuring whatever happens to be in range. A control
     // pressed against a viewport edge cannot be read this way, and a number
     // produced anyway would look exactly like a real one.
-    const tight = Math.min(padLeft, padTop, padRight, padBottom)
-    if (tight < NEEDED) {
+    //
+    // Asked for per axis, because the two are not used alike: the surface
+    // samples reach sideways only, so the wider margin is horizontal, while the
+    // band walk crosses every edge and needs its reach on all four sides.
+    // Demanding the horizontal figure vertically as well refused the header's
+    // links, which sit 6px below the top of a page already scrolled to the top
+    // — a clearance no scroll can create, for probes never going to look up.
+    // 5, because `band` is [-5..3] and each probe steps by one, so that is
+    // exactly how far outside an edge the walk reaches.
+    const BAND = 5
+    const tightVertical = Math.min(padTop, padBottom)
+    const tightHorizontal = Math.min(padLeft, padRight)
+    if (tightVertical < BAND || tightHorizontal < NEEDED) {
       throw new Error(
-        `${selector} sits ${tight.toFixed(1)}px from a viewport edge, and this ` +
-          `reading needs ${NEEDED}px of surface around it`,
+        `${selector} has ${tightHorizontal.toFixed(1)}px of surface either side and ` +
+          `${tightVertical.toFixed(1)}px above and below; this reading needs ` +
+          `${NEEDED}px horizontally and ${BAND}px vertically`,
       )
     }
 
@@ -310,6 +322,11 @@ export async function boundaryContrast(
       )
     }
 
+    // Transitions killed here too. `focusChange` did this and this function did
+    // not, which is the same race in the sibling: no control currently routed
+    // through here carries `transition-colors` or `transition-all`, so it never
+    // bit — the next one added would have found it.
+    await settled(page)
     await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
     const resting = await measure()
     await page.evaluate(
@@ -323,6 +340,33 @@ export async function boundaryContrast(
   }
 
   return readings
+}
+
+/**
+ * Take the animation out of the measurement.
+ *
+ * Several controls carry `transition-colors` or `transition-all`, and Tailwind
+ * v4 includes `outline-color` in both — so a focus indicator *fades in* from
+ * `currentColor`, which on a white-on-indigo button is white. A screenshot the
+ * instant after `focus()` catches that: `/faq`'s Contact Support read 0
+ * qualifying pixels, and 892 once settled.
+ *
+ * This was first written as a poll — read the computed outline until two
+ * consecutive reads agree — and that is a race, not a wait. The easing has a
+ * slow start, so two reads 25ms apart can match while the colour is still near
+ * its beginning, and `/contact`'s submit duly passed in isolation and failed
+ * at 0 qualifying pixels under load. Killing the transitions is deterministic
+ * where waiting for them is not.
+ *
+ * It means the suite measures the settled indicator and nothing about how long
+ * it takes to arrive. That gap is real and is #235 — where the same control
+ * measures 0 qualifying pixels for the first ~100ms and then 1998 all at once.
+ */
+async function settled(page: Page) {
+  await page.addStyleTag({
+    content:
+      '*, *::before, *::after { transition: none !important; animation: none !important; }',
+  })
 }
 
 /**
@@ -363,8 +407,10 @@ export async function focusChange(page: Page, selector: string) {
   )
 
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+  await settled(page)
   const unfocused = (await page.screenshot({ clip })).toString('base64')
   await page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).focus(), selector)
+  await settled(page)
   const focused = (await page.screenshot({ clip })).toString('base64')
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
 

--- a/apps/web/e2e/support/session.ts
+++ b/apps/web/e2e/support/session.ts
@@ -1,0 +1,92 @@
+import { expect, type BrowserContext, type Page } from '@playwright/test'
+
+const SEEDED_EMAIL = 'johnsmith@example.com'
+const SEEDED_PASSWORD = 'password'
+
+/**
+ * The session from the first real sign-in, reused by every later caller.
+ *
+ * Signing in per test cost fifteen round trips through the login form in one
+ * suite run, and each spends a real share of its budget before any measurement
+ * starts — a profile test duly timed out at 90s under load while passing in 6s
+ * alone. Widening the timeout treated the symptom.
+ *
+ * `workers: 1` and `fullyParallel: false`, so this is one sign-in per run. It
+ * degrades the right way if either changes: the cache is per-worker module
+ * state, so more workers means more sign-ins rather than a shared stale cookie,
+ * and a worker restarting resets it.
+ */
+type StoredSession = Awaited<ReturnType<BrowserContext['storageState']>>
+let cached: StoredSession | undefined
+
+/**
+ * Sign in and open one of `/profile`'s tabs.
+ *
+ * The credentials are `auth.spec.ts`'s, which are `prisma/seed.ts`'s, so this
+ * fails for the same reason that spec does if the seed stops producing usable
+ * accounts. The first call goes through the real form — a session this suite
+ * forged from nothing would not prove the fields are reachable by a person —
+ * and every call after it replays the cookies that produced. So the claim is
+ * demonstrated once per run rather than fifteen times, and `auth.spec.ts`
+ * demonstrates it independently besides.
+ *
+ * The Security tab measured here can change that password, so exercising it for
+ * real breaks every test that depends on it. It has happened: a review
+ * submitted the form, and nine tests then failed at `toHaveURL(/\/$/)` with an
+ * error pointing at sign-in rather than at the cause.
+ *
+ * The signature differs on the cached path. A cookie that has gone stale leaves
+ * `/profile` rendering its signed-out CTA, which satisfies the URL assertion
+ * below and then fails on the tab button instead. Either way, when the profile
+ * tests fail together, check the account before the code.
+ */
+export async function openProfileTab(page: Page, tab: string) {
+  if (cached) {
+    await page.context().addCookies(cached.cookies)
+    await page.goto('/profile')
+    await expect(page).toHaveURL(/\/profile/)
+    await page.getByRole('button', { name: tab }).click()
+    return
+  }
+
+  // Signing in lands on the home page, which asks the Next image optimiser for
+  // twenty product images at once. On a cold cache those take minutes, and the
+  // navigation to `/profile` queues behind them on a saturated server — the
+  // request is issued and simply never answered, surfacing as
+  // `net::ERR_ABORTED` when the test gives up. Measured: still pending after 21
+  // seconds, and `networkidle` never reached inside two minutes. That is #230.
+  //
+  // Nothing measured through this helper is an image, so the transit does not
+  // need them. Dropped for the sign-in and restored afterwards, so nothing else
+  // runs against a page with its images blocked. The cached path above never
+  // touches the home page and so never needs this.
+  await page.route('**/_next/image**', (route) => route.abort())
+
+  await page.goto('/login')
+  await page.getByLabel('Email address').fill(SEEDED_EMAIL)
+  await page.getByLabel('Password').fill(SEEDED_PASSWORD)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  // Wait for the redirect to land before touching anything. Signing in
+  // navigates home on its own, and the header renders the profile link as soon
+  // as the session exists — which is before that navigation finishes. A `goto`
+  // issued in that window aborts the one already running, and a click in it is
+  // undone by the redirect that follows.
+  await expect(page).toHaveURL(/\/$/, { timeout: 15_000 })
+
+
+  // The header renders the profile link once the session exists, which is the
+  // signal that signing in worked. Navigating is then a `goto` rather than a
+  // click on it: a Next `<Link>` needs the client bundle to have taken over,
+  // and a click that arrives first does nothing at all — six tests sat on
+  // `http://127.0.0.1:3100/` waiting for a navigation that was never going to
+  // happen. `goto` is safe here in a way it was not a moment ago, because the
+  // redirect this waited for has already landed.
+  await expect(page.getByTitle('Profile Settings')).toBeVisible()
+  await page.goto('/profile')
+  await expect(page).toHaveURL(/\/profile/)
+  await page.unroute('**/_next/image**')
+  cached = await page.context().storageState()
+
+  await page.getByRole('button', { name: tab }).click()
+}
+

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -1,6 +1,7 @@
 import Block from "@/components/block";
 import Header from "@/components/header";
 import Link from "next/link";
+import { ACTION_BOUNDARY } from "@/lib/control-classes";
 
 export default function FAQPage() {
   return (
@@ -70,7 +71,7 @@ export default function FAQPage() {
         <p className="text-lg text-zinc-600 mb-8">
           We&apos;re here to help. Reach out to our support team for assistance.
         </p>
-        <Link href="/contact" className="px-6 py-3 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-500 transition-colors">
+        <Link href="/contact" className={`px-6 py-3 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-500 transition-colors focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}>
           Contact Support
         </Link>
       </Block>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -87,7 +87,7 @@ export default function LoginPage() {
           <div>
             <button
               type="submit"
-              className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              className={`flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
             >
               Sign in
             </button>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -7,6 +7,7 @@ import Header from "@/components/header";
 import AvatarUpload from "@/components/avatar-upload";
 import PasswordChangeForm from "@/components/password-change-form";
 import ShippingAddressForm from "@/components/shipping-address-form";
+import { ACTION_BOUNDARY } from "@/lib/control-classes";
 
 export default function ProfilePage() {
   const { data: session, status, update } = useSession();
@@ -58,7 +59,7 @@ export default function ProfilePage() {
           </p>
           <Link
             href="/login"
-            className="rounded-md bg-zinc-800 px-6 py-2 text-lg text-zinc-100 hover:bg-zinc-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+            className={`rounded-md bg-zinc-800 px-6 py-2 text-lg text-zinc-100 hover:bg-zinc-700 focus-visible:outline-sky-700 ${ACTION_BOUNDARY}`}
           >
             Sign in to continue
           </Link>

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 export default function SignUpPage() {
   const [name, setName] = useState("");
@@ -116,7 +116,7 @@ export default function SignUpPage() {
           <div>
             <button
               type="submit"
-              className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              className={`flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
             >
               Sign up
             </button>

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -11,7 +11,7 @@ import Turn from "./turn";
 import { ChatTurn } from "@/lib/types";
 import { useSession } from "next-auth/react";
 import { sendChatMessage } from "@/lib/messaging";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 interface ChatAction {
   type: "add" | "clear" | "resolve";
@@ -626,7 +626,7 @@ export const Chat = () => {
                 // target in WCAG 2.5.5, Apple's HIG and Android's guidance, and
                 // this is the primary action of a full-screen sheet at phone
                 // width — a bad place to lose it to a side effect.
-                className="rounded-md size-11 flex items-center justify-center bg-sky-700 text-white hover:bg-sky-800 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700"
+                className={`rounded-md size-11 flex items-center justify-center bg-sky-700 text-white hover:bg-sky-800 hover:cursor-pointer focus-visible:outline-sky-700 ${ACTION_BOUNDARY}`}
               >
                 <PaperAirplaneIcon className="w-6" aria-hidden="true" />
               </button>
@@ -701,7 +701,12 @@ export const Chat = () => {
             // Every other control in the widget styles its focus ring; this one
             // was left on the browser default, and the focus trap makes it a
             // stop that keyboard users land on every cycle.
-            className="bg-indigo-600 text-white rounded-full p-2 shadow-[0_0_0_2px_#ffffff,0_0_0_3px_#18181b,0_10px_15px_-3px_#0000001a] hover:bg-indigo-500 hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-indigo-600"
+            // The edge without `ACTION_FOCUS`'s offset: #190 gave this one
+            // offset-4 so the ring clears the photography behind it. Its
+            // three-ring `shadow-[...]` is a box-shadow, which forced colors
+            // strips outright -- measured 1.00:1 there, a bare glyph with no
+            // disc at all.
+            className="bg-indigo-600 text-white rounded-full p-2 shadow-[0_0_0_2px_#ffffff,0_0_0_3px_#18181b,0_10px_15px_-3px_#0000001a] hover:bg-indigo-500 hover:cursor-pointer forced-colors:border-2 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-indigo-600"
             onClick={toggleChat}
             aria-label={showChat ? "Close chat" : "Open chat"}
           >

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 export default function ContactForm() {
   const [formData, setFormData] = useState({
@@ -155,7 +155,7 @@ export default function ContactForm() {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="w-full flex justify-center rounded-lg bg-indigo-600 px-4 py-4 text-sm font-bold text-white shadow-lg hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        className={`w-full flex justify-center rounded-lg bg-indigo-600 px-4 py-4 text-sm font-bold text-white shadow-lg hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-indigo-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed ${ACTION_BOUNDARY}`}
       >
         {isSubmitting ? "Sending..." : "Send Message"}
       </button>

--- a/apps/web/src/components/contact-thanks.tsx
+++ b/apps/web/src/components/contact-thanks.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ACTION_BOUNDARY } from "@/lib/control-classes";
 
 export default function ContactThanks() {
   return (
@@ -11,7 +12,7 @@ export default function ContactThanks() {
       </p>
       <Link
         href="/"
-        className="rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-colors w-full"
+        className={`rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-indigo-600 transition-colors w-full ${ACTION_BOUNDARY}`}
       >
         Return to Shop
       </Link>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -7,6 +7,7 @@ import { useSession, signOut } from "next-auth/react";
 import Link from "next/link";
 import SidebarWrapper from "./sidebar-wrapper";
 import { Suspense } from "react";
+import { ACTION_BOUNDARY, ACTION_FOCUS } from "@/lib/control-classes";
 
 export const Header = () => {
   const { data: session, status } = useSession();
@@ -59,17 +60,21 @@ export const Header = () => {
               </Link>
               <button
                 onClick={() => signOut()}
-                className="ml-4 px-3 py-1.5 text-sm font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-500"
+                className={`ml-4 px-3 py-1.5 text-sm font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-500 focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
               >
                 Sign Out
               </button>
             </>
           ) : (
             <>
-              <Link href="/login" className="px-3 py-1.5 text-sm font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-500">
+              <Link href="/login" className={`px-3 py-1.5 text-sm font-semibold text-white bg-indigo-600 rounded-md hover:bg-indigo-500 focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}>
                 Sign In
               </Link>
-              <Link href="/signup" className="ml-2 px-3 py-1.5 text-sm font-semibold text-indigo-600 border border-indigo-600 rounded-md hover:bg-indigo-50 hover:text-indigo-700">
+              <Link href="/signup" // `ACTION_FOCUS`, not `ACTION_BOUNDARY`: outlined rather than
+                // filled, so it already has an edge forced colors keeps, and
+                // the constant's `border-2` would render it identically to the
+                // filled Sign In beside it.
+                className={`ml-2 px-3 py-1.5 text-sm font-semibold text-indigo-600 border border-indigo-600 rounded-md hover:bg-indigo-50 hover:text-indigo-700 focus-visible:outline-indigo-600 ${ACTION_FOCUS}`}>
                 Sign Up
               </Link>
             </>

--- a/apps/web/src/components/password-change-form.tsx
+++ b/apps/web/src/components/password-change-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 export default function PasswordChangeForm() {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -103,7 +103,7 @@ export default function PasswordChangeForm() {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400"
+        className={`inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400 focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
       >
         {isSubmitting ? "Updating..." : "Update Password"}
       </button>

--- a/apps/web/src/components/shipping-address-form.tsx
+++ b/apps/web/src/components/shipping-address-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { FIELD_BOUNDARY } from "@/lib/field-classes";
+import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
 interface ShippingAddress {
   addressLine1?: string;
@@ -158,7 +158,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
       <button
         type="submit"
         disabled={isSubmitting}
-        className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400"
+        className={`inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-400 focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
       >
         {isSubmitting ? "Saving..." : "Save Address"}
       </button>

--- a/apps/web/src/lib/control-classes.ts
+++ b/apps/web/src/lib/control-classes.ts
@@ -1,6 +1,19 @@
 /**
+ * What the app's controls share, for the parts that have one right answer.
+ *
+ * Two exports, because fields and action controls fail differently and are
+ * fixed differently. `FIELD_BOUNDARY` carries a colour, since a text field's
+ * resting edge has a single correct value everywhere. `ACTION_BOUNDARY` does
+ * not: a button's accent is indigo on the page and sky-700 inside the chat
+ * widget, and #184 chose that split deliberately so the send button reads as
+ * part of the panel rather than part of the page. So the mechanism is shared
+ * and the accent stays at the call site — the same division as radius and
+ * padding staying with each field below.
+ */
+
+/**
  * The boundary and focus indicator shared by the text fields on `/login`,
- * `/signup`, `/contact` and the chat panel.
+ * `/signup`, `/contact`, `/profile` and the chat panel.
  *
  * Eleven fields used to choose this for themselves, and they did not agree.
  * `/profile` renders eleven more behind its tabs. They drew a `border` rather
@@ -121,3 +134,63 @@
 export const FIELD_BOUNDARY =
   'ring-1 ring-inset ring-zinc-500 forced-colors:border focus:ring-sky-700 ' +
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700'
+
+/**
+ * What every button and button-shaped link needs, minus its colour.
+ *
+ * Filled controls have no boundary of their own — their edge *is* their
+ * background, and forced-colors replaces every background with a system
+ * colour. Measured at 1440x900 before this: `Sign in`, `Create account`,
+ * `Contact Support` and the header's `Sign In` all read 6.19:1 normally and
+ * **1.00:1** in forced colors, `Send Message` 5.28:1 and 1.09:1. The header's
+ * `Sign Up` is the control that proves the mechanism — it is outlined rather
+ * than filled, carries `border border-indigo-600`, and reads 13.99:1 there.
+ * `forced-colors:border-2` gives the filled ones the same edge.
+ *
+ * Two pixels, not one, and the second is doing work. At 1px every control
+ * converges on the same rectangle there: measured on `/login`, the submit came
+ * out 384x38 with a 1px border and a 6px radius — the same three numbers as
+ * the two fields above it, with only a bold centred label to say which one you
+ * press. The header was worse: filled `Sign In` and outlined `Sign Up`
+ * rendered as identical declarations, so primary and secondary became tellable
+ * apart only by label width. Forced colors takes the colours away, so weight
+ * is what is left to carry hierarchy, and an action gets twice a field's.
+ *
+ * The outline width and offset are here; the colour is not. `outline-2` and
+ * `outline-offset-2` are right for anything sitting on a page — the chat
+ * launcher is the exception, at `outline-offset-4`, because it sits on
+ * photography and #190 gave it the extra air deliberately. Every call site
+ * should already
+ * pair this with its own `focus-visible:outline-indigo-600` or
+ * `-outline-sky-700`. Six controls carried no focus treatment at all before
+ * this — both `/profile` submits, the FAQ's `Contact Support`, and all three
+ * in the header — which measured 2 qualifying pixels against the 728 a 2px
+ * perimeter needs, because Chromium's dark default ring on `indigo-600` is
+ * 2.44:1.
+ *
+ * Deliberately not a function taking the colour. Tailwind scans source text
+ * for literal class names, so a computed `outline-${accent}` is a class that
+ * never reaches the stylesheet — the failure would be a silently missing
+ * indicator, which is the thing this file exists to prevent.
+ */
+export const ACTION_FOCUS =
+  'focus-visible:outline-2 focus-visible:outline-offset-2'
+
+/**
+ * The focus half plus the forced-colors edge, for controls whose edge is their
+ * fill.
+ *
+ * Split from `ACTION_FOCUS` because the two halves are independent and two
+ * controls need exactly one each. The header's `Sign Up` is outlined rather
+ * than filled — it already has an edge forced colors keeps, measured 13.99:1
+ * there — so taking `border-2` would put it at 2px beside the filled `Sign In`
+ * and render the two as identical declarations, which is the distinction
+ * `border-2` exists to restore. The chat launcher needs the opposite: the edge,
+ * but not `outline-offset-2`, since #190 gave it offset-4 to clear the
+ * photography behind it.
+ *
+ * Both wrote their classes out longhand before this split. That is the failure
+ * this file exists to prevent — six literal classes copied by the next outlined
+ * control, with one of them dropped.
+ */
+export const ACTION_BOUNDARY = `forced-colors:border-2 ${ACTION_FOCUS}`


### PR DESCRIPTION
Closes #227. Closes #232.

Two defects on overlapping populations.

**Resting, in forced colors.** A filled control's edge *is* its background, and forced colors replaces every background with a system colour.

| control | normal | forced-colors before | after |
|---|---|---|---|
| Sign in, Create account | 6.19:1 | **1.00:1** | **21.00:1** |
| Send Message | 5.28:1 | 1.09:1 | 19.23:1 |
| Contact Support, header Sign In | 6.19:1 | 1.00:1 | 13.99:1 |
| chat send, chat launcher, profile CTA | 5.23–14.64:1 | 1.00:1 | bordered |
| header Sign Up (outlined, not filled) | 6.19:1 | 13.99:1 | 13.99:1 |

That last row is the control that proves the mechanism — it already had a border, and a border is what forced colors keeps.

**Focus, in ordinary rendering.** Six controls had no focus treatment at all — both `/profile` submits, the FAQ's Contact Support, and all three in the header. They fell back to Chromium's default ring, which against `indigo-600` is 2.44:1, and measured **2 qualifying pixels against the 728** a 2px perimeter needs.

Normal rendering is unchanged on every control.

## Two constants, because two controls need one half each

`ACTION_FOCUS` carries the indicator; `ACTION_BOUNDARY` adds the forced-colors edge. The header's `Sign Up` is outlined, so `border-2` would render it identically to the filled `Sign In` beside it; the chat launcher needs the edge but keeps `outline-offset-4`, which #190 gave it to clear the photography behind it. Before the split both wrote six classes out longhand — the failure this file exists to prevent.

**Neither carries a colour.** A button's accent is indigo on the page and sky-700 in the chat widget, which #184 chose so the send button reads as part of the panel. So the mechanism is shared and the accent stays at the call site — the same division as radius and padding staying with each field. Not a function taking the colour either: Tailwind scans source text for literal class names, so a computed `outline-${accent}` never reaches the stylesheet and the failure would be a silently missing indicator.

## `border-2`, because at 1px everything converged

The `/login` submit came out **384×38 with a 1px border and a 6px radius** — the same three numbers as the two fields above it, with only a bold centred label to say which one you press. Forced colors takes the colours away, so weight is what is left to carry hierarchy: **fields 1px, filled actions 2px, outlined actions 1px.**

`field-classes.ts` is now `control-classes.ts`, since it covers two families.

## Most of the work was in the measuring, and six of those fixes were mine

- `mouse.move` after `keyboard.press` **withdraws `:focus-visible`** from buttons and links. The contact submit measured 0 qualifying pixels at median 1.21:1 — the default ring, not this change's outline. Text inputs match regardless, which is why the field specs never noticed.
- The clearance check demanded 22px on **all four sides** for probes that only reach sideways, and 7px of band where the walk reaches 5.
- `settled()` began as a poll for two consecutive equal reads — **a race against an eased transition**, which duly passed in isolation and failed under load. It kills the transitions now, and was applied to one of the two measurement functions and not the other.
- Signing in per test cost fifteen round trips; a profile test timed out at 90s under load while passing in 6s alone. The session is captured once from a real sign-in and replayed, so the claim that these controls are reachable by a person is still demonstrated — once per run rather than fifteen times.

## Coverage, stated honestly

The header's `Sign Out` is the one control sharing the constant that nothing measures — it renders only for an authenticated session — and the spec says so. A regression in the constant is still caught by the nine measured; only that call site's own classes could slip.

`verifier` caught me marking three controls "covered" when the chat spec asserted on its input alone while its comment claimed both. Fixed, and the send button is now genuinely asserted.

## Filed, not addressed here

**#235** — these indicators animate: `Send Message` has zero qualifying area for the first ~100ms and then 1998 pixels at once. **#231**, **#233** remain open on `/profile`.

## Verification

- [x] 107 Playwright journeys against a composed production stack, exit 0, zero errors
- [x] `verifier` — lint, both typechecks, journey coverage, 137 vitest, 153 root guardrail tests
- [x] `ui-review` — three viewports × both palettes; its two design findings (`border-2`, and `Sign Up` opting out) are in the change
- [x] `code-review` — no defects; five refinements applied, including the constant split

🤖 Generated with [Claude Code](https://claude.com/claude-code)