### PR TITLE
fix(web): focus a page field in the page's accent, not the chat panel's

### DIFF
--- a/apps/web/e2e/action-controls.spec.ts
+++ b/apps/web/e2e/action-controls.spec.ts
@@ -148,6 +148,45 @@ test.describe('action controls', () => {
   }
 })
 
+test.describe('page controls', () => {
+  test('all agree on one focus accent', async ({ page }) => {
+    // `control-classes.ts` says a control on the page focuses indigo and one
+    // inside the chat widget focuses sky. That is a claim about every control
+    // in the app, so it wants something that walks them rather than a comment.
+    //
+    // Relational, like its sibling in `form-fields.spec.ts`: the first control
+    // sets the expectation and the rest must match it, so the accent can be
+    // changed in one place without editing this. What it will not tolerate is
+    // two of them disagreeing.
+    test.slow()
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const seen: { name: string; colour: string }[] = []
+    for (const control of CONTROLS) {
+      await reach(page, control)
+      await page.mouse.move(2, 2)
+      await page.keyboard.press('Tab')
+      await page.addStyleTag({
+        content: '*, *::before, *::after { transition: none !important; }',
+      })
+      const colour = await page
+        .locator(control.selector)
+        .first()
+        .evaluate((node) => {
+          ;(node as HTMLElement).focus()
+          return getComputedStyle(node).outlineColor
+        })
+      seen.push({ name: control.name, colour })
+    }
+
+    const expected = seen[0].colour
+    expect(
+      seen.filter((control) => control.colour !== expected).map((c) => `${c.name}: ${c.colour}`),
+      `${seen[0].name} focuses ${expected}; these page controls disagree`,
+    ).toEqual([])
+  })
+})
+
 for (const scheme of ['light', 'dark'] as const) {
   test.describe(`action controls in forced colors (${scheme})`, () => {
     test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })

--- a/apps/web/e2e/chat-controls.spec.ts
+++ b/apps/web/e2e/chat-controls.spec.ts
@@ -80,6 +80,103 @@ test.describe('chat panel controls', () => {
   }
 })
 
