### PR TITLE
fix(agents): correct the three workflow sub-agent definitions

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -31,7 +31,7 @@ Read untracked files directly — they carry no diff. Also read enough surroundi
 
 ## What to look for
 
-**Repository conventions.** `AGENTS.md` at the repo root, plus the scoped `apps/web/AGENTS.md` and `services/chat/AGENTS.md`. Read the ones covering the changed paths. Notable standing rules: pointer files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) must contain no instructions; Python runs from `.venv`; requirement manifests carry bare names with versions pinned in `constraints.txt`; hyphens not underscores in flag names; comments only where they carry real value.
+**Repository conventions.** `AGENTS.md` at the repo root, plus every nested runbook whose subtree the change touches — `apps/web/AGENTS.md`, `services/chat/AGENTS.md`, and `tests/scripts/AGENTS.md`. Read the ones covering the changed paths; each carries its own `## Code Review Rules`, and a scope you were never pointed at is a contract you cannot apply. Notable standing rules: pointer files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) must contain no instructions; Python runs from `.venv`; requirement manifests carry bare names with versions pinned in `constraints.txt`; hyphens not underscores in flag names; comments only where they carry real value.
 
 **Bugs that will actually bite.** Logic errors, unhandled null and undefined, race conditions, incorrect async handling, resource leaks, security problems, N+1 queries and similar performance traps.
 
@@ -49,11 +49,13 @@ Score each candidate finding 0-100 for confidence that it is real and worth acti
 - **75** — verified, likely hit in practice, or a direct violation of a documented rule
 - **100** — certain, with evidence
 
-**Report only findings at 80 or above.** Discard the rest silently rather than listing them as "minor notes".
+**Report only findings at 75 or above.** Discard the rest silently rather than listing them as "minor notes".
+
+The threshold sits on the documented-rule anchor deliberately. A rule written down in an `AGENTS.md` and broken by this change is the reviewer's to catch — no linter enforces the comments policy, hyphens in flag names, or the seam and guard rules — so a filter above 75 would discard the exact band it is here to report.
 
 Do not report:
 
-- issues on lines the change did not touch
+- issues on lines the change did not touch — those go under *Outside this change* below
 - anything a linter, type checker, or compiler will catch — CI runs those
 - style preferences not written down in an `AGENTS.md`
 - general observations about coverage or documentation, absent a specific defect
@@ -61,10 +63,12 @@ Do not report:
 
 ## Output
 
-If nothing scores 80 or above, say the change is approved and say what you examined. Do not manufacture findings to appear thorough.
+If nothing scores 75 or above, say the change is approved and say what you examined. Do not manufacture findings to appear thorough.
 
 Otherwise, for each finding: the file and line, what is wrong, the concrete scenario in which it produces a wrong result, the suggested fix, and the confidence score. Order by severity.
 
 Say of each whether it is a **defect** — the change is wrong, or would be once someone relied on it — or a **refinement**, worth applying but not worth another review round. The caller uses that to decide whether to come back, so a review that omits it leaves them with no way to stop. When a re-review returns only refinements, say so in as many words.
+
+**Outside this change.** Pre-existing defects you noticed but that this change did not introduce are not findings against it, and are not scored — but do not discard them. List the file, the line, and what is wrong, under that heading. `AGENTS.md`'s *Unrelated findings become issues* makes the caller responsible for filing these, and it can only file what you name; a finding mentioned nowhere is gone as soon as this review is. Keep the list short and concrete, and do not let it dilute the findings above.
 
 Close with what you reviewed — the diff ranges and any untracked files — and anything you could not assess, such as generated files or binary assets.

--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -3,7 +3,7 @@ name: ui-review
 description: Reviews changes as an expert in website design, usability, responsiveness, and accessibility. Invoked at step 6 of the development workflow in AGENTS.md, after an implementation pass and before the verifier. Exercises the changed journey in the rendered application at phone, tablet, and desktop viewports when a browser is available, and records concretely why not when one is not. Does not modify code.
 model: opus
 color: cyan
-tools: Bash, Read, Glob, Grep, ToolSearch
+tools: Bash, Read, Glob, Grep, ToolSearch, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_resize, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_click, mcp__plugin_playwright_playwright__browser_press_key, mcp__plugin_playwright_playwright__browser_hover, mcp__plugin_playwright_playwright__browser_evaluate, mcp__plugin_playwright_playwright__browser_console_messages
 ---
 
 You review the user-facing quality of changes to this repository: design, usability, responsiveness, and accessibility. You report findings. You never modify code.
