### PR TITLE
docs(agents): say which tests the main agent runs and which the verifier does

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -41,10 +41,23 @@ Pick the narrowest set that covers the change. From `AGENTS.md`:
 | docs | `make docs-check` |
 | cross-surface (web + chat + schema) | `make ci` |
 | integration confidence | `make e2e-smoke` |
+| user journeys | `make test-e2e` |
 
 Run `make docs-check` whenever any Markdown changed; it also runs `agent-docs-check`, which fails if a pointer file gained content.
 
 Run `make e2e-smoke` when the change touches runtime code, the Dockerfiles, or `docker-compose.yml`. It is the only check that exercises the built containers, and this repository has a history of breaks that only appear there — a missing `COPY` line, an unresolvable module inside the image, a stale build-time asset path. Green unit tests do not substitute for it.
+
+Run `make test-e2e` whenever the change touches anything a journey renders. It is not the same check as the smoke: the smoke asks whether routes respond, the journeys ask whether they work, and a page can return 200 while every image on it 404s. Step 4 runs the one spec under change and is told not to run the suite, so this is the only place it runs before a push.
+
+Run them in that order, smoke then journeys, and pass `KEEP_STACK=1`. The smoke always rebuilds: `--build --force-recreate` is unconditional, so it recreates the web and chat containers from current source whatever else is running, and only the teardown is conditional on that flag. Journeys first would measure the images the smoke is about to replace, which on a stack built several steps ago is code that no longer exists.
+
+`KEEP_STACK=1` is what makes a handover survive. Without it an `EXIT` trap runs `docker compose down --volumes`, taking the caller's stack and its seeded database with it — ordering does not save it, because the trap fires either way.
+
+Ports are where the two commands differ. `make test-e2e` goes wherever `E2E_BASE_URL` points, so a remapped stack is fine for it — measured, a stack on 3100 carrying the compose default `NEXTAUTH_URL` signs in and runs the profile journeys. `make e2e-smoke` cannot be aimed anywhere: it probes `http://127.0.0.1:3000` and `http://127.0.0.1:8000` literally.
+
+So on a remapped handover, run the journeys against the URL you were given and report that the smoke was not run and why. Do not run it anyway. What it would do to the stack you were handed depends on which compose files resolve and which ports are already held, and the outcomes range from dropping the remapping under you to probing an unrelated project's containers and coming back green — so the one thing you cannot do is trust its verdict.
+
+If there is no stack at all and you need one, say what you started and stop it when you are done.
 
 ## What to report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,22 @@ Follow these steps in order for every change.
    the intended case produces. Fixture-isolation rules for the root guard suite
    live in `tests/scripts/AGENTS.md`.
 
+   **Run the focused test here, and only the focused test.** This step needs
+   the one spec or module under change, its red phase, and the mutations that
+   demonstrate what each assertion catches. The `verifier` will not do those:
+   it is instructed not to modify the repository, so breaking an input on
+   purpose is not available to it. Fast whole-suite runners are fine too where
+   they are genuinely fast — `make test-web` is a few seconds.
+
+   The one spec may itself be a journey, and then it needs a composed stack:
+   `make e2e-smoke KEEP_STACK=1` builds one and leaves it up, and steps 6 and 7
+   will want that same one. No make target runs a single spec, so running just
+   the one is `npx playwright test <file>` from `apps/web`.
+
+   What does not belong here is the whole journey suite. Running it costs
+   minutes per iteration, and the trigger for handing over is "I believe this
+   is done", not "I want to know whether it works".
+
 5. **Inspect the complete diff.** Review the branch diff plus all staged,
    unstaged, and untracked files. Remove accidental or unrelated changes while
    preserving work that belongs to the user. A real problem found here is filed
@@ -135,12 +151,41 @@ Follow these steps in order for every change.
    not applicable. If a finding is not applicable, record the concrete reason
    rather than silently ignoring it.
 
+   `ui-review` may start and stop a stack of its own. If one is already up from
+   step 4, say so and say it is not to be torn down — otherwise step 7's
+   handover below promises a stack that stopped existing here.
+
 7. **Run `verifier` before code review.** Invoke the `verifier` sub-agent to run
    the builds, static checks, tests, and journey coverage appropriate for the
    change. The verifier must report failures, flakes, missing coverage, and
    environment issues. Fix or explicitly resolve every actionable finding
    before starting code review. If a verifier finding requires a code change,
    rerun the verifier after addressing it.
