### PR TITLE
fix(web): tell the visitor what happened to the picture they uploaded

### DIFF
--- a/apps/web/e2e/avatar.spec.ts
+++ b/apps/web/e2e/avatar.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect, type Page } from '@playwright/test'
+import { boundaryContrast, focusChange, REQUIRED_RATIO } from './support/boundary'
+import { openProfileTab } from './support/session'
+
+/**
+ * The picture frame on `/profile`'s General tab, which is not a control.
+ *
+ * `action-controls.spec.ts` measures the label beside it — the thing you
+ * operate. This measures the thing you look at, and it fails two criteria the
+ * control does not.
+ *
+ * **The placeholder text.** `text-gray-400` on `bg-gray-200` is 2.10:1 at 16px,
+ * against the 4.5:1 WCAG 2.2 1.4.3 asks. It is the branch that renders for an
+ * account with no picture, which is the seeded one, so it was the default view
+ * rather than an edge case.
+ *
+ * **The frame in forced colors.** `bg-gray-200` resolves to Canvas, so the
+ * circle had no boundary at all and "No Image" floated in nothing. Same
+ * mechanism as #216 and #227 — an element whose edge is its background — on
+ * something that is neither a field nor an action. Both are #237.
+ *
+ * The frame is addressed structurally rather than by its Tailwind classes: it
+ * is the first child of the column that holds the file input's label. A class
+ * selector would go stale silently the next time the frame is restyled, and the
+ * one class that reads like an identity here (`h-32`) is the size, which is the
+ * thing most likely to change.
+ */
+const FRAME = 'div:has(> label input[type="file"]) > div:first-child'
+const PLACEHOLDER = `${FRAME} > div`
+
+test.describe('the avatar frame', () => {
+  test('its placeholder text is legible', async ({ page }) => {
+    test.slow()
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await openProfileTab(page, 'General')
+
+    const placeholder = page.locator(PLACEHOLDER).first()
+    await expect(placeholder).toHaveText(/no image/i)
+
+    // Computed colours rather than sampled pixels, unlike the rest of this
+    // directory. Both values are flat and declared on the same element, so the
+    // painted answer cannot differ from the computed one — and text contrast
+    // sampled from a screenshot is a measurement of antialiasing as much as of
+    // colour. 1.4.11 needed paint because a boundary can be drawn four ways;
+    // 1.4.3 does not.
+    const ratio = await placeholder.evaluate((node) => {
+      const style = getComputedStyle(node)
+
+      // Resolved by painting it, not by parsing it. Tailwind v4 serialises
+      // these as `lab(...)`, so reading the first three numbers out of the
+      // string treats lightness and two opponent axes as red, green and blue:
+      // the pre-fix placeholder came back 1.17:1 that way, where the colours it
+      // actually paints are 2.10:1. A canvas normalises whatever syntax the
+      // engine chose to the sRGB the ratio is defined over.
+      const canvas = document.createElement('canvas')
+      canvas.width = 1
+      canvas.height = 1
+      const context = canvas.getContext('2d')!
+      const parse = (value: string): [number, number, number] => {
+        context.clearRect(0, 0, 1, 1)
+        context.fillStyle = value
+        context.fillRect(0, 0, 1, 1)
+        const [r, g, b] = context.getImageData(0, 0, 1, 1).data
+        return [r, g, b]
+      }
+      const luminance = ([r, g, b]: [number, number, number]) => {
+        const channel = (v: number) => {
+          const s = v / 255
+          return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+      }
+      const [light, dark] = [
+        luminance(parse(style.color)),
+        luminance(parse(style.backgroundColor)),
+      ].sort((a, b) => b - a)
+      return (light + 0.05) / (dark + 0.05)
+    })
+
+    expect(
+      ratio,
+      `the placeholder reads ${ratio.toFixed(2)}:1 against its own background ` +
+        '(WCAG 1.4.3 asks 4.5:1 of text this size)',
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  for (const scheme of ['light', 'dark'] as const) {
+    test.describe(`in forced colors (${scheme})`, () => {
+      test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })
+
+      test('the frame keeps an edge', async ({ page }) => {
+        test.slow()
+        await page.setViewportSize({ width: 1440, height: 900 })
+        await openProfileTab(page, 'General')
+        await page.mouse.move(2, 2)
+
+        // Sampled rather than read from an ancestor's CSS, for the reason
+        // `action-controls.spec.ts` gives: in this mode every background is a
+        // system colour, so what an ancestor declares says nothing about what
+        // is painted behind the frame.
+        // `round`, because the frame is a circle and the rectangular walk
+        // probes its box corners — which the control does not occupy, so it
+        // reports the background against itself and fails a frame that is
+        // plainly there. The round walk steps sixteen radial probes instead,
+        // and the diagonals are the point: a 1px stroke on a curve is about a
+        // fifth covered there, which is why this frame carries `border-2`.
+        const [reading] = await boundaryContrast(
+          page,
+          [{ name: 'the avatar frame', selector: FRAME, round: true }],
+          { kind: 'sample' },
+        )
+
+        expect(
+          reading.resting,
+          `the avatar frame has no visible edge (${REQUIRED_RATIO}:1 asked of a ` +
+            'boundary; without one the placeholder floats in Canvas)',
+        ).toBeGreaterThanOrEqual(REQUIRED_RATIO)
+      })
+    })
+  }
+})
+
+/**
+ * Driving the control, which the unit tests cannot.
+ *
+ * Three things about this component live only in a browser. A file input's
+ * value is never set in jsdom — the harness assigns `files` directly — so
+ * whether the value is cleared for a retry is unreachable there. `opacity`
+ * compositing is paint. And focus is a browser behaviour that jsdom models
+ * loosely enough that the defect this component had, a `disabled` attribute
+ * dropping focus to `body`, did not reproduce.
+ *
+ * **Nothing is written to the account.** Every `PUT /api/profile` here is
+ * answered inside the browser by `route.fulfill`, so the request never reaches
+ * the server and the seeded row keeps its empty avatar — which matters, because
+ * the placeholder branch is what the rest of this file measures.
+ */
+async function holdTheSave(page: Page) {
+  let release: (() => void) | undefined
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await page.route('**/api/profile', async (route) => {
+    if (route.request().method() !== 'PUT') return route.continue()
+    await held
+    await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
+  })
+  return () => release?.()
+}
+
+// A 1x1 PNG. The smallest thing the control will accept, since nothing here
+// looks at the picture.
+const PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+test.describe('the avatar upload', () => {
+  test('a refused save leaves the control ready for the same file again', async ({ page }) => {
+    test.slow()
+    await openProfileTab(page, 'General')
+    const release = await holdTheSave(page)
+
+    const input = page.locator('input[type="file"]')
+    // Focused first, and left that way for the rest of the test. This is where
+    // focus sits when someone picks a file with the keyboard, and it is what
+    // the component has to hold on to.
+    await input.evaluate((node) => (node as HTMLElement).focus())
+    await input.setInputFiles({ name: 'avatar.png', mimeType: 'image/png', buffer: PIXEL })
+    await expect(page.getByText('Uploading your picture…')).toBeVisible()
+
+    // Still on the control while the upload runs. A `disabled` attribute here
+    // moved focus to `body` — and re-enabling did not bring it back, so every
+    // upload returned a keyboard user to the top of the document. That is why
+    // this state is `aria-busy` and the refusal lives in the handler.
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('type'))).toBe('file')
+    release()
+
+    await expect(page.getByText('That picture was not saved.')).toBeVisible()
+    // And still on it afterwards.
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('type'))).toBe('file')
+    // The placeholder is back, so the frame is not left claiming a picture the
+    // server refused.
+    await expect(page.getByText('No Image')).toBeVisible()
+    // And the value is empty, so choosing that same file again is still a
+    // change event. Without it the obvious next action does nothing at all,
+    // with the failure sentence still on screen — and this is the only place
+    // that can tell, since jsdom never sets the value to begin with.
+    await expect(input).toHaveValue('')
+  })
+
+  test('the busy control keeps its focus indicator, and shows it is busy', async ({ page }) => {
+    test.slow()
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await openProfileTab(page, 'General')
+    const release = await holdTheSave(page)
+
+    const input = page.locator('input[type="file"]')
+    await input.setInputFiles({ name: 'avatar.png', mimeType: 'image/png', buffer: PIXEL })
+    await expect(page.getByText('Uploading your picture…')).toBeVisible()
+
+    // Measured *during* the upload, which is the window nothing else looks at:
+    // `action-controls.spec.ts` measures this same label at rest and on focus,
+    // so a busy state that fades the control keeps passing there. An
+    // `opacity-60` busy treatment computed to 2.86:1 on this outline, and the
+    // point of preferring `aria-busy` to `disabled` is that a keyboard user is
+    // still standing on this control while it runs.
+    // The pointer affordance, read from what the engine resolved rather than
+    // from the class string. A unit test can only see the class name, and a
+    // busy branch refactored into a composed name (`cursor-${busy ? …}`) drops
+    // out of Tailwind's literal scan while the string assertion still passes.
+    const label = page.locator('label:has(input[type="file"])')
+    expect(await label.evaluate((node) => getComputedStyle(node).cursor)).toBe('wait')
+
+    await page.mouse.move(2, 2)
+    await page.keyboard.press('Tab')
+    const change = await focusChange(page, 'label:has(input[type="file"])')
+    expect(
+      change.qualifying,
+      `while uploading, the control's focus indicator covers ${change.qualifying} pixels ` +
+        `changing by ${REQUIRED_RATIO}:1 or more, against the ${Math.round(change.required)} a ` +
+        `2px perimeter needs (median ${change.median.toFixed(2)}:1)`,
+    ).toBeGreaterThanOrEqual(change.required)
+
+    release()
+    await expect(page.getByText('That picture was not saved.')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/support/boundary.ts
+++ b/apps/web/e2e/support/boundary.ts
@@ -41,7 +41,19 @@ export type Surface =
   | { kind: 'css'; selector: string }
   | { kind: 'sample' }
 
-export type Boundary = { name: string; selector: string }
+export type Boundary = {
+  name: string
+  selector: string
+  /**
+   * Walk the element's own circular perimeter rather than its bounding box.
+   *
+   * A round control's box corners are empty, so the rectangular walk below
+   * probes four regions the control does not occupy and reports the weakest of
+   * them — which is the background against itself. Measured on `/profile`'s
+   * avatar frame: 1.00:1 with a boundary plainly visible on screen.
+   */
+  round?: true
+}
 export type Reading = { name: string; resting: number; focused: number }
 
 /**
@@ -112,7 +124,7 @@ export async function boundaryContrast(
     boxes.set(selector, await documentBox(selector))
   }
 
-  for (const { name, selector } of boundaries) {
+  for (const { name, selector, round } of boundaries) {
     const control = page.locator(selector)
     // Scrolled into view before its box is read. `boundingBox` is relative to
     // the viewport, so a control below the fold reports coordinates outside it
@@ -226,7 +238,17 @@ export async function boundaryContrast(
     const measure = async () => {
       const shot = (await page.screenshot({ clip })).toString('base64')
       return page.evaluate(
-        async ({ shot, padLeft, padTop, width, height, surface, leftOffsets, rightOffsets }) => {
+        async ({
+          shot,
+          padLeft,
+          padTop,
+          width,
+          height,
+          surface,
+          leftOffsets,
+          rightOffsets,
+          round,
+        }) => {
           const image = new Image()
           image.src = `data:image/png;base64,${shot}`
           await image.decode()
@@ -292,11 +314,37 @@ export async function boundaryContrast(
 
           const band = [-5, -4, -3, -2, -1, 0, 1, 2, 3]
           const edges: [number, number, number, number][] = []
-          for (const f of fractions) {
-            edges.push([padLeft + width * f, padTop, 0, 1])
-            edges.push([padLeft + width * f, padTop + height, 0, -1])
-            edges.push([padLeft, padTop + height * f, 1, 0])
-            edges.push([padLeft + width, padTop + height * f, -1, 0])
+          if (round) {
+            // Sixteen radial probes, each stepping the band along its own
+            // outward normal. Fewer would step over the place a curve is
+            // weakest: a 1px stroke is fully covered where it runs straight
+            // and about a fifth covered at 45 degrees, so the diagonals are
+            // exactly where a round boundary fails and a walk that skipped
+            // them would report the axes and call it an edge.
+            const cx = padLeft + width / 2
+            const cy = padTop + height / 2
+            // A circle, not a stadium or a rounded rectangle. On anything but a
+            // square box this would trace the inscribed circle and report the
+            // interior as an edge — quietly, and in the direction that passes.
+            if (Math.abs(width - height) > 1) {
+              throw new Error(
+                `round asked of a ${width}x${height} box; it walks a circle and ` +
+                  'that is not one',
+              )
+            }
+            const radius = Math.min(width, height) / 2
+            for (let step = 0; step < 16; step++) {
+              const angle = (step / 16) * Math.PI * 2
+              const [ux, uy] = [Math.cos(angle), Math.sin(angle)]
+              edges.push([cx + ux * radius, cy + uy * radius, -ux, -uy])
+            }
+          } else {
+            for (const f of fractions) {
+              edges.push([padLeft + width * f, padTop, 0, 1])
+              edges.push([padLeft + width * f, padTop + height, 0, -1])
+              edges.push([padLeft, padTop + height * f, 1, 0])
+              edges.push([padLeft + width, padTop + height * f, -1, 0])
+            }
           }
 
           let weakest = Infinity
@@ -318,6 +366,7 @@ export async function boundaryContrast(
           surface,
           leftOffsets,
           rightOffsets,
+          round,
         },
       )
     }

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -74,7 +74,105 @@ describe('Profile Page', () => {
     
     const securityTab = screen.getByRole('button', { name: /Security/i })
     fireEvent.click(securityTab)
-    
+
     expect(screen.getByText(/Change Password/i)).toBeDefined()
+  })
+
+  it('stays on screen while the session refreshes behind it', async () => {
+    // Saving an avatar calls `update()`, which puts the session back into
+    // `loading` — and this page used to answer that by replacing itself with
+    // the first-load spinner. Measured by `ui-review`: the page blanked for
+    // ~35ms, `AvatarUpload` unmounted mid-save so the "Picture saved." it set
+    // never rendered, and focus fell from the file input to `body`.
+    vi.mocked(useSession).mockReturnValue({
+      status: 'authenticated',
+      data: { user: { name: 'Test User' } },
+      update: vi.fn(),
+    } as any)
+    // Per route, for the reason the test below gives: a blanket profile-shaped
+    // answer hands `/api/categories` something with no `.map` and takes the
+    // whole tree down, which then fails this test for a reason that has nothing
+    // to do with what it is asking.
+    vi.mocked(fetch).mockImplementation((url: any) =>
+      String(url).includes('/api/categories')
+        ? (Promise.resolve({ ok: true, json: async () => [] }) as any)
+        : (Promise.resolve({ ok: true, json: async () => ({ name: 'Test User' }) }) as any),
+    )
+
+    const { rerender } = render(<ProfilePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText(/upload avatar/i)).toBeDefined()
+    })
+
+    vi.mocked(useSession).mockReturnValue({
+      status: 'loading',
+      data: { user: { name: 'Test User' } },
+      update: vi.fn(),
+    } as any)
+    rerender(<ProfilePage />)
+
+    expect(screen.getByLabelText(/upload avatar/i)).toBeDefined()
+    expect(screen.queryByText(/loading your profile/i)).toBeNull()
+  })
+
+  it('tells the avatar control when the server would not store the picture', async () => {
+    // #237: this handler did nothing on a non-ok response, so `AvatarUpload`
+    // went on showing the picture it had optimistically previewed and reported
+    // a save that never happened. The contract is that it rejects; the message
+    // the visitor reads is `avatar-upload.test.tsx`'s.
+    vi.mocked(useSession).mockReturnValue({
+      status: 'authenticated',
+      data: { user: { name: 'Test User' } },
+      update: vi.fn(),
+    } as any)
+
+    // Keyed on the request rather than a `mockResolvedValueOnce` chain. With a
+    // chain, a third call — the sidebar asking for categories, as it happens —
+    // falls off the end and resolves `undefined`, and reading `.ok` off it
+    // throws. The component reports a failure either way, so the test passed
+    // against a handler that swallowed the 500. Measured: it survived that
+    // mutation.
+    //
+    // Each route answered in its own shape for the same reason. A catch-all
+    // returning the profile object gave `/api/categories` something with no
+    // `.map`, which took the whole tree down mid-test and left an empty body to
+    // search — a failure that looks nothing like its cause.
+    vi.mocked(fetch).mockImplementation((url: any, init?: any) => {
+      if (init?.method === 'PUT') return Promise.resolve({ ok: false, status: 500 }) as any
+      if (String(url).includes('/api/categories')) {
+        return Promise.resolve({ ok: true, json: async () => [] }) as any
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ name: 'Test User' }) }) as any
+    })
+
+    render(<ProfilePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText(/upload avatar/i)).toBeDefined()
+    })
+
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    })
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        readAsDataURL = vi.fn()
+        result = 'data:image/png;base64,hello'
+        error = null
+        onloadend: (() => void) | null = null
+        constructor() {
+          setTimeout(() => this.onloadend && this.onloadend(), 0)
+        }
+      },
+    )
+
+    fireEvent.change(screen.getByLabelText(/upload avatar/i), {
+      target: { files: [new File(['hello'], 'hello.png', { type: 'image/png' })] },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/not saved/i)).toBeDefined()
+    })
   })
 })

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -30,7 +30,21 @@ export default function ProfilePage() {
     }
   }, [status]);
 
-  if (status === "loading" || (status === "authenticated" && isLoadingProfile)) {
+  // `!profileData` and not `status === "loading"` on its own. `update()` puts
+  // the session back into `loading` every time it refreshes, and this branch
+  // then replaced the whole page — tabs, heading and all — with the first-load
+  // spinner. Measured after a successful avatar save: the page blanked for
+  // ~35ms, `AvatarUpload` unmounted mid-save so its "Picture saved." was set on
+  // a component that no longer existed and never rendered, and focus fell from
+  // the file input to `body`. A keyboard user saved their picture and was
+  // returned to the top of the document with no confirmation.
+  //
+  // This is the first load only: nothing to show yet. A refresh behind a page
+  // that already has its data leaves that page alone.
+  if (
+    (status === "loading" && !profileData) ||
+    (status === "authenticated" && isLoadingProfile)
+  ) {
     // role=status so the wait is announced rather than being a silent blank
     // screen for anyone not watching the pixels.
     return (
@@ -68,20 +82,22 @@ export default function ProfilePage() {
     );
   }
 
+  // Throws when the picture was not stored, and does not catch what `fetch`
+  // throws. Both are the contract `AvatarUpload` needs: it shows the new
+  // picture as soon as it is chosen, so a failure it is not told about leaves
+  // the visitor looking at a change that did not happen. This used to do
+  // nothing at all on a non-ok response and send a thrown error to the console.
   const handleAvatarUpload = async (url: string) => {
-    try {
-      const response = await fetch("/api/profile", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ avatar: url }),
-      });
-      if (response.ok) {
-        await update();
-        setProfileData({ ...profileData, avatar: url });
-      }
-    } catch (err) {
-      console.error("Failed to update avatar", err);
+    const response = await fetch("/api/profile", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar: url }),
+    });
+    if (!response.ok) {
+      throw new Error(`The server did not save the avatar (${response.status})`);
     }
+    await update();
+    setProfileData({ ...profileData, avatar: url });
   };
 
   const tabs = [

--- a/apps/web/src/components/avatar-upload.test.tsx
+++ b/apps/web/src/components/avatar-upload.test.tsx
@@ -234,6 +234,31 @@ describe('AvatarUpload', () => {
     expect(onUpload).not.toHaveBeenCalled()
   })
 
+  it('renders no picture for a stored value that is not a picture URL', async () => {
+    // `initialAvatar` is whatever is on the account, and the account holds
+    // whatever a previous save put there. A `javascript:` URL does not execute
+    // in an `<img src>` — it simply fails to paint — but the value is rendered
+    // in the chat panel too, and "safe because of how one element treats it" is
+    // an argument with a short shelf life. CodeQL calls this flow
+    // `js/xss-through-dom`.
+    render(<AvatarUpload initialAvatar="javascript:alert(1)" onUpload={() => {}} />)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByText('No Image')).toBeDefined()
+  })
+
+  it('renders the picture URLs an avatar can legitimately have', () => {
+    for (const src of [
+      'blob:http://localhost/abc',
+      'data:image/png;base64,hello',
+      'https://example.com/a.png',
+      '/uploads/a.png',
+    ]) {
+      const { unmount } = render(<AvatarUpload initialAvatar={src} onUpload={() => {}} />)
+      expect((screen.getByRole('img') as HTMLImageElement).getAttribute('src')).toBe(src)
+      unmount()
+    }
+  })
+
   it('refuses a file that is not an image', async () => {
     // `accept="image/*"` filters the picker's dialog and nothing else; any file
     // can be chosen past it. What the string becomes is the reason to check —

--- a/apps/web/src/components/avatar-upload.test.tsx
+++ b/apps/web/src/components/avatar-upload.test.tsx
@@ -10,12 +10,16 @@ import AvatarUpload from './avatar-upload'
  * the component reads `error` rather than treating the event as a result. The
  * stub reproduces that: `fails` makes it set `error` and still call `onloadend`.
  */
-function stubFileReader({ fails = false, via = 'onloadend' as 'onloadend' | 'onerror' } = {}) {
+function stubFileReader({
+  fails = false,
+  via = 'onloadend' as 'onloadend' | 'onerror',
+  result = 'data:image/png;base64,hello',
+} = {}) {
   vi.stubGlobal(
     'FileReader',
     class {
       readAsDataURL = vi.fn()
-      result = fails ? null : 'data:image/png;base64,hello'
+      result = fails ? null : result
       error = fails ? new Error('unreadable') : null
       onloadend: (() => void) | null = null
       onerror: (() => void) | null = null
@@ -227,6 +231,23 @@ describe('AvatarUpload', () => {
     })
     // Nothing was sent, so nothing can have been stored under a picture the
     // browser never managed to read.
+    expect(onUpload).not.toHaveBeenCalled()
+  })
+
+  it('refuses a file that is not an image', async () => {
+    // `accept="image/*"` filters the picker's dialog and nothing else; any file
+    // can be chosen past it. What the string becomes is the reason to check —
+    // it is stored on the account and later handed to an `<img src>`, here and
+    // in the chat.
+    const onUpload = vi.fn()
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader({ result: 'data:text/html;base64,PHNjcmlwdD4=' })
+
+    selectAFile()
+
+    await waitFor(() => {
+      expect(screen.getByText('That picture was not saved.')).toBeDefined()
+    })
     expect(onUpload).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/components/avatar-upload.test.tsx
+++ b/apps/web/src/components/avatar-upload.test.tsx
@@ -2,10 +2,47 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import AvatarUpload from './avatar-upload'
 
+/**
+ * A stub `FileReader` that resolves on the next tick, standing in for the real
+ * one because jsdom's does not run in this environment.
+ *
+ * `onloadend` fires for success and failure alike in the real API, which is why
+ * the component reads `error` rather than treating the event as a result. The
+ * stub reproduces that: `fails` makes it set `error` and still call `onloadend`.
+ */
+function stubFileReader({ fails = false, via = 'onloadend' as 'onloadend' | 'onerror' } = {}) {
+  vi.stubGlobal(
+    'FileReader',
+    class {
+      readAsDataURL = vi.fn()
+      result = fails ? null : 'data:image/png;base64,hello'
+      error = fails ? new Error('unreadable') : null
+      onloadend: (() => void) | null = null
+      onerror: (() => void) | null = null
+      constructor() {
+        setTimeout(() => {
+          if (fails && via === 'onerror') this.onerror?.()
+          else this.onloadend?.()
+        }, 0)
+      }
+    },
+  )
+}
+
+function selectAFile() {
+  const input = screen.getByLabelText(/upload avatar/i) as HTMLInputElement
+  const file = new File(['hello'], 'hello.png', { type: 'image/png' })
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
 describe('AvatarUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal('fetch', vi.fn())
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    })
   })
 
   it('renders initial avatar if provided', () => {
@@ -17,27 +54,196 @@ describe('AvatarUpload', () => {
   it('handles file selection and uploads base64', async () => {
     const onUpload = vi.fn()
     render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
-    const file = new File(['hello'], 'hello.png', { type: 'image/png' })
-    const input = screen.getByLabelText(/upload avatar/i) as HTMLInputElement
-    
-    const mockUrl = 'blob:mock'
-    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => mockUrl) })
+    stubFileReader()
 
-    vi.stubGlobal('FileReader', class {
-      readAsDataURL = vi.fn()
-      result = 'data:image/png;base64,hello'
-      onloadend: (() => void) | null = null
-      constructor() {
-        setTimeout(() => this.onloadend && this.onloadend(), 100)
-      }
-    })
-
-    fireEvent.change(input, { target: { files: [file] } })
+    selectAFile()
 
     await waitFor(() => {
       const img = screen.getByRole('img') as HTMLImageElement
-      expect(img.src).toBe(mockUrl)
+      expect(img.src).toBe('blob:mock')
       expect(onUpload).toHaveBeenCalledWith('data:image/png;base64,hello')
     })
+  })
+
+  /**
+   * The three below are #237's first two defects.
+   *
+   * The picture was shown, the spinner stopped, and nothing was saved: the
+   * component called `setPreview` before the upload started and cleared
+   * `isUploading` when the file finished *reading*, so a rejected save left a
+   * visitor looking at the picture they thought they had just set. Reload and
+   * it is gone.
+   *
+   * And the upload was announced to nobody. The only signal it was happening
+   * was a spinning div with no accessible name, so a screen-reader user got
+   * nothing at the start and nothing at the end.
+   *
+   * One mechanism answers both: the state is a sentence, it is rendered where
+   * everyone can see it, and it sits in a live region so it is spoken as well.
+   */
+  it('keeps the picture that was saved when a save fails, and says so', async () => {
+    const onUpload = vi.fn().mockRejectedValue(new Error('the server said no'))
+    render(<AvatarUpload initialAvatar="http://example.com/old.png" onUpload={onUpload} />)
+    stubFileReader()
+
+    selectAFile()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('That picture was not saved. Your previous picture is still in place.'),
+      ).toBeDefined()
+    })
+    // The old picture, not the one that failed to save. Showing the new one is
+    // the defect: it is a claim that the change took.
+    const img = screen.getByRole('img') as HTMLImageElement
+    expect(img.src).toContain('example.com/old.png')
+
+    // The retry that failure invites is *not* asserted here, and the reason is
+    // worth writing down. `handleFileChange` clears `e.target.value` so that
+    // choosing the same file again counts as a change; in jsdom a file input's
+    // value is never set in the first place, since `fireEvent.change` assigns
+    // `files` directly. So both halves — that the value is empty, and that a
+    // second identical selection reaches `onUpload` — hold whether or not the
+    // component clears anything. Measured: deleting that line leaves all
+    // fourteen tests green. It is real behaviour with no unit-level guard.
+  })
+
+  it('does not claim a previous picture when there was none', async () => {
+    // The second sentence is a claim about the screen, and on an account with
+    // no avatar — the seeded one, and the branch this component renders most —
+    // the revert restores nothing. Saying "your previous picture is still in
+    // place" there puts it directly under a circle reading "No Image".
+    const onUpload = vi.fn().mockRejectedValue(new Error('the server said no'))
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader()
+
+    selectAFile()
+
+    await waitFor(() => {
+      expect(screen.getByText('That picture was not saved.')).toBeDefined()
+    })
+    expect(screen.queryByText(/previous picture/i)).toBeNull()
+  })
+
+  it('announces the upload while it is running and once it is saved', async () => {
+    let finish: (() => void) | undefined
+    const onUpload = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    )
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader()
+
+    selectAFile()
+
+    const live = await screen.findByText(/uploading/i)
+    // Live rather than merely present: the same text arriving in an ordinary
+    // paragraph is a change no screen reader would mention.
+    expect(live.closest('[aria-live]')).not.toBeNull()
+
+    finish?.()
+    // The exact sentence, and the absence of the other one. `/saved/i` also
+    // matches "That picture was not saved…", so it could not tell success from
+    // failure — measured, this test stayed green with the success branch
+    // setting `failed`, which is a component that tells every visitor their
+    // picture was not saved.
+    await waitFor(() => {
+      expect(screen.getByText('Picture saved.')).toBeDefined()
+    })
+    expect(screen.queryByText(/not saved/i)).toBeNull()
+  })
+
+  it('takes one upload at a time', async () => {
+    // Two overlapping attempts each captured the other's object URL as the
+    // picture to revert to, and the first failure revoked it — leaving the
+    // frame holding a dead blob, which paints as a broken-image glyph with its
+    // alt text spilling out of the circle, above a sentence saying the picture
+    // was not saved. `ui-review` drove it and photographed it.
+    let finish: (() => void) | undefined
+    const onUpload = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    )
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader()
+
+    selectAFile()
+    await screen.findByText(/uploading/i)
+
+    const input = screen.getByLabelText(/upload avatar/i) as HTMLInputElement
+    expect(input.getAttribute('aria-busy')).toBe('true')
+    // The pointer half of the same signal. Asserted through the class name
+    // because jsdom computes no Tailwind, so there is no cursor to read — a
+    // weak guard, but the alternative is a claimed affordance with nothing
+    // behind it.
+    expect(input.closest('label')?.className).toContain('cursor-wait')
+    // Not `disabled`: disabling a focused input drops focus to `body` and
+    // re-enabling does not bring it back, and this input is exactly where focus
+    // sits when the change fires. The handler is what refuses the second file.
+    expect(input.disabled).toBe(false)
+
+    selectAFile()
+    // Settled first. A second call would not arrive until the stub reader's own
+    // tick, so asserting straight after the event holds whether or not the
+    // handler guards — measured, that version of this test survived deleting
+    // the guard, and a probe confirmed the event itself is delivered.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(onUpload).toHaveBeenCalledTimes(1)
+
+    finish?.()
+    // And it takes the next one once the first is done, so the guard is a
+    // window rather than a latch.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/upload avatar/i).getAttribute('aria-busy')).toBe('false')
+    })
+    selectAFile()
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('points the control at the sentence describing what happened', async () => {
+    // The announcement has gone by the time someone tabs back to the control.
+    render(<AvatarUpload initialAvatar="" onUpload={() => {}} />)
+    const input = screen.getByLabelText(/upload avatar/i)
+    const describedBy = input.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('reports a file it cannot read rather than spinning forever', async () => {
+    const onUpload = vi.fn()
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader({ fails: true })
+
+    selectAFile()
+
+    await waitFor(() => {
+      expect(screen.getByText(/not saved/i)).toBeDefined()
+    })
+    // Nothing was sent, so nothing can have been stored under a picture the
+    // browser never managed to read.
+    expect(onUpload).not.toHaveBeenCalled()
+  })
+
+  it('reports a read that fails through onerror as well', async () => {
+    // The same failure, reported the other way the API allows. `readAsDataUrl`
+    // handles both because engines differ on which fires, and the test above
+    // only drives one of them — a reader that reported failure solely through
+    // `onerror` would have left the upload hanging with no path out.
+    const onUpload = vi.fn()
+    render(<AvatarUpload initialAvatar="" onUpload={onUpload} />)
+    stubFileReader({ fails: true, via: 'onerror' })
+
+    selectAFile()
+
+    await waitFor(() => {
+      expect(screen.getByText(/not saved/i)).toBeDefined()
+    })
+    expect(onUpload).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/avatar-upload.tsx
+++ b/apps/web/src/components/avatar-upload.tsx
@@ -53,6 +53,34 @@ function readAsDataUrl(file: File): Promise<string> {
   });
 }
 
+/**
+ * The URL forms this frame will render, and nothing else.
+ *
+ * `preview` is not a value this component chose. It arrives as `initialAvatar`
+ * from `/api/profile`, which returns what is stored on the account, and what is
+ * stored on the account is whatever a previous upload put there. Handing that
+ * straight to `src` is CodeQL's `js/xss-through-dom`, open against this line
+ * since February.
+ *
+ * The exploit that rule names does not land here — an `<img src>` runs neither
+ * `javascript:` nor `data:text/html`, it just fails to paint — and only the
+ * account holder can write their own avatar. But "an arbitrary string from the
+ * database is fine as a URL because of how one element happens to treat it" is
+ * an argument that stops being true the moment the value is rendered somewhere
+ * else, and it already is: the chat panel reads the same field.
+ *
+ * So the three shapes an avatar can legitimately have: a `blob:` URL this
+ * component just minted, a `data:image/` URL a save produced, and an ordinary
+ * http(s) or site-relative path for accounts whose picture is hosted. Anything
+ * else renders as no picture at all, which is the honest outcome — it is not a
+ * picture.
+ */
+const RENDERABLE = /^(?:blob:|data:image\/|https?:\/\/|\/)/;
+
+function pictureSrc(value: string): string {
+  return RENDERABLE.test(value) ? value : "";
+}
+
 type Status =
   | { state: "idle" }
   | { state: "uploading" }
@@ -166,9 +194,9 @@ export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadPr
         on the whole perimeter is 15.52:1.
       */}
       <div className="relative h-32 w-32 rounded-full forced-colors:border-2">
-        {preview ? (
+        {pictureSrc(preview) ? (
           <img
-            src={preview}
+            src={pictureSrc(preview)}
             alt="Avatar Preview"
             className="h-full w-full rounded-full object-cover"
           />

--- a/apps/web/src/components/avatar-upload.tsx
+++ b/apps/web/src/components/avatar-upload.tsx
@@ -28,11 +28,23 @@ interface AvatarUploadProps {
 function readAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    const fail = () => reject(reader.error ?? new Error("The file could not be read"));
-    reader.onerror = fail;
+    const fail = (why?: string) =>
+      reject(why ? new Error(why) : (reader.error ?? new Error("The file could not be read")));
+    reader.onerror = () => fail();
     reader.onloadend = () => {
       if (reader.error || typeof reader.result !== "string") {
         fail();
+        return;
+      }
+      // `accept="image/*"` is a hint to the file picker, not a rule: it filters
+      // what the dialog offers and any file can still be chosen past it. This
+      // is the only place that checks, and what it protects is what the string
+      // becomes — the value is stored on the account and later handed to an
+      // `<img src>`, here and in the chat. A data URL declaring some other type
+      // is not a picture, so refusing it is both the security answer and the
+      // correct one.
+      if (!reader.result.startsWith("data:image/")) {
+        fail("That file is not an image");
         return;
       }
       resolve(reader.result);

--- a/apps/web/src/components/avatar-upload.tsx
+++ b/apps/web/src/components/avatar-upload.tsx
@@ -5,35 +5,155 @@ import { ACTION_FOCUS_WITHIN } from "@/lib/control-classes";
 
 interface AvatarUploadProps {
   initialAvatar: string;
-  onUpload: (url: string) => void;
+  /**
+   * Saves the picture, and rejects if it was not saved.
+   *
+   * Rejecting is the contract, not an implementation detail: this component
+   * shows the new picture the moment it is chosen, which is a claim that the
+   * change took. An `onUpload` that swallows its own failures makes that claim
+   * false and there is nothing here that could tell.
+   */
+  onUpload: (url: string) => void | Promise<void>;
 }
+
+/**
+ * `FileReader` as a promise, rejecting on the failures the callback API reports
+ * by other means.
+ *
+ * `onloadend` fires whether the read succeeded or failed, so awaiting it alone
+ * would treat an unreadable file as a successful read of `null`. `error` is
+ * what separates them, and `onerror` covers the same ground for readers that
+ * report it that way.
+ */
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    const fail = () => reject(reader.error ?? new Error("The file could not be read"));
+    reader.onerror = fail;
+    reader.onloadend = () => {
+      if (reader.error || typeof reader.result !== "string") {
+        fail();
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+type Status =
+  | { state: "idle" }
+  | { state: "uploading" }
+  | { state: "saved" }
+  | { state: "failed"; hadPicture: boolean };
+
+/**
+ * What the visitor is looking at, rather than a cause this cannot know or an
+ * instruction it cannot back.
+ *
+ * The picture reverted in front of them and the sentence has to account for
+ * that; "please try again" accounted for nothing and promised that repeating a
+ * 500 would go differently. Retrying is obvious anyway — the control is right
+ * there, and the input's value is cleared so choosing the same file again still
+ * counts as a change.
+ *
+ * `hadPicture`, because the second sentence is a claim about the screen and it
+ * is false on the branch most accounts are on. An account with no avatar reverts
+ * to no avatar, and "your previous picture is still in place" then sits directly
+ * under a circle reading "No Image".
+ */
+function message(status: Status): string {
+  switch (status.state) {
+    case "idle":
+      return "";
+    case "uploading":
+      return "Uploading your picture…";
+    case "saved":
+      return "Picture saved.";
+    case "failed":
+      return status.hadPicture
+        ? "That picture was not saved. Your previous picture is still in place."
+        : "That picture was not saved.";
+  }
+}
+
+const STATUS_ID = "avatar-upload-status";
 
 export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadProps) {
   const [preview, setPreview] = useState(initialAvatar);
-  const [isUploading, setIsUploading] = useState(false);
+  const [status, setStatus] = useState<Status>({ state: "idle" });
+  const isUploading = status.state === "uploading";
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+    const input = e.target;
+    const file = input.files?.[0];
     if (!file) return;
 
-    // Create preview
+    // Cleared here, before anything can return early, and the `File` above
+    // survives it — the reference is independent of the input.
+    //
+    // Choosing the same file twice in a row is not a change event, so whatever
+    // is left in the value is a file the visitor cannot pick again. Clearing on
+    // the completed paths only meant the *ignored* file was the one that stuck:
+    // pick A, change your mind mid-upload and pick B, B is refused by the guard
+    // below and stays in the value, and once the control is idle picking B does
+    // nothing at all — no event, no message. The one selection someone is most
+    // likely to repeat was the one made impossible.
+    input.value = "";
+
+    // One at a time, and this is the only thing enforcing it — the label below
+    // shows that the control is busy but nothing takes it out of reach. Two
+    // overlapping attempts each captured the *other's* object URL as the
+    // picture to go back to, and the first failure revoked it: the frame was
+    // left holding a dead blob, which paints as a broken-image glyph with its
+    // alt text spilling out of the circle, directly above a sentence saying the
+    // picture was not saved.
+    if (isUploading) return;
+
+    // What to go back to. The preview changes before the save is attempted,
+    // because waiting for a round trip to show the picture someone just chose
+    // is the worse trade — but that makes the picture a claim, so a save that
+    // does not happen has to take it back.
+    const saved = preview;
     const objectUrl = URL.createObjectURL(file);
     setPreview(objectUrl);
-    setIsUploading(true);
+    setStatus({ state: "uploading" });
 
-    // Convert to Base64
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const base64String = reader.result as string;
-      onUpload(base64String);
-      setIsUploading(false);
-    };
-    reader.readAsDataURL(file);
+    try {
+      // Awaited, so `uploading` covers the whole operation. It used to end when
+      // the file finished *reading*, which is before the request is even sent:
+      // the spinner stopped, and a save that took two seconds and failed looked
+      // like a save that took no time and worked.
+      await onUpload(await readAsDataUrl(file));
+      setStatus({ state: "saved" });
+    } catch {
+      setPreview(saved);
+      URL.revokeObjectURL(objectUrl);
+      setStatus({ state: "failed", hadPicture: saved !== "" });
+    }
   };
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="relative h-32 w-32">
+      {/*
+        The frame carries the boundary rather than either branch below, so it
+        is there whether or not a picture is.
+
+        Without it, `bg-gray-200` resolves to Canvas in forced colors and the
+        circle vanishes, leaving "No Image" floating in nothing — the same
+        mechanism as #216 and #227, on an element that is neither a field nor a
+        control.
+
+        `border-2` here is geometry rather than the weight convention those two
+        set, where 1px means a field and 2px means an action. A curve cannot
+        hold a 1px stroke: measured on this frame, black on Canvas reads 19.56:1
+        where the circle runs straight past the axes and 1.47:1 at 45 degrees,
+        because the stroke lands about a fifth covered on a diagonal pixel and
+        antialiasing takes the rest. The straight-edged fields do not pay that,
+        which is why the same class is enough for them. At 2px the weakest point
+        on the whole perimeter is 15.52:1.
+      */}
+      <div className="relative h-32 w-32 rounded-full forced-colors:border-2">
         {preview ? (
           <img
             src={preview}
@@ -41,17 +161,25 @@ export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadPr
             className="h-full w-full rounded-full object-cover"
           />
         ) : (
-          <div className="h-full w-full rounded-full bg-gray-200 flex items-center justify-center text-gray-400">
+          // `text-gray-700`, not `text-gray-400`: on `bg-gray-200` that was
+          // 2.10:1 at 16px, against the 4.5:1 WCAG 2.2 1.4.3 asks. It is the
+          // branch the seeded account renders, so it was the default view.
+          <div className="h-full w-full rounded-full bg-gray-200 flex items-center justify-center text-gray-700">
             No Image
           </div>
         )}
         {isUploading && (
-          <div className="absolute inset-0 bg-black/50 rounded-full flex items-center justify-center">
+          // Decoration. The spinner says nothing a screen reader can read, and
+          // the sentence below says it in words for everyone.
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-black/50 rounded-full flex items-center justify-center"
+          >
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>
           </div>
         )}
       </div>
-      
+
       {/*
         The boundary and the focus indicator both belong here rather than on
         the input: this label is the control anyone can see, and the input it
@@ -71,7 +199,22 @@ export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadPr
         constant rather than a second copy of this literal.
       */}
       <label
-        className={`cursor-pointer bg-white px-3 py-2 border border-zinc-500 rounded-md shadow-xs text-sm font-medium text-gray-700 hover:bg-gray-50 has-[:focus-visible]:outline-indigo-600 forced-colors:border-2 ${ACTION_FOCUS_WITHIN}`}
+        className={`px-3 py-2 border border-zinc-500 rounded-md shadow-xs text-sm font-medium text-gray-700 has-[:focus-visible]:outline-indigo-600 forced-colors:border-2 ${ACTION_FOCUS_WITHIN} ${
+          // Busy rather than disabled, and the styling is the whole of it: the
+          // handler is what refuses a second file. The cursor and the changed
+          // surface are so a pointer user can see the control will not take
+          // one, since a click that is quietly ignored is worse than one that
+          // is visibly unavailable.
+          //
+          // The surface changes; nothing fades. `opacity` composites the
+          // element with its border and outline as one group, so an `opacity-60`
+          // busy state took the label text to 3.37:1, the border to 2.27:1 and
+          // the focus outline to 2.86:1 — all below their floors, and the focus
+          // one is the worst of the three precisely because this state exists
+          // to keep a keyboard user *on* the control rather than disabling it
+          // out from under them.
+          isUploading ? "cursor-wait bg-zinc-100" : "cursor-pointer bg-white hover:bg-gray-50"
+        }`}
       >
         <span>Upload Avatar</span>
         <input
@@ -79,9 +222,54 @@ export default function AvatarUpload({ initialAvatar, onUpload }: AvatarUploadPr
           className="sr-only"
           accept="image/*"
           aria-label="upload avatar"
+          // So the result is available on the control itself, not only as an
+          // announcement that has already gone by. Someone who tabs away and
+          // back after a failure would otherwise have no way to hear it again.
+          aria-describedby={STATUS_ID}
+          // `aria-busy` and not `disabled`. Disabling a *focused* input moves
+          // focus to `body`, and re-enabling does not bring it back — measured
+          // in Chromium, and this input is where focus sits at the moment the
+          // change fires, because `sr-only` clips rather than removes. So the
+          // guard against two uploads would have put a keyboard user back at
+          // the top of the document on every upload: the same defect that
+          // `/profile`'s loading branch caused, moved into the component that
+          // was fixing it.
+          aria-busy={isUploading}
           onChange={handleFileChange}
         />
       </label>
+
+      {/*
+        Visible text in a live region, rather than an `sr-only` announcement
+        beside a visual spinner. One sentence then serves both: it is spoken
+        when it changes, and a sighted user gets a result rather than a spinner
+        that stops.
+
+        `aria-live` without `role="status"`, following `chat.tsx` — `/profile`
+        already renders a `role="status"` while it loads, and a test addresses
+        the region by that role.
+
+        Always rendered, empty when idle. A live region that appears at the same
+        moment as its content is not reliably announced; the region has to be
+        there first for the change to be a change.
+
+        Below the control rather than above it, and this is the only reason:
+        the message wraps. `min-h-5` reserves one line, which is enough at 100%
+        but not at 200% text, where the failure sentence takes three — measured
+        at 390px, the button moved 80px between idle and failed, 40px of it
+        while someone would be reaching for it to retry. Reserving the worst
+        case is guesswork at an unknown zoom. Nothing sits below this, so here
+        the message can grow to any height and move nothing at all.
+      */}
+      <p
+        id={STATUS_ID}
+        aria-live="polite"
+        className={`min-h-5 max-w-xs text-center text-sm ${
+          status.state === "failed" ? "text-red-700" : "text-gray-700"
+        }`}
+      >
+        {message(status)}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Closes #237.

A save that failed was indistinguishable from one that worked. The picture appeared, the spinner stopped, and nothing had been stored: `handleAvatarUpload` did nothing on a non-ok response and sent thrown errors to the console, and by then the component had already shown the new picture and cleared `isUploading` — which it did when the file finished *reading*, before the request was even sent.

It also happened silently: the only sign an upload was running was an `animate-spin` div with no accessible name.

## What this does

The handler throws when the server refuses, `uploading` covers the whole operation, and a failure puts the previous picture back. The state is one sentence under the control, rendered where everyone can read it and in a live region so it is spoken as well. The spinner is `aria-hidden`. The failure sentence adds "Your previous picture is still in place" only when there was one — on an account with no avatar, which is most of them, that half would sit under a circle reading "No Image".

Two contrast failures, both on the branch an account with no picture renders:

- the "No Image" placeholder was 2.10:1 at 16px against the 4.5:1 of WCAG 2.2 1.4.3. Now 8.33:1.
- the 128px frame had no boundary in forced colors, where `bg-gray-200` resolves to Canvas.

The frame takes `forced-colors:border-2`, and 2px is geometry rather than the field/action weight convention. A curve cannot hold a 1px stroke: measured, black on Canvas reads 19.56:1 where the circle runs straight past the axes and 1.47:1 at 45 degrees, because the diagonal pixel lands about a fifth covered. At 2px the weakest point on the perimeter is 15.52:1. `boundaryContrast` gained a `round` option to see it — the rectangular walk probes box corners a circle does not occupy, so it measured the background against itself and read 1.00:1 on a frame that was plainly there.

## Two more, found by `ui-review` while looking at the fix

- `await update()` put the session back into `loading`, and `/profile` answered by replacing the whole page with its first-load spinner. `AvatarUpload` unmounted mid-save, so the "Picture saved." it had just set never rendered, and focus fell to `body`.
- Two overlapping uploads each captured the other's object URL as the picture to revert to, and the first failure revoked it, leaving a broken-image glyph with its alt text spilling out of the circle above a sentence saying the picture was not saved.

The control takes one upload at a time but is not disabled to do it — disabling a focused input moves focus to `body` and re-enabling does not bring it back, which is the first defect by another route. The handler refuses, `aria-busy` says so, and the label shows it with a cursor and a changed surface. Changed rather than faded: `opacity` composites an element with its border and outline as one group, and an `opacity-60` busy state took the focus indicator to 2.86:1.

## Guards

Unit tests cover the states and the announcement. `e2e/avatar.spec.ts` covers the two contrast failures and drives the control in a browser for the three things jsdom cannot reach — a file input's value, `opacity` compositing, and focus. It holds `PUT /api/profile` open with `route.fulfill`, so nothing is written to the seeded account; the verifier checked the row before and after every run.

Eleven unit mutations and three browser mutations were run against these guards, all caught. Four tests were rewritten during review for passing without asking anything, including `getByText(/saved/i)` — which also matches "That picture was not saved".

## Verification

Full battery against a production stack built from this branch: 130/130 Playwright journeys (run twice), 146 unit tests, lint, typecheck and the production build. Three code-review rounds.

`alt="Avatar Preview"` describes the element rather than the picture; filed as #243 rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