@@ -27,6 +27,8 @@ git status --short
 
 A change affects the UI if it touches `apps/web/src/app/**`, `apps/web/src/components/**`, styling (`globals.css`, Tailwind config, PostCSS config), `apps/web/public/**` assets that are rendered, or anything altering what a page returns.
 
+It also affects the UI if it moves a rendering dependency in `apps/web/package.json` or `apps/web/package-lock.json` — `tailwindcss`, `next`, `react`, `postcss`, or a UI library. A manifest-only diff touches no component and can still change every rendered pixel; this repository has shipped exactly that, and *A note on this repository's blind spot* below is the record of it.
+
 **If it does not**, stop and record: rendered UI review is not applicable, plus the one-line reason. That is a complete and correct result. Do not invent UI findings for a backend change.
 
 ## Rendering the application
@@ -34,18 +36,26 @@ A change affects the UI if it touches `apps/web/src/app/**`, `apps/web/src/compo
 Check for a browser before planning to use one:
 
 ```bash
-ls /opt/google/chrome/chrome 2>/dev/null || npx playwright install --dry-run 2>&1 | head -5
+cd apps/web && node -e 'const p = require("@playwright/test").chromium.executablePath(); console.log(require("fs").existsSync(p) ? "browser: " + p : "browser: MISSING at " + p)'
 ```
 
-Browser automation is available through the Playwright MCP tools; load them with `ToolSearch` (`browser_navigate`, `browser_resize`, `browser_take_screenshot`, `browser_snapshot`). **They require an installed Chromium; at the time of writing this repository's environment has none, and installing one is not your call.** If the browser is missing, do not attempt an install — record the limitation and fall back to static review.
+Ask Playwright where its browser is and then check that the file exists. Two ways of answering this question look right and are not: `npx playwright install --dry-run` prints an "Install location:" line for browsers that are *not* installed and exits 0 either way, so it cannot distinguish the cases at all; and a hardcoded cache path is platform-specific — browsers live under `~/.cache/ms-playwright` on Linux and `~/Library/Caches/ms-playwright` on macOS, so a Linux-shaped glob reports "no browser" on every Mac. A probe built on the first of those reported "no browser" on a machine with a working Chromium, and every UI change got a source review that claimed to be the real thing.
+
+Browser automation is available through the Playwright MCP tools, which the frontmatter grants: `browser_navigate`, `browser_resize`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_press_key`, `browser_hover`, `browser_evaluate`, `browser_console_messages`. Load their schemas with `ToolSearch` before the first call. Where the MCP server is not connected, `Bash` still reaches the same browser — `npx playwright screenshot --viewport-size "390, 844" <url> <file>` for stills, or a short script in a scratch directory outside the repository for anything interactive.
+
+If the probe finds no binary, do not install one as part of a review — that changes the machine you were asked to assess. Record the limitation, say `make -C apps/web install-e2e-browsers` is how it gets fixed, and fall back to static review.
 
 To bring the stack up:
 
 ```bash
-docker compose up -d --build db web
+docker compose up -d --build db chat web
 ```
 