+test.describe('chat panel accent', () => {
+  for (const { width, height, shape } of WIDTHS) {
+    test(`every panel control agrees in the ${shape}, and none is the page accent`, async ({
+      page,
+    }) => {
+    // The widget is the one place that is deliberately not indigo: #184 gave it
+    // sky-700 so the panel reads as its own place, and #221's fields took sky
+    // everywhere before that split had a name. When the page fields moved to
+    // indigo and `/profile`'s CTA with them, sky is the widget's alone — this
+    // input, its send button, and the clear and close controls. This is what
+    // says it stayed, and that the row agrees with itself.
+    // Both shapes, because the close button only exists below `lg`: at 1440 the
+    // walk finds three controls, and the sheet is where the fourth lives.
+    // Running one width would have left it measured by nothing while this
+    // test's own comment claimed otherwise.
+    await page.setViewportSize({ width, height })
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByRole('dialog', { name: /chat/i })).toBeVisible()
+    await page.mouse.move(2, 2)
+    await page.keyboard.press('Tab')
+    await page.addStyleTag({
+      content: '*, *::before, *::after { transition: none !important; }',
+    })
+
+    // Every focusable control the panel renders, not a list of selectors. The
+    // widget's close button only exists below `lg`, so naming four would either
+    // miss it here or fail at this width; walking whatever is present says the
+    // same thing without knowing which shape the panel is in.
+    const accents = await page
+      .locator('[role="dialog"] input, [role="dialog"] button')
+      .evaluateAll((nodes) =>
+        nodes.map((node) => {
+          ;(node as HTMLElement).focus()
+          return {
+            name: node.getAttribute('aria-label') ?? node.id ?? node.tagName,
+            colour: getComputedStyle(node).outlineColor,
+          }
+        }),
+      )
+
+    // The population, not a floor. `toBeGreaterThan(1)` re-armed the very gap
+    // the both-shapes run closed: if the close button stopped rendering at 390,
+    // the sheet would walk three controls, pass, and leave it measured by
+    // nothing while the comment above said otherwise.
+    expect(
+      accents.map((control) => control.name).sort(),
+      `the ${shape} did not render the controls this expects`,
+    ).toEqual(
+      shape === 'sheet'
+        ? ['Clear conversation', 'Close chat', 'Message', 'Send message']
+        : ['Clear conversation', 'Message', 'Send message'],
+    )
+
+    const widget = accents[0].colour
+    expect(
+      accents.filter((control) => control.colour !== widget).map((c) => `${c.name}: ${c.colour}`),
+      `${accents[0].name} focuses ${widget}; these panel controls disagree`,
+    ).toEqual([])
+
+    // And that it is the widget's accent rather than the page's. Read off a
+    // page control rather than named, so this does not have to know a hex.
+    //
+    // Two things have to hold for the read to be real, and the failure mode of
+    // either is a pass rather than a failure — a wrong colour here differs from
+    // the widget's, which is exactly what this asserts. So the two lines below
+    // arrange them instead of relying on them.
+    //
+    // The `Tab` re-primes Chromium's keyboard state after the navigation, since
+    // it grants `:focus-visible` to a programmatically focused button only when
+    // the last interaction was a keypress. Measured, the press before the
+    // `goto` does carry across; this does not depend on that holding.
+    //
+    // The style tag defuses a transition. Tailwind transitions `outline-color`,
+    // so a submit that grew `transition-colors` would be read mid-fade from
+    // `currentColor` — white, on a white-on-indigo button. That is #235.
+    // `/login`'s submit carries no transition today.
+    await page.goto('/login')
+    await page.keyboard.press('Tab')
+    await page.addStyleTag({
+      content: '*, *::before, *::after { transition: none !important; }',
+    })
+    const pageAccent = await page
+      .locator('button[type=submit]')
+      .evaluate((node) => {
+        ;(node as HTMLElement).focus()
+        return getComputedStyle(node).outlineColor
+      })
+    expect(
+      widget,
+      `the panel focuses ${widget}, the same as the page's ${pageAccent}, ` +
+        'so it no longer reads as its own place',
+      ).not.toBe(pageAccent)
+    })
+  }
+})
+
 /**
  * The same two controls in Windows High Contrast and its equivalents.
  *

--- a/apps/web/e2e/form-fields.spec.ts
+++ b/apps/web/e2e/form-fields.spec.ts
@@ -38,19 +38,25 @@ import { openProfileTab } from './support/session'
  * disappear into. Swept over fifteen widths from 360 to 1920, the worst
  * perimeter pixel on any field is 3.80:1.
  *
- * ## What the focus half of this does not catch
+ * ## What the contrast half of this does not catch
  *
- * Deleting the designed outline from `FIELD_BOUNDARY`. Chromium then paints
- * its own `auto 1px rgb(16,16,16)` ring, which satisfies 2.4.13 by itself:
- * measured, `/login`'s email field gives 1662 qualifying pixels against 1659
- * required without the outline, and 1673 with it. Only the contact textarea
- * notices, and by three pixels.
+ * Deleting the designed outline from `FIELD_BOUNDARY`. That measurement was
+ * taken when the constant still carried the colour, and gave Chromium's own
+ * `auto 1px rgb(16,16,16)` ring at 1662 qualifying pixels against 1659
+ * required. Since the accent moved to the call sites the mutation is fainter
+ * still: the fallback ring wears the author's colour, so the field focuses 1px
+ * of indigo rather than 2px, and every pixel count in this file passes.
  *
- * That is the check being right rather than weak — the criterion asks whether
- * focus is visible, not whose CSS made it so, and a browser default is a real
- * indicator. But it means a green run here is not evidence that the designed
- * outline is doing anything, and the reason to keep it is cross-engine
- * consistency, which one Chromium project cannot test. See the note in
+ * That is those checks being right rather than weak — the criterion asks
+ * whether focus is visible, not whose CSS made it so, and a browser default is
+ * a real indicator. But it means a contrast run is not evidence that the
+ * designed outline is doing anything. `a form and its submit agree on a focus
+ * indicator`, below, is what closes it: it compares each field's computed
+ * outline width and style against the submit's, so a field on the fallback
+ * reads `1px auto` against a `2px solid` button and fails. That mutation ran
+ * red before this paragraph was written. What no Chromium-only project can
+ * test is the reason the designed outline exists at all, which is that the
+ * fallback differs between engines — see the note in
  * `src/lib/control-classes.ts`.
  *
  * Both numbers sit near the threshold because a 2px outline and a 2px
@@ -202,6 +208,136 @@ test.describe('form field boundaries', () => {
       })
     }
   }
+
+  test('a form and its submit agree on a focus indicator', async ({ page }) => {
+    test.slow()
+    // Relational rather than a hardcoded hue: what matters is that a keyboard
+    // user tabbing a form does not watch the indicator change colour partway
+    // down it. `/login` did exactly that until the fields moved off sky-700 —
+    // the two inputs focused sky, the button under them indigo, 45 degrees of
+    // hue apart inside one form.
+    //
+    // Read from computed style rather than the class list, so a call site
+    // naming an accent Tailwind never emitted fails here rather than passing on
+    // a string. It is not a paint reading, and that is the point: the geometry
+    // it compares is invisible to everything that measures pixels. Delete
+    // `focus-visible:outline-2` from `FIELD_BOUNDARY` and Chromium falls back to
+    // `outline-style: auto` while keeping the call site's colour, so the field
+    // focuses a 1px ring instead of a 2px one in the right hue — which every
+    // contrast check in this file passes, because they weigh colour and not
+    // width. That is not hypothetical: this change dropped `outline-2` while
+    // moving the accent out to the call sites, all 22 fields shipped on
+    // Chromium's fallback ring, and five review rounds and two green batteries
+    // went past it before the width was read.
+    // `/profile`'s two forms are in here because this change touched them too:
+    // eleven of the twenty-one fields it moved to indigo are behind those tabs,
+    // and a loop over the anonymous routes alone would not have seen them.
+    const FORMS = [
+      { label: '/login', reach: (p: Page) => p.goto('/login').then(() => undefined) },
+      { label: '/signup', reach: (p: Page) => p.goto('/signup').then(() => undefined) },
+      { label: '/contact', reach: (p: Page) => p.goto('/contact').then(() => undefined) },
+      { label: '/profile (Security)', reach: (p: Page) => openProfileTab(p, 'Security') },
+      { label: '/profile (Shipping)', reach: (p: Page) => openProfileTab(p, 'Shipping') },
+    ]
+
+    for (const { label: path, reach } of FORMS) {
+      await reach(page)
+
+      // Pointer parked, then one real keypress, and the order matters here for
+      // the same reason it does in `action-controls.spec.ts`: Chromium grants
+      // `:focus-visible` to a programmatically focused *button* only when the
+      // last interaction was a keyboard one. `openProfileTab` ends by clicking
+      // a tab, so without this the submit reports `currentColor` — white on a
+      // white-on-indigo button — and the form looks like it disagrees with
+      // itself when it does not.
+      await page.mouse.move(2, 2)
+      await page.keyboard.press('Tab')
+
+      // Transitions off before reading, for the reason `support/boundary.ts`
+      // gives: Tailwind transitions `outline-color`, so a colour read the
+      // instant after `focus()` is whatever the indicator is fading *from* —
+      // `currentColor`, which on `/contact`'s white-on-indigo submit is white.
+      // That is #235, and it made this check fail on a form that agrees.
+      await page.addStyleTag({
+        content: '*, *::before, *::after { transition: none !important; }',
+      })
+
+      // The submit sets the expectation for the outline; the ring expectation
+      // comes from the first field, since a button has no ring to compare.
+      //
+      // Width and style come from the submit too, and they are what pins the
+      // geometry. `ACTION_FOCUS` and `FIELD_BOUNDARY` both ask for `outline-2`,
+      // so a form whose fields have it reads `2px solid` on both sides; a form
+      // that has lost it reads `1px auto` on the fields against the button's
+      // `2px solid` and fails here. Relational again, so raising the app to a
+      // 3px indicator stays a one-line change.
+      const submit = page.locator('button[type=submit]').first()
+      await submit.evaluate((node) => (node as HTMLElement).focus())
+      const { outline, width, style: outlineStyle } = await submit.evaluate((node) => {
+        const computed = getComputedStyle(node)
+        return {
+          outline: computed.outlineColor,
+          width: computed.outlineWidth,
+          style: computed.outlineStyle,
+        }
+      })
+      const ring = await page
+        .locator('form input, form textarea')
+        .first()
+        .evaluate((node) => {
+          ;(node as HTMLElement).focus()
+          return getComputedStyle(node).boxShadow
+        })
+      const expected = { colour: outline, ring, width, style: outlineStyle }
+
+      // Every field, not the first one. Before this change the accent came from
+      // the shared constant and a field could not have the wrong one; now it is
+      // a literal pair copied to each call site, so the invariant is only as
+      // good as what reads it. A `.first()` here would have watched five of the
+      // twenty-one, and `textarea` is in the selector because `/contact`'s
+      // `#message` is one of them.
+      const wrong = await page
+        .locator('form input, form textarea')
+        .evaluateAll((nodes, want) =>
+          nodes
+            .map((node) => {
+              ;(node as HTMLElement).focus()
+              const style = getComputedStyle(node)
+              // The ring half of the pair as well as the outline. Each call
+              // site copies `focus:ring-<accent> focus-visible:outline-<accent>`
+              // and reading one of the two leaves the other free to drift —
+              // the ring moves only 1.34:1, below what `expectVisibleControls`
+              // counts, so nothing else would see it.
+              return {
+                id: node.id,
+                colour: style.outlineColor,
+                ring: style.boxShadow,
+                width: style.outlineWidth,
+                style: style.outlineStyle,
+              }
+            })
+            .filter(
+              (field) =>
+                field.colour !== want.colour ||
+                field.ring !== want.ring ||
+                field.width !== want.width ||
+                field.style !== want.style,
+            )
+            .map(
+              (field) =>
+                `${field.id || '(no id)'} focuses ${field.width} ${field.style} ` +
+                `${field.colour} / ${field.ring}`,
+            ),
+          expected,
+        )
+
+      expect(
+        wrong,
+        `${path} focuses its submit ${width} ${outlineStyle} ${outline}; these ` +
+          `disagree, so the indicator changes partway down the form`,
+      ).toEqual([])
+    }
+  })
 
   test('every field on these pages is one of the ones checked', async ({ page }) => {
     // This one walks every surface, so it pays the sign-in cost twice.

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -54,7 +54,7 @@ export default function LoginPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -77,7 +77,7 @@ export default function LoginPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -59,7 +59,7 @@ export default function ProfilePage() {
           </p>
           <Link
             href="/login"
-            className={`rounded-md bg-zinc-800 px-6 py-2 text-lg text-zinc-100 hover:bg-zinc-700 focus-visible:outline-sky-700 ${ACTION_BOUNDARY}`}
+            className={`rounded-md bg-zinc-800 px-6 py-2 text-lg text-zinc-100 hover:bg-zinc-700 focus-visible:outline-indigo-600 ${ACTION_BOUNDARY}`}
           >
             Sign in to continue
           </Link>

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -62,7 +62,7 @@ export default function SignUpPage() {
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -83,7 +83,7 @@ export default function SignUpPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>
@@ -106,7 +106,7 @@ export default function SignUpPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 ${FIELD_BOUNDARY}`}
+                className={`block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
               />
             </div>
           </div>

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -600,7 +600,7 @@ export const Chat = () => {
                 // constant, which is where the reasoning behind them now lives:
                 // this input and the ten in #196 had drifted apart, and having
                 // one definition is the point of that change.
-                className={`block p-2 grow rounded-md text-zinc-700 placeholder:text-zinc-500 placeholder:opacity-100 shadow-xs ${FIELD_BOUNDARY}`}
+                className={`block p-2 grow rounded-md text-zinc-700 placeholder:text-zinc-500 placeholder:opacity-100 shadow-xs focus:ring-sky-700 focus-visible:outline-sky-700 ${FIELD_BOUNDARY}`}
               />
               <button
                 type="button"

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -69,7 +69,7 @@ export default function ContactForm() {
           required
           value={formData.name}
           onChange={handleChange}
-          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           placeholder="Your name"
         />
       </div>
@@ -88,7 +88,7 @@ export default function ContactForm() {
           required
           value={formData.email}
           onChange={handleChange}
-          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           placeholder="you@example.com"
         />
       </div>
@@ -108,7 +108,7 @@ export default function ContactForm() {
             required
             value={formData.subject}
             onChange={handleChange}
-            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
+            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
             placeholder="How can we help?"
           />
         </div>
@@ -125,7 +125,7 @@ export default function ContactForm() {
             name="orderNumber"
             value={formData.orderNumber}
             onChange={handleChange}
-            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
+            className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
             placeholder="Optional"
           />
         </div>
@@ -145,7 +145,7 @@ export default function ContactForm() {
           required
           value={formData.message}
           onChange={handleChange}
-          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm ${FIELD_BOUNDARY}`}
+          className={`block w-full rounded-lg border-0 px-4 py-3 text-gray-900 shadow-xs placeholder:text-gray-400 sm:text-sm focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           placeholder="Write your message here..."
         ></textarea>
       </div>

--- a/apps/web/src/components/password-change-form.tsx
+++ b/apps/web/src/components/password-change-form.tsx
@@ -61,7 +61,7 @@ export default function PasswordChangeForm() {
           required
           value={currentPassword}
           onChange={(e) => setCurrentPassword(e.target.value)}
-          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
         />
       </div>
       <div>
@@ -77,7 +77,7 @@ export default function PasswordChangeForm() {
           required
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
-          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
         />
       </div>
       <div>
@@ -93,7 +93,7 @@ export default function PasswordChangeForm() {
           required
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
-          className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+          className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
         />
       </div>
 

--- a/apps/web/src/components/shipping-address-form.tsx
+++ b/apps/web/src/components/shipping-address-form.tsx
@@ -63,7 +63,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.name || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -75,7 +75,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.addressLine1 || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -87,7 +87,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.addressLine2 || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -99,7 +99,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.city || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -111,7 +111,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.state || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -123,7 +123,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.zipCode || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div>
@@ -135,7 +135,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.country || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
         <div className="sm:col-span-2">
@@ -147,7 +147,7 @@ export default function ShippingAddressForm({ initialAddress }: { initialAddress
             type="text"
             value={formData.phoneNumber || ""}
             onChange={handleChange}
-            className={`mt-1 block w-full rounded-md shadow-xs p-2 ${FIELD_BOUNDARY}`}
+            className={`mt-1 block w-full rounded-md shadow-xs p-2 focus:ring-indigo-600 focus-visible:outline-indigo-600 ${FIELD_BOUNDARY}`}
           />
         </div>
       </div>

--- a/apps/web/src/lib/control-classes.ts
+++ b/apps/web/src/lib/control-classes.ts
@@ -3,13 +3,28 @@
  *
  * Four exports, because fields and action controls fail differently, are fixed
  * differently, and a control whose focusable element is a descendant needs a
- * different variant again. `FIELD_BOUNDARY` carries a colour, since a text field's
- * resting edge has a single correct value everywhere. `ACTION_BOUNDARY` does
- * not: a button's accent is indigo on the page and sky-700 inside the chat
- * widget, and #184 chose that split deliberately so the send button reads as
- * part of the panel rather than part of the page. So the mechanism is shared
- * and the accent stays at the call site — the same division as radius and
+ * different variant again. None of them carries an accent. A control's focus
+ * colour is indigo on the page and sky-700 inside the chat widget — #184 chose
+ * that split so the panel reads as its own place — so the mechanism is shared
+ * and the accent stays at the call site, the same division as radius and
  * padding staying with each field below.
+ *
+ * Two things were contradicting that and both moved together. The fields took
+ * sky-700 in #221, standardising on the only example that existed at the time,
+ * and `/profile`'s signed-out CTA had carried it since #144 — both predating
+ * #236, which named the axis as location rather than control type and so made
+ * a field on `/login` a page control. Until they moved, `/login` changed the
+ * colour of its focus indicator between the password field and the button
+ * underneath it.
+ *
+ * Sky now appears only inside the widget: the chat input, its send button, and
+ * its clear and close controls. `chat-controls.spec.ts` walks whatever the
+ * panel renders, in both shapes, and asserts they agree with each other and
+ * differ from the page. `action-controls.spec.ts` asserts the same agreement
+ * across the eleven page controls it lists — which is not every page control:
+ * the chat launcher is one, sits outside the dialog, and nothing reads its
+ * accent. The header's `Open menu` has no focus accent at all, which predates
+ * any of this.
  */
 
 /**
@@ -55,11 +70,19 @@
  * indicator has to change *shape*. So focus keeps the ring and adds an offset
  * outline, painting a new perimeter over pixels that were background.
  *
- * The ring still recolours to sky-700 as well. It contributes almost nothing —
- * `e2e/support/boundary.ts` measures those pixels changing at 1.21:1, below
- * the 3:1 that counts toward the indicator area — and it is here because the
- * chat panel does it, and having eleven fields that are actually identical is
- * the point of this file.
+ * The accent is not here, for the reason `ACTION_FOCUS` gives: a control on the
+ * page focuses indigo and one inside the chat widget focuses sky-700, which
+ * #184 chose so the panel reads as its own place. The fields carried sky-700
+ * everywhere until that convention existed, which left `/login` changing the
+ * colour of its focus indicator between the password field and the button
+ * underneath it — 45 degrees of hue, inside one form, for no reason a user
+ * could infer.
+ *
+ * Each call site pairs this with `focus:ring-<accent> focus-visible:outline-<accent>`.
+ * The ring recolour contributes almost nothing on its own —
+ * `e2e/support/boundary.ts` measures those pixels changing at 1.21:1, below the
+ * 3:1 that counts toward the indicator area — and is kept so that a field and
+ * its neighbours agree rather than because it is doing work.
  *
  * `focus-visible`, not `focus`, for the outline: a pointer user who clicks
  * into a field has not lost track of where they are, and does not need a
@@ -67,17 +90,25 @@
  *
  * ## What the outline is actually buying, measured
  *
- * Not Chromium compliance. Strip these three classes and Chromium paints its
- * own `auto 1px rgb(16,16,16)` ring, which passes 2.4.13 on its own — measured
- * at 1662 qualifying pixels against the 1659 a 2px perimeter of `/login`'s
- * email field needs. With the outline the same field measures 1673. Both
- * clear it; the browser's does so by three pixels.
+ * Not Chromium compliance. Strip the outline entirely — the two classes here
+ * and the call site's colour with them — and Chromium paints its own
+ * `auto 1px rgb(16,16,16)` ring, which passes 2.4.13 on its own: measured at
+ * 1662 qualifying pixels against the 1659 a 2px perimeter of `/login`'s email
+ * field needs. With the outline the same field measures 1673. Both clear it;
+ * the browser's does so by three pixels.
  *
- * What the outline buys is that the indicator is ours: a known 2px sky-700 at
- * a known offset, the same in every engine, rather than a default that differs
- * between Chromium, Firefox and Safari and that the suite only ever sees one
- * of. It is also what keeps the *change* visible, since the ring recolour it
- * sits beside is a 1.21:1 change that no one would notice.
+ * Strip only `outline-2` and the fallback is worse to spot, because the colour
+ * survives: `auto 1px` in the call site's own accent, which looks deliberate
+ * and passes every pixel check here. That happened on this branch and shipped
+ * green twice. `form-fields.spec.ts` now reads the computed width and style
+ * against the submit's, which is the only thing that catches it.
+ *
+ * What the outline buys is that the indicator is ours: a known 2px at a known
+ * offset in the surface's own accent, the same in every engine, rather than a
+ * default that differs between Chromium, Firefox and Safari and that the suite
+ * only ever sees one of. It is also what keeps the *change* visible, since the
+ * ring recolour it sits beside moves 1.34:1 against indigo and 1.21:1 against
+ * sky — neither of which anyone would notice on its own.
  *
  * Both margins are thin because the criterion's floor is a 2px perimeter and
  * the indicator is a 2px outline, so the two are nearly the same number by
@@ -133,8 +164,8 @@
  * trusting it, and the swap above is one of the mutations it catches.
  */
 export const FIELD_BOUNDARY =