+
+   **The whole battery belongs here** — the merge-gate command, the production
+   build, the root guard suite, and the full journey run. Do not pre-run those
+   and hand over a summary: it doubles the wall-clock, and a summary is not
+   what the next step needs.
+
+   **Hand over the stack rather than leaving one to be found.** Where journeys
+   need a composed stack, step 4 has usually built one, and step 6 may have
+   built its own — `ui-review` is allowed to, and that one is then its to tear
+   down and may be on ports it chose. Give the `E2E_BASE_URL`, say the stack is
+   yours, and say `KEEP_STACK=1`: without that flag `make e2e-smoke` deletes
+   the containers and their volumes on exit. What the handover buys is not the
+   rebuild, which happens either way, but that the verifier knows a stack
+   exists, knows where it is, and knows not to destroy it. Tear it down after
+   the last step that needs it, not after this one.
+
+   Say the ports if they are not the defaults. `make test-e2e` follows
+   `E2E_BASE_URL` anywhere; `make e2e-smoke` probes `127.0.0.1:3000` and
+   `:8000` literally and cannot be aimed elsewhere, so it and a remapped stack
+   do not mix. One of the ways they fail is a green smoke run against an
+   unrelated project's containers, which is worse than a failure because
+   nothing looks wrong. Exactly which way you get depends on which compose
+   files resolve and which ports are already held, and is not worth predicting
+   here. Free the default ports before step 7, or hand over nothing and say
+   why.
 
 8. **Run `code-review` before every commit.** Invoke the `code-review`
    sub-agent against the current branch diff and every staged, unstaged, and
@@ -404,7 +449,9 @@ explicit range when validating committed work:
 CHANGED_BASE=<base-sha> CHANGED_HEAD=<head-sha> make quick-ci-changed
 ```
 
-Before pushing, run the merge-gate command for every changed surface:
+Every changed surface's merge-gate command has to have run before pushing.
+Step 7 is where that happens, so this matrix is what tells `verifier` which
+ones apply rather than a list to work through by hand:
 
 - Web: `make -C apps/web ci` (includes lint, type-check, tests, and build)
 - Chat: `make -C services/chat ci`
@@ -412,8 +459,10 @@ Before pushing, run the merge-gate command for every changed surface:
 - Documentation/runbooks: `make docs-check`
 - Cross-surface or repository-wide: `make ci`
 
-Add integration confidence where the change crosses a runtime boundary:
+Add integration confidence where the change crosses a runtime boundary. These
+are the verifier's too.
 
+- End-to-end journeys: `make test-e2e` (needs a running stack; see step 7)
 - Cross-surface integration confidence: `make e2e-smoke`
 - Contract-only integration confidence (minimal chat stack): `make e2e-smoke-lite`
 - Full local-provider integration confidence: `make e2e-smoke-full`


### PR DESCRIPTION
The runbook never drew the line, so the two overlapped: the full journey suite was run in the main agent four to six times an issue at seven to nine minutes, **and** handed to the verifier to run again.

| step 4 | step 7 |
|---|---|
| the one spec under change | full journey suite |
| its red phase and mutations | merge gate + production build |
| fast whole-suite runners (`make test-web` is seconds) | root guard suite |

The red phase and the mutations cannot move: the verifier is instructed not to modify the repository, so **breaking an input on purpose is not available to it**. That, rather than "one test vs all tests", is what fixes the boundary.

## Two things that turned up while writing it

**`## Validation expectations` contradicted the new step 7.** It told the author to run every merge gate before pushing. The matrix stays — it is now what tells the verifier which gates apply.

**Nobody was instructed to run the journeys at all.** Step 4 was being told not to, and `verifier.md` never mentioned `make test-e2e` — only `make e2e-smoke`, which is a different check. The smoke asks whether routes respond; the journeys ask whether they work, and a page can return 200 while every image on it 404s. `verifier.md` gains the row.

Plus a stack handover with `KEEP_STACK=1`, because without it the smoke deletes what it was handed.

## Eight review rounds, and why that is the interesting part

**Every defect was in a claim about mechanism. None was in the rule.** Three of them were introduced by fixing the previous round's finding.

| claim | how it ended |
|---|---|
| a remapped stack breaks sign-in via `NEXTAUTH_URL` | **disproved by running it** — a stack on 3100 carrying the compose default signs in fine: 5 auth tests, 8 profile journeys |
| the journeys need chat | no journey sends a message; `db web` runs the whole suite |
| the smoke would build a second stack | depends on which compose *files* resolve, not the project |

The `NEXTAUTH_URL` one is the sharpest: every suite run this session passed on port 3100 only because my scratch override also set `NEXTAUTH_URL`. I had never tested without it, and inferred a mechanism from that. `.github/workflows/ci.yml:325` carries the same claim in a comment and is almost certainly where I got it — filed as **#240**.

## So the mechanism is not written down

What is left is what can be checked — `test-e2e` follows `E2E_BASE_URL`, `e2e-smoke` probes two literal addresses and takes no override — plus the outcome that matters (**a green smoke against containers nobody meant to test**, which is worse than a failure because nothing looks wrong), plus the rule, unchanged since the round it was first written: free the default ports, or hand over nothing and say why.

## Verification

- [x] `make docs-check` and `make test-scripts` (153) after every edit
- [x] `verifier` — confirmed the step-reference guard reads the new "step 4"/"step 7" mentions rather than passing vacuously, and that the claim about the verifier matches its own definition
- [x] `code-review` — eight rounds; the last returned no defects
- [x] `ui-review` — not applicable, Markdown with no rendered surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)