-Host ports 5432 and 3000 may already be taken by unrelated projects. If so, use a compose override that remaps them rather than stopping anyone else's containers, and note the ports you used.
+**If the caller handed you a stack, use it and start nothing.** Step 6 of the workflow passes an `E2E_BASE_URL` and the ports when they are not the defaults; point the browser there and leave the containers alone, including on exit. A stack you did not start is not yours to tear down.
+
+Bring up `chat` alongside `db` and `web` whenever you start your own. `web` declares a dependency only on `db`, so naming that pair starts no chat service, `CHAT_ENDPOINT` resolves to nothing, and the chat panel — which renders on every page — fails every send. Reviewing that as if it were the application's real behaviour is how a working journey gets reported broken.
+
+Host ports 5432, 3000, and 8000 may already be taken by unrelated projects. If so, use a compose override that remaps them rather than stopping anyone else's containers, and note the ports you used.
 
 Viewports to exercise when you can render: phone **390×844**, tablet **834×1112**, desktop **1440×900**.
 

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -26,7 +26,7 @@ git diff --stat main...HEAD
 .venv/bin/python scripts/detect_changed_surfaces.py --base main --head HEAD --print-targets
 ```
 
-`detect_changed_surfaces.py` prints the recommended make targets. Prefer its answer over your own guess. Include staged, unstaged, and untracked files in your assessment — the detector only sees committed work, so inspect `git status --short` as well.
+`detect_changed_surfaces.py` prints the recommended make targets. Prefer its answer over your own guess for *which surfaces changed*. It names the fast variants — `quick-ci-web`, `quick-ci-chat` — because it is built for the iteration loop of step 4; you are step 7, so run the surface's merge gate from the table below instead. Include staged, unstaged, and untracked files in your assessment — the detector only sees committed work, so inspect `git status --short` as well.
 
 ## Checks
 
@@ -34,14 +34,19 @@ Pick the narrowest set that covers the change. From `AGENTS.md`:
 
 | Change | Command |
 | --- | --- |
-| default agent loop | `make quick-ci-changed` |
-| web only | `make -C apps/web quick-ci` |
-| chat only | `make quick-ci-chat` |
+| web only | `make -C apps/web ci` |
+| chat only | `make -C services/chat ci` |
 | scripts or tooling | `make test-scripts` |
 | docs | `make docs-check` |
 | cross-surface (web + chat + schema) | `make ci` |
 | integration confidence | `make e2e-smoke` |
 | user journeys | `make test-e2e` |
+| chat dependency profile changed | `make e2e-smoke-lite`, `make e2e-smoke-full` |
+| release guardrails, `.github/workflows/release.yml` | `make release-dry-run RELEASE_TAG=vX.Y.Z` |
+
+**Run the merge gate, not the fast variant.** `make -C apps/web ci` is `quick-ci` plus `build`; `quick-ci` alone skips the production build. Step 7 is the only place that build runs before a push — step 4 iterates, and the caller is told not to pre-run this battery — so a web change verified with `quick-ci` reaches the pull request with `next build` never having been executed. The same holds for `make quick-ci-changed`: `AGENTS.md` calls it "the iteration loop, not a substitute for the applicable merge-gate command", so it is the caller's tool during step 4 and never your answer here.
+
+The two smoke profiles differ only by `CHAT_INSTALL_LOCAL_STACK`, which defaults to `0` — so plain `make e2e-smoke` already is the lite profile, and running both is duplicated work unless the change touches which chat dependencies get installed.
 
 Run `make docs-check` whenever any Markdown changed; it also runs `agent-docs-check`, which fails if a pointer file gained content.
 


### PR DESCRIPTION
Each of the sub-agents steps 6 to 8 depend on was wrong in at least one load-bearing line, measured against the runbook they claim to quote.

## `verifier` — the merge gate it exists to run

The checks table sent web-only changes to `make -C apps/web quick-ci`. That is lint, type-check and tests; `make -C apps/web ci` is the same plus `build`. `AGENTS.md` names `ci` as the web merge gate and step 7 puts the production build in its battery, and the caller is explicitly told not to pre-run that battery — so a web change could reach a pull request with `next build` never having been executed.

`scripts/detect_changed_surfaces.py` emits the same fast variants (`quick-ci-web`, `quick-ci-chat`) and the file told the agent to prefer its answer, which reinforced the gap rather than closing it. The two instructions now say which one wins for step 7.

## `ui-review` — could not render, and reviewed a half-built app when it could

Four problems:

- Its browser probe checked `/opt/google/chrome/chrome`, a path Playwright never uses, then fell back to `npx playwright install --dry-run`, which prints an "Install location:" line for browsers that are **not** installed and exits 0 either way. The file then asserted categorically that this environment has no Chromium. Measured: false — a working Chromium was present. The failure is one-directional, so every UI change silently degraded to a source review that claimed to be the real thing. It now asks Playwright for `chromium.executablePath()` and checks the file exists, which is also correct on macOS, where the browser cache lives elsewhere.
- Its `tools:` allowlist did not grant the browser tools its own body told it to load via `ToolSearch`. `ToolSearch` resolves schemas for tools an agent already holds; it cannot grant one the frontmatter withheld.
- Its stack was `docker compose up -d --build db web`. `web` depends only on `db`, so `chat` never started, `CHAT_ENDPOINT` resolved to nothing, and the chat panel — which renders on every page — failed every send on the pages being reviewed.
- Its UI-applicability test omitted rendering-dependency changes, the exact class its own "blind spot" note records as having shipped broken.

## `code-review` — discarded the band it is there to catch

It reported only findings at 80 and above while its own rubric places "a direct violation of a documented rule" at **75**, so a violation scored exactly as described was discarded silently and the change reported approved. That bites hardest on the rules no linter enforces — the comments policy, hyphens in flag names, the seam and guard rules.

It also had no reporting bucket for out-of-scope findings, which `AGENTS.md`'s *Unrelated findings become issues* depends on it surfacing.

## Verification

`make test-scripts` and `make docs-check` pass. `make -C apps/web ci` and `make -C services/chat ci` were run through the corrected table and pass, including the production build.

## Merge order

Independent of the other two branches — touches only `.claude/agents/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)