### PR TITLE
fix(web): give the avatar control an edge and a focus indicator

### DIFF
--- a/apps/web/e2e/action-controls.spec.ts
+++ b/apps/web/e2e/action-controls.spec.ts
@@ -64,6 +64,19 @@ const CONTROLS: Control[] = [
     selector: 'a[href="/login"].bg-zinc-800',
     path: '/profile',
   },
+  // The visible control is the label; the input it wraps is `sr-only`, a 1x1
+  // clipped box. Measuring the input would measure nothing a user can see.
+  //
+  // `focusChange` calls `.focus()` on this label, which is not itself
+  // focusable — Chromium delegates that to the labelled control, so the input
+  // takes focus, `:has(:focus-visible)` matches and the outline paints. That
+  // delegation is load-bearing and this suite is Chromium-only: if it ever
+  // stopped, the reading would be 0 rather than an error.
+  {
+    name: "the avatar control",
+    selector: 'label:has(input[type="file"])',
+    tab: 'General',
+  },
   { name: 'the password submit', selector: 'button[type=submit]', tab: 'Security' },
   { name: 'the address submit', selector: 'button[type=submit]', tab: 'Shipping' },
 ]
@@ -80,6 +93,34 @@ async function reach(page: Page, control: Control) {
 
 test.describe('action controls', () => {
   for (const control of CONTROLS) {
+    test(`${control.name} has an edge at rest`, async ({ page }) => {
+      // Ordinary rendering, and the only resting check these controls have in
+      // it — the forced-colors one below replaces every fill with a system
+      // colour, so a fill regression is invisible there.
+      //
+      // The indigo-filled controls clear this on their background alone at
+      // 6.19:1, and the outlined ones go further: `Sign Up` reads 13.99:1. So
+      // it bites two things. An outlined control whose edge is too pale, which
+      // is what it caught here — the avatar's `border-gray-300` measured
+      // 1.41:1, the value #196 removed from the text fields. And a fill that
+      // goes light, `bg-indigo-600` to `bg-indigo-300`, which nothing else
+      // would see.
+      if (control.tab) test.slow()
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await reach(page, control)
+      await page.mouse.move(2, 2)
+
+      const [reading] = await boundaryContrast(
+        page,
+        [{ name: control.name, selector: control.selector }],
+        { kind: 'sample' },
+      )
+      expect(
+        reading.resting,
+        `${control.name} has no visible edge at rest (WCAG 1.4.11 asks ${REQUIRED_RATIO}:1)`,
+      ).toBeGreaterThanOrEqual(REQUIRED_RATIO)
+    })
+
     test(`${control.name} has a focus indicator`, async ({ page }) => {
       if (control.tab) test.slow()
       await page.setViewportSize({ width: 1440, height: 900 })

--- a/apps/web/src/components/avatar-upload.tsx
+++ b/apps/web/src/components/avatar-upload.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, ChangeEvent } from "react";
+import { ACTION_FOCUS_WITHIN } from "@/lib/control-classes";
 
 interface AvatarUploadProps {
   initialAvatar: string;
@@ -51,7 +52,27 @@ export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadPr
         )}
       </div>
       
-      <label className="cursor-pointer bg-white px-3 py-2 border border-gray-300 rounded-md shadow-xs text-sm font-medium text-gray-700 hover:bg-gray-50">
+      {/*
+        The boundary and the focus indicator both belong here rather than on
+        the input: this label is the control anyone can see, and the input it
+        wraps is `sr-only`. `border-gray-300` measured 1.41:1 against the
+        white it sits on, the same value #196 took off the text fields.
+
+        `forced-colors:border-2` because that is flatly what an action is in
+        this app there, and a field is 1px. Not because of what sits nearby: in
+        ordinary rendering this control is a 1px zinc-500 rounded edge, which
+        is `FIELD_BOUNDARY`'s treatment exactly, so it reads as a field
+        normally and as an action in forced colors. The convention carries it;
+        the neighbours are on another tab and never share a screen.
+
+        Written out rather than taken from `ACTION_BOUNDARY`, which pairs it
+        with `focus-visible` — and the focusable element here is a descendant.
+        If a second control ever needs this pairing, the edge wants its own
+        constant rather than a second copy of this literal.
+      */}
+      <label
+        className={`cursor-pointer bg-white px-3 py-2 border border-zinc-500 rounded-md shadow-xs text-sm font-medium text-gray-700 hover:bg-gray-50 has-[:focus-visible]:outline-indigo-600 forced-colors:border-2 ${ACTION_FOCUS_WITHIN}`}
+      >
         <span>Upload Avatar</span>
         <input
           type="file"

--- a/apps/web/src/lib/control-classes.ts
+++ b/apps/web/src/lib/control-classes.ts
@@ -1,8 +1,9 @@
 /**
  * What the app's controls share, for the parts that have one right answer.
  *
- * Two exports, because fields and action controls fail differently and are
- * fixed differently. `FIELD_BOUNDARY` carries a colour, since a text field's
+ * Four exports, because fields and action controls fail differently, are fixed
+ * differently, and a control whose focusable element is a descendant needs a
+ * different variant again. `FIELD_BOUNDARY` carries a colour, since a text field's
  * resting edge has a single correct value everywhere. `ACTION_BOUNDARY` does
  * not: a button's accent is indigo on the page and sky-700 inside the chat
  * widget, and #184 chose that split deliberately so the send button reads as
@@ -194,3 +195,24 @@ export const ACTION_FOCUS =
  * control, with one of them dropped.
  */
 export const ACTION_BOUNDARY = `forced-colors:border-2 ${ACTION_FOCUS}`
+
+/**
+ * `ACTION_FOCUS` for a control whose focusable element is a descendant.
+ *
+ * The avatar upload is a `<label>` wrapping an `sr-only` `<input type="file">`.
+ * The label is what a person sees and clicks; the input is a 1x1 clipped box,
+ * and it is the input that takes focus. So Chromium paints its default ring on
+ * a 1x1 element and the visible control shows nothing at all — measured, the
+ * pixels changing anywhere around it on focus were 0, against the 610 a 2px
+ * perimeter of the label needs. Not a weak indicator; none.
+ *
+ * `has-[:focus-visible]:`, not `focus-within:`. Focus-within also fires for a
+ * pointer, and the whole reason the rest of this file uses `focus-visible` is
+ * that someone who clicked a control knows where they are.
+ *
+ * The geometry is the same as `ACTION_FOCUS` and has to be repeated rather
+ * than composed, because a Tailwind variant is a prefix on each class and the
+ * scanner only sees literals.
+ */
+export const ACTION_FOCUS_WITHIN =
+  'has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2'


### PR DESCRIPTION
Closes #231 — the last control in the app without either.

It is a `<label>` wrapping an `sr-only` `<input type="file">`. The label is what anyone sees and clicks; the input is a 1×1 clipped box. Both defects followed from styling the wrong one of the two.

| | before | after |
|---|---|---|
| resting boundary | **1.41:1** | **4.62:1** |
| focus indicator | **0** qualifying pixels / 610 required | **628** / 610, median 6.19:1 |
| forced-colors border | 1px | 2px — an action, not a field |

Zero is not a weak indicator. Chromium painted its default ring on the 1×1 input, so nothing changed anywhere around the visible control.

## `has-[:focus-visible]:`, not `focus-within:`

Clicking the label *does* focus the input, and `focus-within` would fire on that. `:focus-visible` does not — which is the point: someone who clicked a control knows where they are. Confirmed by rendering both, not reasoned from the spec.

`ACTION_FOCUS_WITHIN` repeats `ACTION_FOCUS`'s geometry rather than composing it. A Tailwind variant is a prefix on each class and the scanner only reads literals, so there is nothing to compose from — the same constraint that stops any of these constants taking a colour.

## `forced-colors:border-2`

Because an action is flatly 2px in this app there and a field is 1px. **Not** because of the neighbours, which sit on another tab and never share a screen: in ordinary rendering this control is a 1px `zinc-500` rounded edge, which is `FIELD_BOUNDARY`'s treatment exactly. So it reads as a field normally and as an action in forced colors.

## The guard gained a check it was missing

`action-controls.spec.ts` measured resting contrast only in **forced colors**, where every fill is replaced by a system colour — so nothing in it could ever have caught a 1.41:1 border. It now checks ordinary rendering too, across all eleven controls, and bites two things: an outlined edge that is too pale, and a fill that goes light (`bg-indigo-600` → `bg-indigo-300`), which nothing else in the suite would see.

`code-review` caught that check's comment citing "5.28:1 to 6.19:1 across the set". 5.28 is the chat send button, which this file's own header says is measured elsewhere, and the set runs to 13.99:1 — a number borrowed from a population it doesn't describe. Corrected.

## Filed, not addressed here

- **#237** — the same component fails a failed upload silently (preview and spinner both say success), announces the upload to nobody, renders "No Image" at 2.10:1, and loses its 128px frame entirely in forced colors.
- **#238** — choosing the neutral border here leaves the app with two outlined actions in two colours, and this one's hover measures a **1.00:1** change: `bg-white` → `hover:bg-gray-50` against a `bg-zinc-50` page moves the fill *toward* the background.

## Verification

Run by `verifier`, not pre-run here:

- [x] `make -C apps/web ci` — lint, both typechecks, journey coverage, 137 unit, production build
- [x] `make test-scripts` — 153
- [x] Full Playwright suite — **121/121 in one run** against a composed production stack
- [x] Compiled CSS confirmed to emit all four new selectors, and the label→input focus delegation confirmed to produce a real indicator rather than a silent zero
- [x] `ui-review` — three viewports, 2×, both forced-colors palettes; its `forced-colors:border-2` finding is in the change
- [x] `code-review` — no defects; the one refinement is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)