### PR TITLE
fix(web): fetch listing images for cards the visitor can reach

### DIFF
--- a/apps/web/e2e/image-deferral.spec.ts
+++ b/apps/web/e2e/image-deferral.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * The listing pages request images for cards the visitor can reach, not for
+ * every card on the page.
+ *
+ * `loading="lazy"` is not a viewport test. Chrome fetches lazy images within a
+ * threshold that is far larger than the viewport, measured here at roughly
+ * 3900px: at 1440x900 the home page's document is 5038px tall and it fetched
+ * 18 of its 20 product images before any scrolling, the deepest one 4.3
+ * viewports down. Only about three are on screen.
+ *
+ * Each of those is a separate `sharp` decode-and-resize of a 1024px source. On
+ * a two-core runner they measured a median of 2343ms each, and an unrelated
+ * navigation issued while they were in flight went from 78ms to 500ms. In CI,
+ * where the browser, database and chat service share those two cores, the same
+ * contention aborted a navigation outright and failed `browse.spec.ts` (#230).
+ *
+ * So the defect is the count, not the cost per image: most of that work is for
+ * cards nobody has scrolled to. These journeys pin the count down.
+ *
+ * They deliberately measure requests to `/_next/image` rather than `<img>`
+ * elements or `loading` attributes. The attribute is already correct and has
+ * been throughout — asserting on it would pass on today's tree and prove
+ * nothing. What went wrong is only visible in what the browser actually asked
+ * the server for.
+ *
+ * **Only the home page, for now.** The category grid is worse, not merely
+ * similar: measured the same way at 1440x900, `/products/category/tents`
+ * requests **21 of its 21** images before any scrolling, on a 3965px document
+ * that Chrome's threshold swallows whole. It is tracked in #263 and left out
+ * here as a slice boundary, not because it is hard to reach — the composed
+ * stack these journeys run against has the seeded database, and
+ * `image-delivery.spec.ts` already measures that surface across 21 widths.
+ * What keeps it out is that its `priority={i < 3}` cutoff is an open question
+ * of its own in #180, and answering both at once would tangle them.
+ */
+
+/** Distinct optimiser URLs requested, recorded from navigation onward. */
+function trackOptimiserRequests(page: Page): Set<string> {
+  const seen = new Set<string>()
+  page.on('request', (request) => {
+    const url = request.url()
+    if (url.includes('/_next/image')) seen.add(url)
+  })
+  return seen
+}
+
+const PRODUCT_CARD =
+  'a[href^="/products/"]:not([href^="/products/category/"])'
+
+/**
+ * Above this and the page is doing speculative work again; the pre-fix tree
+ * measured 18. Deliberately not pinned to an exact number: the count that
+ * matters is "a small multiple of what is on screen", and tying it to one
+ * integer would make an unrelated layout change look like this regression.
+ *
+ * 12 rather than 8, because the two knobs that set the real count are tuned
+ * against pop-in rather than against this bound, and 8 silently forbade both.
+ * At a 1200px margin with the first two categories eager, the count measured 9
+ * at desktop and tablet and 5 at phone; Chrome unaided fetches 20. A bound at
+ * 8 would have made either knob look like a regression while the page was
+ * getting better.
+ */
+const MAX_INITIAL_REQUESTS = 12
+
+test.describe('listing image deferral', () => {
+  test('the home page does not optimise every card before it is scrolled to', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const requested = trackOptimiserRequests(page)
+
+    await page.goto('/')
+    // Long enough that a browser intending to fetch these has done so: the
+    // slowest optimisation measured on a constrained server was 3253ms, and
+    // the request is issued long before it completes.
+    await page.waitForTimeout(3000)
+
+    const cards = await page.locator(PRODUCT_CARD).count()
+    // Vacuity: with no cards, or one, the bound below is satisfied by a page
+    // that renders nothing at all.
+    expect(cards, 'home page rendered no product grid to measure').toBeGreaterThan(
+      MAX_INITIAL_REQUESTS,
+    )
+
+    expect(
+      requested.size,
+      `${requested.size} optimiser requests for ${cards} cards before scrolling`,
+    ).toBeLessThanOrEqual(MAX_INITIAL_REQUESTS)
+  })
+
+  test('scrolling loads the images that were deferred', async ({ page }) => {
+    // The default 30s does not fit this journey on a cold cache. The largest
+    // term is `page.goto`, which waits for `load` and so waits on the nine
+    // optimisations the first screen starts — about a second each at two
+    // cores, per the still-pending measurement in #230 — before the two 3s
+    // waits and a poll that itself waits out the last row's share of eleven
+    // queued jobs. Run inside the full suite it fits, because `browse.spec.ts`
+    // sorts first under `workers: 1` and warms the same `w=384` variants; run
+    // on its own against a fresh stack, which is what AGENTS.md step 4 asks
+    // for, it does not. `image-delivery.spec.ts` raises its own for the same
+    // reason.
+    test.setTimeout(60_000)
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const requested = trackOptimiserRequests(page)
+
+    await page.goto('/')
+    await page.waitForTimeout(3000)
+    const initial = requested.size
+
+    // What this catches that the first journey cannot: deferral that never
+    // resolves. An image that is simply never requested also satisfies a bound
+    // on the initial count, and the page would look identical until you scroll.
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForTimeout(3000)
+
+    expect(
+      requested.size,
+      `scrolling to the bottom requested no further images (still ${initial})`,
+    ).toBeGreaterThan(initial)
+
+    // Every card that is now on screen has to have a decoded image, not just a
+    // request in flight — a deferred image that 404s would still count above.
+    //
+    // Polled rather than waited out. The assertion above needs requests
+    // *issued*, which 3s covers many times over; this one needs them
+    // *decoded*, and the two are far apart on a cold cache. Landing at the
+    // bottom of the document brings the remaining deferred cards inside the
+    // margin at once — about eleven optimisations queued together — and the
+    // measurements at the top of this file put each at a 2343ms median on two
+    // cores. A fixed 3s here would fail a page that is behaving correctly,
+    // with `retries: 0`, which is the class of CI failure #230 exists to
+    // remove. 15s fits inside the raised budget set at the top of this test.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            (selector) =>
+              [...document.querySelectorAll(`${selector} img`)].filter((img) => {
+                const image = img as HTMLImageElement
+                const box = image.getBoundingClientRect()
+                const onScreen = box.top < window.innerHeight && box.bottom > 0
+                return onScreen && image.naturalWidth === 0
+              }).length,
+            PRODUCT_CARD,
+          ),
+        {
+          timeout: 15_000,
+          message: 'on-screen cards whose image did not decode',
+        },
+      )
+      .toBe(0)
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import ListingImage from "@/components/listing-image";
 import Block from "@/components/block";
 import { ProductGroup } from "@/lib/types";
 import { promises as fs } from "fs";
@@ -110,15 +110,26 @@ export default async function Home() {
                 className="w-full max-w-[350px]"
               >
                 <div className="items-center">
-                  <Image
+                  <ListingImage
+                    // The first two categories, not just the first. A deferred
+                    // image cannot be requested until this component hydrates,
+                    // and that wait grows with the device: measured at +237ms
+                    // unthrottled but +2.0s at 6x CPU throttle. At 1440x2000
+                    // nine cards are above the fold, so covering only the
+                    // first category left six of them as empty boxes for that
+                    // whole window before the request even started.
+                    //
+                    // Two categories covers the first screen at every viewport
+                    // measured up to 1440x2000, for three extra server-rendered
+                    // images. Everything below is one to four viewports down --
+                    // see #230 for the measured positions.
+                    eager={i <= 1}
                     src={product.images[0]}
                     // Decorative, because the link already says it. The card
                     // is one link whose text is the product's name, so
                     // `alt={product.name}` made its accessible name the name
                     // twice. See e2e/browse.spec.ts.
                     alt=""
-                    width={350}
-                    height={350}
                     // 350px is the cap, not the box. The `minmax(0, 350px)`
                     // tracks only reach it once the container can hold three of
                     // them plus the gaps — from 1106px of viewport. Below that
@@ -138,9 +149,6 @@ export default async function Home() {
                     // card fetches w=640. The middle clause's `100vw` is
                     // harmless only because this one is here.
                     sizes="(min-width: 1106px) 350px, (min-width: 640px) calc( ( 100vw - 56px ) / 3 ), calc( 50vw - 20px )"
-                    // w-full so the image scales into its column: at its
-                    // intrinsic 350px it overflows one instead.
-                    className="rounded-3xl w-full h-auto"
                   />
                   <div className="text-center mt-2 text-base sm:text-xl md:text-2xl font-semibold break-words">
                     {product.name}

--- a/apps/web/src/components/listing-image.test.tsx
+++ b/apps/web/src/components/listing-image.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import ListingImage from './listing-image'
+
+/**
+ * The deferral itself, at the level the journeys cannot reach cheaply.
+ *
+ * `e2e/image-deferral.spec.ts` measures what the browser asks the server for,
+ * which is the property that matters and the one that regressed in #230. What
+ * it cannot do is drive the observer directly, so these cover the two states
+ * and the transition between them without waiting on a real viewport.
+ */
+
+const PROPS = {
+  src: '/images/1/example.webp',
+  alt: '',
+  sizes: '350px',
+}
+
+/** Callbacks registered by the component, newest last. */
+let callbacks: IntersectionObserverCallback[]
+let options: (IntersectionObserverInit | undefined)[]
+let observed: Element[]
+let disconnects: number
+
+beforeEach(() => {
+  callbacks = []
+  options = []
+  observed = []
+  disconnects = 0
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(
+        callback: IntersectionObserverCallback,
+        init?: IntersectionObserverInit,
+      ) {
+        callbacks.push(callback)
+        options.push(init)
+      }
+      observe = (element: Element) => {
+        observed.push(element)
+      }
+      unobserve = vi.fn()
+      disconnect = () => {
+        disconnects += 1
+      }
+      takeRecords = () => []
+      root = null
+      rootMargin = ''
+      thresholds = []
+    },
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** Fire the most recently registered observer as if the box had arrived. */
+function arrive() {
+  const callback = callbacks[callbacks.length - 1]
+  act(() => {
+    callback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
+  })
+}
+
+describe('ListingImage', () => {
+  it('renders no image until the box is nearly on screen', () => {
+    const { container } = render(<ListingImage {...PROPS} />)
+
+    // Only the `<noscript>` source, which is inert markup here: jsdom parses
+    // noscript content as text, so it contributes no element to query.
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+    expect(observed).toHaveLength(1)
+
+    // The margin is the whole tuning decision, and it is the one direction no
+    // other check can see: drop the options argument entirely and every count
+    // in `e2e/image-deferral.spec.ts` gets *better* while the page gets worse,
+    // because fewer requests is exactly what a too-small margin looks like.
+    // What it costs is the lead time measured at the constant's definition —
+    // at 1000ms optimiser latency, 14 of 20 cards grey as they enter.
+    expect(options[0]?.rootMargin).toBe('1200px')
+  })
+
+  it('renders the image once the box arrives, and stops observing', () => {
+    const { container } = render(<ListingImage {...PROPS} />)
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+
+    arrive()
+
+    const images = container.querySelectorAll('img')
+    expect(images).toHaveLength(1)
+    // What this catches beyond "an img appeared": `next/image` rewrites the
+    // src through the optimiser, so a component that fell back to a plain
+    // `<img src={src}>` would satisfy the count and still ship the 1024px
+    // source to a 350px box.
+    expect(images[0].getAttribute('src')).toContain('/_next/image')
+    expect(disconnects).toBeGreaterThan(0)
+  })
+
+  it('renders the image immediately when eager, and registers no observer', () => {
+    const { container } = render(<ListingImage {...PROPS} eager />)
+
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    // The eager path is what the first screen depends on. An observer here
+    // would mean those cards still wait for hydration, which is the hole that
+    // `eager={i <= 1}` on the home grid exists to close.
+    expect(observed).toHaveLength(0)
+  })
+
+  it('reserves the same box in both states', () => {
+    const { container: deferred } = render(<ListingImage {...PROPS} />)
+    const { container: immediate } = render(<ListingImage {...PROPS} eager />)
+
+    const box = (root: HTMLElement) => root.querySelector('div')?.className
+
+    // The reserved box and the loaded box are one element, so this is really
+    // asserting that the tone and the aspect ratio do not live on something
+    // that unmounts -- the defect where a scrolling visitor sees a fully
+    // transparent gap rather than a placeholder.
+    expect(box(deferred)).toBe(box(immediate))
+    expect(box(deferred)).toContain('aspect-square')
+    expect(box(deferred)).toContain('bg-zinc-200')
+  })
+
+  it('keeps the image decorative so the card is not announced twice', () => {
+    render(<ListingImage {...PROPS} eager />)
+
+    // `alt=""` is what makes the surrounding link's accessible name the
+    // product name once rather than twice. See e2e/browse.spec.ts and #200.
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+})

--- a/apps/web/src/components/listing-image.tsx
+++ b/apps/web/src/components/listing-image.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  src: string;
+  alt: string;
+  sizes: string;
+  /**
+   * Render the image straight away, server-side and in the HTML. For cards on
+   * or near the first screen, where deferring costs more than it saves.
+   */
+  eager?: boolean;
+};
+
+/**
+ * How far ahead of the viewport to start fetching.
+ *
+ * Chrome's own `loading="lazy"` threshold measured at roughly 3900px here,
+ * which is what #230 is about: at 1440x900 that reaches 4.3 viewports down and
+ * pulls in 18 of the home page's 20 cards.
+ *
+ * The margin buys `600 / v` seconds of lead at scroll speed `v`, so it hides a
+ * fetch only while the fetch is faster than that. Measured against injected
+ * optimiser latency at a 800px/s reading scroll: at 150ms nothing is ever
+ * grey; at 1000ms, 14 of 20 cards are grey as they enter. 1200 rather than 600
+ * doubles the lead for three extra requests a viewport -- 6 to 9 at desktop --
+ * which is still under a half of what Chrome does unaided.
+ *
+ * No margin fixes a hard fling on a slow server; nothing short of ~7000px
+ * does, and that is the behaviour this replaces. That case is handled by the
+ * box below staying visible rather than by fetching earlier.
+ */
+const ROOT_MARGIN = "1200px";
+
+/**
+ * A product-card image that is fetched when it is nearly on screen.
+ *
+ * `loading="lazy"` is a hint about a threshold the browser picks, not a
+ * viewport test, and the threshold it picks is far too generous for a page
+ * carrying twenty separately-optimised images. This narrows it.
+ *
+ * **The box is one element, not two.** The tone has to sit on a wrapper that
+ * survives the swap, because `next/image` renders with `color: transparent`
+ * and no background of its own: hanging the tone on a placeholder that
+ * unmounts means the state a scrolling visitor actually sees -- image
+ * requested, not yet decoded -- is a fully transparent gap. Keeping one
+ * element also removes an unmount/remount between the two states.
+ *
+ * `bg-zinc-200` measures 1.22:1 against the `bg-inherit` bands and 1.15:1
+ * against the `bg-zinc-100` ones, read back as painted sRGB rather than off the
+ * computed value, which Tailwind serialises as `lab()`. That is deliberately
+ * short of 1.4.11's 3:1: reaching it needs about `zinc-400`, and this box is a
+ * transient state of a decorative image, so a tone dark enough to pass would
+ * flash a heavy grey block on every ordinary load to serve a case that is
+ * meant to be brief. It is the same tone the about page's image band uses;
+ * the category grid's equivalent box is `bg-gray-200`, a shade off this one.
+ * Where that reasoning stops holding is when the box is *not* brief -- a
+ * blocked script leaves it forever -- which is #261 rather than this file.
+ *
+ * **`aspect-square` is an observation about the catalogue, and nothing holds
+ * it.** Every one of the 853 catalogue sources is 1024x1024 today, which is why
+ * the reserved box is exactly the loaded box and this shifts nothing. But the
+ * encoding contract in `config/catalogue_images.json` and the guard in
+ * `tests/scripts/test_image_encoding.py` only bound the *long edge* --
+ * `maxDimension` -- so a 1024x600 source passes every check in the repository
+ * and would render letterboxed here, with a strip of the tone below it and
+ * nothing turning red.
+ *
+ * This component is where that dependency starts: the markup it replaces took
+ * its box from the source's own ratio via `width`/`height` and `h-auto`. The
+ * category grid has the same unheld assumption and crops rather than
+ * letterboxes. See #262.
+ *
+ * Without JavaScript the deferred images are never requested, so `<noscript>`
+ * carries the unoptimised source. That is roughly 12x the bytes of the
+ * optimiser's variant -- measured at 5.1 MB against about 400 KB across the
+ * twenty cards -- and correct, which is the right way round for a case this
+ * rare. It does not cover JavaScript that loads and then fails: a blocked
+ * chunk leaves the deferred cards as empty boxes, which is the other reason
+ * the tone below has to be visible.
+ */
+export default function ListingImage({
+  src,
+  alt,
+  sizes,
+  eager = false,
+}: Props) {
+  const [show, setShow] = useState(eager);
+  const box = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (show) return;
+    const node = box.current;
+    if (!node) return;
+
+    // No feature test for IntersectionObserver. The obvious one --
+    // `typeof IntersectionObserver === "undefined"` -- is also true on the
+    // server, so it would render every image eagerly during SSR and undo the
+    // whole change while looking like a safety net. A correct test would have
+    // to run only on the client and then set state from inside this effect,
+    // which `react-hooks/set-state-in-effect` rejects. The observer has been
+    // in every browser Next supports since 2019, and the case that genuinely
+    // has none -- scripting off -- is served by the `<noscript>` below.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setShow(true);
+        observer.disconnect();
+      },
+      { rootMargin: ROOT_MARGIN },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [show]);
+
+  return (
+    <div
+      ref={box}
+      className="aspect-square w-full overflow-hidden rounded-3xl bg-zinc-200"
+    >
+      {show ? (
+        <Image
+          src={src}
+          alt={alt}
+          width={350}
+          height={350}
+          sizes={sizes}
+          className="w-full h-auto"
+        />
+      ) : (
+        <noscript>
+          <img src={src} alt={alt} className="w-full h-auto" />
+        </noscript>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -22,6 +22,33 @@ if (!window.matchMedia) {
   })) as unknown as typeof window.matchMedia
 }
 
+// jsdom implements no intersection logic either, so `IntersectionObserver` is
+// absent and any component that defers work until an element is near the
+// viewport throws on mount rather than failing an assertion.
+//
+// This one observes and never fires, which for a deferred image means the
+// not-yet-visible case — the same choice as `matchMedia` above, where the
+// default is the state a component starts in rather than the one it reaches. A
+// test that cares about what happens when the element does arrive drives the
+// callback itself; `listing-image.test.tsx` does, and that is the only way the
+// visible case should ever be reached, since a default that fired immediately
+// would make every deferral test pass without deferring anything.
+if (!window.IntersectionObserver) {
+  window.IntersectionObserver = class {
+    readonly root = null
+    readonly rootMargin = ''
+    readonly thresholds: readonly number[] = []
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+    takeRecords = () => []
+    constructor(
+      _callback: IntersectionObserverCallback,
+      _options?: IntersectionObserverInit,
+    ) {}
+  } as unknown as typeof window.IntersectionObserver
+}
+
 // Mock next/router
 vi.mock('next/router', () => ({
   useRouter: () => ({


### PR DESCRIPTION
Closes #230.

## What was wrong

The home page asked the optimiser for **18 images on first paint** while about three were on screen.

Every one of the twenty was already `loading="lazy"`. The markup was never wrong — `loading="lazy"` is a hint about a threshold the browser picks, not a viewport test, and Chrome's threshold measured **~3900px** here. At 1440x900 that reaches **4.3 viewports** down a 5038px document, so the browser fetched almost the entire page.

Each is a separate `sharp` decode-and-resize of a 1024px source:

| | before |
|---|---|
| Optimiser requests, 1440x900 | 18 of 20 |
| Optimiser requests, 390x844 | 9 |
| Per-image cost, 2-core server | 674ms min, **2343ms median**, 3253ms max |
| Unrelated navigation during them | **500ms** (78ms idle) |

In CI, where the browser, database and chat service share two vCPUs, that contention aborted a navigation outright and failed `browse.spec.ts` on #251 — `page.goto: net::ERR_ABORTED` after a 30s timeout. A first-time visitor gets the same thing, once; the cache hides it on every later visit, which is why nothing had caught it.

**So the defect is the count, not the cost per image.** Roughly 15 of the 18 were for cards nobody had scrolled to.

## What this does

An `IntersectionObserver` with a 1200px margin decides when a listing image is fetched.

| | before | after |
|---|---|---|
| Requests, 390x844 | 9 | **6** |
| Requests, 1440x900 | 18 | **9** |
| Deepest speculative fetch | 4.3 viewports | **1.4 viewports** |
| Navigation during in-flight jobs | 500ms | **121ms** |
| Document height | 5038px | 5038px |
| CLS | — | **0.000** |

**1200px, not 600.** The margin buys `1200 / v` seconds of lead at scroll speed `v`. At 600 with a 1000ms optimisation, 14 of 20 cards were still grey as they entered the viewport; on a phone at 2343ms, 14 never decoded while on screen at all.

**The first two categories stay eager and server-rendered.** A deferred image cannot be requested until the component hydrates — measured at +237ms unthrottled but **+2.0s at 6x CPU throttle**. Covering only the first category left six cards at 1440x2000 as empty boxes for that entire window before their request even started. With two, zero above-fold cards are still empty after 4s at every viewport tested up to 1440x2000.

**The reserved box and the loaded box are one element.** `next/image` renders with `color: transparent` and no background of its own, so hanging the tone on a placeholder that unmounts leaves the state a scrolling visitor actually sees — requested, not yet decoded — as a fully transparent gap. One element also keeps the document height identical and CLS at zero.

## What this gives up

Stated plainly, because they are real:

- **A deferred image is not in the server-rendered HTML.** `<noscript>` carries the unoptimised source for scripting-off, at roughly **12x the bytes** (5.1 MB against ~400 KB across the twenty cards). It does not cover scripting that loads and then *fails* — a blocked chunk leaves 17 of 20 cards as empty boxes. Filed as **#261**.
- **The box now assumes a square source.** The markup it replaces took its box from the source's own ratio. `config/catalogue_images.json` and `test_image_encoding.py` bound only the long edge, so a 1024x600 would letterbox with nothing turning red. All 853 catalogue sources are 1024x1024 today. Filed as **#262**.
- **`bg-zinc-200` is 1.22:1 and 1.15:1** against the two band colours, short of 1.4.11's 3:1. Deliberate: this is a transient state of an `alt=""` image whose card takes its name entirely from the link text, and a tone dark enough to pass would flash a heavy grey block on every ordinary load. Where that stops holding is the permanent case, which is #261.

## Scope

Home page only. The category grid is **worse** — measured at 21 of 21 requests on a 3965px document — and is filed as **#263**. It is out of this slice because its `priority={i < 3}` cutoff is an open question in #180, and answering both at once would tangle them. The spec header records that boundary.

## Verification

- **Red phase first.** The guard failed on the unfixed tree for the right reason: `18 optimiser requests for 20 cards before scrolling`, expected <= 8.
- `make -C apps/web ci` — exit 0: lint, both typechecks, **154/154** unit tests, production build.
- `make test-scripts` — 157/157.
- All **132 Playwright journeys** pass against a composed stack containing this change.
- Unit assertions demonstrated against deliberate mutations, each caught by exactly one: ignoring `eager`, moving the tone back onto an unmounting placeholder, and dropping the `rootMargin` argument.

`ui-review` exercised the rendered page at phone, tablet and desktop, at 1x and 2x, under injected optimiser latency and CPU throttling; its findings on the placeholder tone, the margin and the eager cutoff are what the three tuning decisions above came from. `verifier` caught that jsdom has no `IntersectionObserver`, which was breaking `page.test.tsx` — fixed with a polyfill beside the existing `matchMedia` one, deliberately one that observes and never fires, so a deferral test cannot pass without anything being deferred.

Refs #230, #261, #262, #263