-  'ring-1 ring-inset ring-zinc-500 forced-colors:border focus:ring-sky-700 ' +
-  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-700'
+  'ring-1 ring-inset ring-zinc-500 forced-colors:border ' +
+  'focus-visible:outline-2 focus-visible:outline-offset-2'
 
 /**
  * What every button and button-shaped link needs, minus its colour.


### PR DESCRIPTION
Tabbing down `/login` changed the colour of the focus indicator partway: the two inputs focused sky-700 and the button underneath them indigo-600, 45 degrees of hue apart inside one form. The same split ran through `/signup`, `/contact` and both `/profile` tabs — 21 fields in all.

Neither colour was chosen wrongly; they were chosen against different axes. #184 gave the chat widget sky-700 so the panel reads as its own place. #221 then standardised the fields on sky-700, because the chat input was the only worked example that existed. #236 named the axis afterwards — location rather than control type — which made a field on `/login` a page control and left #221's answer pointing the wrong way.

## What this does

The accent leaves `FIELD_BOUNDARY`, since that constant is shared with the chat input, which keeps sky. Each call site pairs it with `focus:ring-<accent> focus-visible:outline-<accent>`. The mechanism stays shared; the colour goes where the surface is decided, the same division as radius and padding.

One button comes along. `/profile`'s signed-out CTA has carried sky-700 since #144, also predating #236, and it is a page control. It is here rather than in a follow-up because the guard this adds cannot pass while one page control disagrees — the check is that every page control focuses the same colour, and it is relational by design.

## Guards

A literal pair copied to 22 call sites is only as good as what reads it.

- `form-fields.spec.ts` walks every field on all five forms and compares its computed outline colour, width, style and focused ring against the form's submit. A `.first()` would have watched five of twenty-one.
- `action-controls.spec.ts` walks the eleven page controls it lists and asserts they agree.
- `chat-controls.spec.ts` walks the panel in both shapes, asserts the controls it found are the ones it expected to find, that they agree, and that they differ from the page.

The width and style comparison is there because moving the accent out also dropped `focus-visible:outline-2`, and no pixel check saw it: the fallback wears the author's colour, so the field focused 1px of indigo where it should have focused 2px, and the whole battery ran green twice that way. Contrast checks weigh colour, not width. That mutation is now red.

## Verification

Full battery against a production stack built from this branch: 125/125 Playwright journeys, 137 unit tests, 153 script guards, lint and typecheck (app and specs) clean. Six review rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
