### PR TITLE
chore(compose): publish ports off the contended defaults

### DIFF
--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -55,7 +55,7 @@ docker compose up -d --build db chat web
 
 Bring up `chat` alongside `db` and `web` whenever you start your own. `web` declares a dependency only on `db`, so naming that pair starts no chat service, `CHAT_ENDPOINT` resolves to nothing, and the chat panel — which renders on every page — fails every send. Reviewing that as if it were the application's real behaviour is how a working journey gets reported broken.
 
-Host ports 5432, 3000, and 8000 may already be taken by unrelated projects. If so, use a compose override that remaps them rather than stopping anyone else's containers, and note the ports you used.
+Host ports 3100, 8100, and 55432 may already be taken by unrelated projects. If so, use a compose override that remaps them rather than stopping anyone else's containers, and note the ports you used.
 
 Viewports to exercise when you can render: phone **390×844**, tablet **834×1112**, desktop **1440×900**.
 

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -58,7 +58,7 @@ Run them in that order, smoke then journeys, and pass `KEEP_STACK=1`. The smoke 
 
 `KEEP_STACK=1` is what makes a handover survive. Without it an `EXIT` trap runs `docker compose down --volumes`, taking the caller's stack and its seeded database with it — ordering does not save it, because the trap fires either way.
 
-Ports are where the two commands differ. `make test-e2e` goes wherever `E2E_BASE_URL` points, so a remapped stack is fine for it — measured, a stack on 3100 carrying the compose default `NEXTAUTH_URL` signs in and runs the profile journeys. `make e2e-smoke` cannot be aimed anywhere: it probes `http://127.0.0.1:3000` and `http://127.0.0.1:8000` literally.
+Ports are where the two commands differ. `make test-e2e` goes wherever `E2E_BASE_URL` points, so a remapped stack is fine for it — measured, a stack remapped off the published port while `NEXTAUTH_URL` still names the compose default signs in and runs the profile journeys. `make e2e-smoke` cannot be aimed anywhere: it probes `http://127.0.0.1:3100` and `http://127.0.0.1:8100` literally.
 
 So on a remapped handover, run the journeys against the URL you were given and report that the smoke was not run and why. Do not run it anyway. What it would do to the stack you were handed depends on which compose files resolve and which ports are already held, and the outcomes range from dropping the remapping under you to probing an unrelated project's containers and coming back green — so the one thing you cannot do is trust its verdict.
 
@@ -74,7 +74,7 @@ Report each of these explicitly. Say "none" where that is the truth.
 
 **Missing coverage.** Behaviour the change introduces or alters that no test exercises. Be specific about which behaviour, not "needs more tests". Pay attention to gaps this suite is structurally blind to: rendered appearance, container file layout, and anything only reachable through a route with dynamic segments.
 
-**Environment issues.** Missing tools, absent browsers, unset variables, ports already bound, Docker problems. Two known local constraints: host ports 5432 and 3000 may be occupied by unrelated projects, and `LLM_PROVIDER=local` in a local `.env` requires an Ollama that may not be installed — CI runs without `.env`, so compose falls back to `gcp`. Report a collision rather than stopping anyone else's containers.
+**Environment issues.** Missing tools, absent browsers, unset variables, ports already bound, Docker problems. Two known local constraints: host ports 3100, 8100 and 55432 may be occupied by unrelated projects, and `LLM_PROVIDER=local` in a local `.env` requires an Ollama that may not be installed — CI runs without `.env`, so compose falls back to `gcp`. Report a collision rather than stopping anyone else's containers.
 
 ## Output
 

--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,13 @@ NODE_ENV=development
 NEXTAUTH_SECRET=replace-with-random-secret
 
 # Public base URL for the web app.
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://localhost:3100
 
 # Web app database URL (host-local form for non-containerized web commands).
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/contoso-db?schema=public
+DATABASE_URL=postgresql://postgres:postgres@localhost:55432/contoso-db?schema=public
 
 # Web -> chat service endpoint used by /api/chat/service.
-CHAT_ENDPOINT=http://localhost:8000/api/create_response
+CHAT_ENDPOINT=http://localhost:8100/api/create_response
 
 # Web -> chat auth header value; "dummy" is fine for local/dev.
 CHAT_API_KEY=dummy
@@ -23,7 +23,7 @@ CHAT_API_KEY=dummy
 ENVIRONMENT=development
 
 # Allowed CORS origins for chat service (comma-separated).
-ALLOWED_ORIGINS=http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3100
 
 # Chat model provider: local or gcp.
 LLM_PROVIDER=local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,9 +322,16 @@ jobs:
       - name: Run end-to-end journeys
         if: always() && steps.run_smoke.outcome == 'success'
         env:
-          # Must match NEXTAUTH_URL in docker-compose.yml, or the session
-          # cookie is set for a different origin than the journeys browse.
-          E2E_BASE_URL: http://localhost:3000
+          # The port the composed `web` service publishes. It matches
+          # `NEXTAUTH_URL` in docker-compose.yml, but not because it has to:
+          # the claim this comment used to make — that a mismatch sets the
+          # session cookie for a different origin — is wrong, since cookies are
+          # not isolated by port (RFC 6265 section 8.5). Measured in #240: a
+          # stack remapped off the published port signs in and runs the
+          # journeys with `NEXTAUTH_URL` left behind. What a mismatch does
+          # break is sign-out, which no journey exercises. What this has to
+          # match is the port the stack actually answers on.
+          E2E_BASE_URL: http://localhost:3100
         run: make test-e2e
 
       - name: Upload journey failure artifacts
@@ -351,7 +358,7 @@ jobs:
 
           out_file = os.environ["OUT_FILE"]
           profile_label = os.environ["PROFILE_LABEL"]
-          url = "http://127.0.0.1:8000/health/dependencies"
+          url = "http://127.0.0.1:8100/health/dependencies"
 
           payload = None
           capture_error = None
@@ -579,7 +586,7 @@ jobs:
 
           out_file = os.environ["OUT_FILE"]
           profile_label = os.environ["PROFILE_LABEL"]
-          url = "http://127.0.0.1:8000/health/dependencies"
+          url = "http://127.0.0.1:8100/health/dependencies"
 
           payload = None
           capture_error = None

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "name": "Next.js: debug client-side",
       "type": "chrome",
       "request": "launch",
-      "url": "http://localhost:3000"
+      "url": "http://localhost:3100"
     },
     {
       "name": "Next.js: debug full stack",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,8 +191,8 @@ Follow these steps in order for every change.
    the last step that needs it, not after this one.
 
    Say the ports if they are not the defaults. `make test-e2e` follows
-   `E2E_BASE_URL` anywhere; `make e2e-smoke` probes `127.0.0.1:3000` and
-   `:8000` literally and cannot be aimed elsewhere, so it and a remapped stack
+   `E2E_BASE_URL` anywhere; `make e2e-smoke` probes `127.0.0.1:3100` and
+   `:8100` literally and cannot be aimed elsewhere, so it and a remapped stack
    do not mix. One of the ways they fail is a green smoke run against an
    unrelated project's containers, which is worse than a failure because
    nothing looks wrong. Exactly which way you get depends on which compose
@@ -254,7 +254,7 @@ Follow these steps in order for every change.
       `docker compose down --volumes` to drop the seeded database with it. Step
       7 hands its stack forward under `KEEP_STACK=1`, which disables the only
       teardown the workflow otherwise performs — so without this the containers
-      outlive the change and hold ports 3000, 5432, and 8000 against the next
+      outlive the change and hold ports 3100, 55432, and 8100 against the next
       one.
     - Push and create the pull request only after local verification and any
       required code review are complete.

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ e2e-smoke: | $(VENV_PYTHON) ## Run dockerized end-to-end smoke check (web -> cha
 	}; \
 	trap 'cleanup $$?' EXIT; \
 	CHAT_INSTALL_LOCAL_STACK="$(CHAT_INSTALL_LOCAL_STACK)" $(DOCKER_COMPOSE) up $(E2E_COMPOSE_UP_FLAGS) db chat web; \
-	$(PYTHON) $(E2E_SMOKE_SCRIPT) --web-url "http://127.0.0.1:3000" --chat-url "http://127.0.0.1:8000" --timeout $(E2E_SMOKE_TIMEOUT)
+	$(PYTHON) $(E2E_SMOKE_SCRIPT) --web-url "http://127.0.0.1:3100" --chat-url "http://127.0.0.1:8100" --timeout $(E2E_SMOKE_TIMEOUT)
 
 e2e-smoke-lite: ## Run dockerized contract smoke with minimal chat dependency profile
 	$(MAKE) e2e-smoke CHAT_INSTALL_LOCAL_STACK=0

--- a/README.md
+++ b/README.md
@@ -64,11 +64,25 @@ This runs the Web App, AI Chat Service, and Database in containers. The default 
     ```bash
     docker-compose up
     ```
-    - Web App: [http://localhost:3000](http://localhost:3000)
-    - Chat Service: [http://localhost:8000](http://localhost:8000)
+    - Web App: [http://localhost:3100](http://localhost:3100)
+    - Chat Service: [http://localhost:8100](http://localhost:8100)
 
 ### Option 2: Local Development (Hybrid)
 **Best for:** developing the Next.js application with hot-reloading.
+
+> **Updating existing env files.** The published host ports moved off the
+> contended defaults — web `3100`, chat `8100`, database `55432`. Neither
+> `.env` nor `services/chat/.env` is tracked, so older ones still name `3000`,
+> `8000` and `5432`, and every one of those fails by *reaching something else*
+> rather than by erroring: `CHAT_ENDPOINT` posts your `CHAT_API_KEY` to
+> whatever now owns the old port, and the chat service's `DATABASE_URL` runs
+> raw SQL against whatever owns `5432`.
+>
+> Re-copy both from their `.env.example`, or update `NEXTAUTH_URL`,
+> `CHAT_ENDPOINT`, `DATABASE_URL` and `ALLOWED_ORIGINS` by hand.
+> `make agent-doctor` names every drifted key, and `make bootstrap` runs it —
+> worth one of the two if you set this up before the ports moved.
+
 
 1.  **Start Database & Chat Service:**
     ```bash
@@ -97,6 +111,12 @@ This runs the Web App, AI Chat Service, and Database in containers. The default 
     ```bash
     npm run dev:web
     ```
+    - Web App: [http://localhost:3100](http://localhost:3100)
+
+    The dev server uses the same 3100 the composed `web` service publishes, so
+    `NEXTAUTH_URL` in `.env` is correct for both options. Running this *and*
+    the full `docker-compose up` at once is the one case where they collide —
+    Option 2 expects only `db` and `chat` in Docker.
 
 For a fresh Docker DB volume (schema + seed + chat reindex) use:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3100",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3100',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,24 @@
+# Published host ports are deliberately off the defaults: 3100, 8100 and 55432
+# rather than 3000, 8000 and 5432. Those three are the most contended ports a
+# developer machine has -- every other Next app wants 3000, every other Python
+# service 8000, every other Postgres 5432.
+#
+# This is not a tidiness preference. A collision on `db` is silent and
+# destructive rather than loud: contoso's own container cannot bind, so it
+# never starts, and every host-side Prisma command then resolves
+# `localhost:5432` to the *other* project's server. Measured on a developer
+# machine, a single `make migrate-deploy` created a full contoso schema inside
+# an unrelated project's Postgres, and `make docker-init-fresh` would have
+# seeded data into it. See #245.
+#
+# The left-hand number is the host's and is the only one that moved. Container
+# ports stay at the defaults, so `CHAT_ENDPOINT=http://chat:8000` and the
+# `db:5432` URLs below are unaffected -- they never leave the compose network.
 services:
   web:
     build: .
     ports:
-      - "3000:3000"
+      - "3100:3000"
     depends_on:
       db:
         condition: service_healthy
@@ -12,7 +28,21 @@ services:
       # a bare `docker compose up` have no secret, and every sign-in fails at
       # /api/auth/error rather than rejecting a credential.
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-local-development-only-not-a-real-secret}
-      - NEXTAUTH_URL=http://localhost:3000
+      # Follows the published host port, not the container's, because NextAuth
+      # builds absolute redirect URLs from it. `signOut()` in the header
+      # assigns `window.location.href` to a URL the server derives from this
+      # value, and the default redirect callback returns `baseUrl` whenever the
+      # requested origin does not match — origin includes the port. Leave this
+      # at 3000 while the stack answers on 3100 and signing out lands the user
+      # on a dead port, or on whatever else holds 3000.
+      #
+      # Not sign-in: `login/page.tsx` calls `signIn(..., { redirect: false })`
+      # and navigates itself, so that path never reads this. And not a cookie
+      # problem: cookies are not isolated by port (RFC 6265 section 8.5), so a
+      # mismatch cannot strip the session. `.claude/agents/verifier.md` records
+      # the measurement — a remapped stack still signs in and runs the
+      # journeys, which is exactly why sign-out is the flow to name here.
+      - NEXTAUTH_URL=http://localhost:3100
       - CHAT_ENDPOINT=http://chat:8000/api/create_response
       - CHAT_API_KEY=${CHAT_API_KEY:-dummy}
   db:
@@ -37,7 +67,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: contoso-db
     ports:
-      - "5432:5432"
+      - "55432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
   chat:
@@ -50,7 +80,7 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "8100:8000"
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/contoso-db
       - PROJECT_ID=${PROJECT_ID}

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -170,7 +170,7 @@ If smoke fails:
    `docker compose ps`
    `docker compose logs --no-color db chat web`
 5. retry smoke only:
-   `python scripts/e2e_smoke.py --web-url http://127.0.0.1:3000 --chat-url http://127.0.0.1:8000`
+   `python scripts/e2e_smoke.py --web-url http://127.0.0.1:3100 --chat-url http://127.0.0.1:8100`
 
 For full-profile failures:
 

--- a/scripts/agent_doctor.py
+++ b/scripts/agent_doctor.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parent.parent
 
+COMPOSE_FILE = ROOT / "docker-compose.yml"
 TOOLCHAIN_CHECK = ROOT / "scripts/check_toolchain.py"
 VENV_DIR = ROOT / ".venv"
 VENV_PYTHON = VENV_DIR / "bin/python"
@@ -25,6 +28,82 @@ WEB_PRISMA_PACKAGE = ROOT / "apps/web/node_modules/@prisma/client/index.js"
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT, check=False)
+
+
+def published_ports() -> dict[str, int]:
+    """`{service: host_port}` from docker-compose.yml, or `{}` if unreadable."""
+    if not COMPOSE_FILE.exists():
+        return {}
+    lines = COMPOSE_FILE.read_text(encoding="utf-8").splitlines()
+    starts = [i for i, line in enumerate(lines) if re.fullmatch(r"  (\w[\w-]*):\s*", line)]
+    ports: dict[str, int] = {}
+    for position, start in enumerate(starts):
+        name = lines[start].strip().rstrip(":")
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        for line in lines[start:end]:
+            match = re.fullmatch(r'\s*-\s*"(\d+):(\d+)"\s*', line)
+            if match:
+                ports[name] = int(match.group(1))
+                break
+    return ports
+
+
+# The env keys that name a host port, and the compose service each has to agree
+# with. `.env` is not tracked, so moving a published port in the repository
+# leaves every existing one behind — and each of these fails quietly rather
+# than loudly when it is stale: CHAT_ENDPOINT posts the request and its API key
+# to whatever now owns the old port, and NEXTAUTH_URL sends the browser off the
+# served port on sign-out. `docker-compose.yml` carries the detail. See #245.
+PORT_BEARING_KEYS = {
+    "NEXTAUTH_URL": "web",
+    "CHAT_ENDPOINT": "chat",
+    # chat's key, but it names the origin the browser is on, so it follows web.
+    "ALLOWED_ORIGINS": "web",
+    "DATABASE_URL": "db",
+}
+
+
+def ports_in(value: str) -> list[int]:
+    """Every host port a value names, across a comma-separated list.
+
+    `urlsplit` rather than a regex for the port: a DSN's password may start
+    with digits (`postgres:5up3r@localhost:55432`), and a non-greedy pattern
+    stops at those and reports a port that appears nowhere.
+    """
+    found = []
+    for element in value.split(","):
+        element = element.strip()
+        if not element:
+            continue
+        try:
+            port = urlsplit(element).port
+        except ValueError:
+            continue
+        if port is not None:
+            found.append(port)
+    return found
+
+
+def stale_port_keys(env: dict[str, str], ports: dict[str, int]) -> list[str]:
+    """Keys in `env` whose host port disagrees with what compose publishes.
+
+    A value naming several origins is stale only when *none* of them is the
+    published port, so adding a second origin does not start warning on the
+    order it was written in.
+    """
+    stale = []
+    for key, service in PORT_BEARING_KEYS.items():
+        value = env.get(key)
+        if not value:
+            continue
+        expected = ports.get(service)
+        if expected is None:
+            continue
+        found = ports_in(value)
+        if found and expected not in found:
+            named = ", ".join(f":{port}" for port in found)
+            stale.append(f"{key} names {named}, compose publishes :{expected}")
+    return stale
 
 
 def parse_env_file(path: Path) -> dict[str, str]:
@@ -155,6 +234,15 @@ def main() -> int:
         if root_env.get("NEXTAUTH_SECRET") in {"replace-with-random-secret", "your-secret"}:
             warnings.append("NEXTAUTH_SECRET appears to be a template value.")
 
+        stale = stale_port_keys(root_env, published_ports())
+        if stale:
+            warnings.append(
+                ".env host ports disagree with docker-compose.yml — "
+                + "; ".join(stale)
+                + ". Update .env against .env.example; a stale port reaches "
+                "whatever else owns it rather than failing.",
+            )
+
     if not CHAT_ENV.exists():
         failures.append(
             (
@@ -177,6 +265,19 @@ def main() -> int:
             )
         else:
             passes.append("Chat .env contains required service keys.")
+
+        # Checked here too, not only for the root file. `services/chat/.env` is
+        # what `load_dotenv()` finds when the service runs from its own
+        # directory, and its `DATABASE_URL` reaches Postgres through
+        # hand-written asyncpg queries rather than Prisma — so a stale port
+        # runs raw SQL against whatever else owns it.
+        stale_chat = stale_port_keys(chat_env, published_ports())
+        if stale_chat:
+            warnings.append(
+                "services/chat/.env host ports disagree with docker-compose.yml — "
+                + "; ".join(stale_chat)
+                + ". Update it against services/chat/.env.example.",
+            )
 
     # Web dependencies and generated Prisma client
     if WEB_NODE_MODULES.exists():

--- a/scripts/e2e_smoke.py
+++ b/scripts/e2e_smoke.py
@@ -20,8 +20,8 @@ class NonRetryableSmokeError(RuntimeError):
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--web-url", default="http://127.0.0.1:3000", help="Base URL for web app.")
-    parser.add_argument("--chat-url", default="http://127.0.0.1:8000", help="Base URL for chat service.")
+    parser.add_argument("--web-url", default="http://127.0.0.1:3100", help="Base URL for web app.")
+    parser.add_argument("--chat-url", default="http://127.0.0.1:8100", help="Base URL for chat service.")
     parser.add_argument("--timeout", type=int, default=240, help="Total timeout in seconds.")
     parser.add_argument("--interval", type=float, default=2.0, help="Polling interval in seconds.")
     return parser.parse_args()

--- a/services/chat/.env.example
+++ b/services/chat/.env.example
@@ -6,10 +6,10 @@
 ENVIRONMENT=development
 
 # Allowed CORS origins (comma-separated).
-ALLOWED_ORIGINS=http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3100
 
 # Shared database URL (same Prisma schema as web app).
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/contoso-db
+DATABASE_URL=postgresql://postgres:postgres@localhost:55432/contoso-db
 
 # Provider selection: local or gcp.
 LLM_PROVIDER=local

--- a/services/chat/AGENTS.md
+++ b/services/chat/AGENTS.md
@@ -81,7 +81,7 @@ Most common local values:
 
 - `LLM_PROVIDER=local`
 - `OLLAMA_BASE_URL=http://localhost:11434`
-- `ALLOWED_ORIGINS=http://localhost:3000`
+- `ALLOWED_ORIGINS=http://localhost:3100`
 
 ## Database access
 

--- a/services/chat/Makefile
+++ b/services/chat/Makefile
@@ -78,8 +78,8 @@ diagnose-chat-local: ## Print local-provider diagnostics (checks + health endpoi
 	@echo ""
 	@echo "-- /health/dependencies snapshot --"
 	@if command -v curl >/dev/null 2>&1; then \
-		curl --silent --show-error --max-time 8 "http://127.0.0.1:8000/health/dependencies" || \
-		echo "Chat service not reachable at http://127.0.0.1:8000"; \
+		curl --silent --show-error --max-time 8 "http://127.0.0.1:8100/health/dependencies" || \
+		echo "Chat service not reachable at http://127.0.0.1:8100 (the composed stack). A locally run \`make dev\` serves 8000 instead."; \
 	else \
 		echo "curl not found; skipping endpoint snapshot."; \
 	fi

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -42,9 +42,17 @@ make local-provider-check # preflight for LLM_PROVIDER=local
 make diagnose-chat-local # full local diagnostics from repo root
 ```
 
-Service endpoint: `http://localhost:8000`
+Service endpoint: `http://localhost:8100`
 
 ### Option 2: Run directly with Python
+
+> **If you set this up before the published ports moved:** `services/chat/.env`
+> is not tracked, so an older one still points `DATABASE_URL` at `5432` and
+> `ALLOWED_ORIGINS` at `3000`. The service runs hand-written asyncpg queries,
+> so a stale port runs them against whatever else owns it rather than failing.
+> Re-copy from `.env.example`, or run `make agent-doctor` from the repository
+> root to see which keys drifted.
+
 
 1. Install pinned tool versions (from repository root):
 

--- a/services/chat/src/api/main.py
+++ b/services/chat/src/api/main.py
@@ -72,7 +72,7 @@ async def log_requests(request: Request, call_next):
     return response
 
 # CORS middleware - restrict to known origins
-_allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+_allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3100").split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,

--- a/tests/scripts/AGENTS.md
+++ b/tests/scripts/AGENTS.md
@@ -35,6 +35,15 @@ constant the demonstrated assertion reaches:
   and `REPO_ROOT`, which it walks for references.
 - `test_page_headings.py` reads `REPO_ROOT` directly for component-supplied headings,
   so rebinding `APP_DIR` alone leaves that assertion pointed at the checkout.
+- `test_published_ports.py` needs both `REPO_ROOT`, which `read()` resolves every
+  coupled file through, and `COMPOSE`, which the port parser opens directly.
+  Rebinding one leaves half the comparison pointed at the checkout, and the halves
+  agreeing is the whole assertion.
+- `test_agent_doctor.py` loads `scripts/agent_doctor.py` as a module, so the
+  constants to rebind are that module's `COMPOSE_FILE`, `ROOT_ENV` and `CHAT_ENV` —
+  not this file's `REPO_ROOT`, which only locates the script to load. Its
+  `stale_port_keys` tests take their inputs as arguments and reach no path at all,
+  which is the reason they are shaped that way.
 
 Confirm the run opened the fixture with a failure that names a fixture path or a
 vacuity guard whose count matches what the fixture contains. The count is the

--- a/tests/scripts/test_agent_doctor.py
+++ b/tests/scripts/test_agent_doctor.py
@@ -1,0 +1,140 @@
+"""Guard `agent_doctor`'s port-drift detection.
+
+`.env` is not tracked, so moving a published port in the repository leaves
+every existing one behind. The keys that carry a port fail by *reaching
+something else* rather than by erroring — `CHAT_ENDPOINT` posts the request and
+its API key to whatever now owns the old port, and `services/chat/.env`'s
+`DATABASE_URL` runs hand-written asyncpg queries against whatever owns 5432.
+That is what this detection exists for, and it is worth testing because it is
+the only thing standing between a stale file and a silent wrong target.
+
+Two shapes of assertion here:
+
+- Table tests over `stale_port_keys`, which is a pure function of two dicts.
+  These are what catch parsing mistakes; the first version of it read a DSN's
+  digit-leading password as the port.
+- One vacuity assertion that `published_ports()` parses the real compose file
+  non-empty. That is the important one: this parser **fails open**. If the
+  compose format drifts, it returns `{}`, every key is skipped, and the warning
+  silently stops existing rather than going red. `test_published_ports.py`
+  carries a second copy of the same parser whose failure is loud, so without
+  this assertion the two could diverge with only the quiet one left standing.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_agent_doctor():
+    spec = importlib.util.spec_from_file_location(
+        "agent_doctor", REPO_ROOT / "scripts/agent_doctor.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+doctor = load_agent_doctor()
+
+PORTS = {"web": 3100, "chat": 8100, "db": 55432}
+
+
+class PortsInTests(unittest.TestCase):
+    def test_reads_the_port_not_a_digit_leading_password(self):
+        """The mistake the first implementation made.
+
+        A non-greedy `://.*?:(\\d+)` stops at the password and reports `:5`,
+        which appears nowhere in the value.
+        """
+        dsn = "postgresql://postgres:5up3rs3cret@localhost:55432/contoso-db"
+        self.assertEqual(doctor.ports_in(dsn), [55432])
+
+    def test_reads_every_element_of_a_comma_separated_list(self):
+        origins = "http://localhost:5173,http://localhost:3100"
+        self.assertEqual(doctor.ports_in(origins), [5173, 3100])
+
+    def test_a_value_naming_no_port_yields_none(self):
+        self.assertEqual(doctor.ports_in("postgresql://user:pass@localhost/db"), [])
+        self.assertEqual(doctor.ports_in("https://example.com"), [])
+
+    def test_an_unparseable_value_is_skipped_rather_than_raising(self):
+        self.assertEqual(doctor.ports_in("http://localhost:not-a-port"), [])
+        self.assertEqual(doctor.ports_in(""), [])
+
+
+class StalePortKeyTests(unittest.TestCase):
+    def test_a_stale_file_names_every_drifted_key(self):
+        env = {
+            "NEXTAUTH_URL": "http://localhost:3000",
+            "CHAT_ENDPOINT": "http://localhost:8000/api/create_response",
+            "ALLOWED_ORIGINS": "http://localhost:3000",
+            "DATABASE_URL": "postgresql://postgres:postgres@localhost:55432/contoso-db",
+        }
+        stale = doctor.stale_port_keys(env, PORTS)
+        self.assertEqual(len(stale), 3)
+        self.assertTrue(any("NEXTAUTH_URL names :3000" in item for item in stale))
+        self.assertTrue(any("CHAT_ENDPOINT names :8000" in item for item in stale))
+        # Already migrated, so it must not be reported.
+        self.assertFalse(any("DATABASE_URL" in item for item in stale))
+
+    def test_a_current_file_reports_nothing(self):
+        env = {
+            "NEXTAUTH_URL": "http://localhost:3100",
+            "CHAT_ENDPOINT": "http://localhost:8100/api/create_response",
+            "ALLOWED_ORIGINS": "http://localhost:3100",
+            "DATABASE_URL": "postgresql://postgres:postgres@localhost:55432/contoso-db",
+        }
+        self.assertEqual(doctor.stale_port_keys(env, PORTS), [])
+
+    def test_a_list_containing_the_published_port_is_not_stale(self):
+        """Order must not decide the verdict.
+
+        Warning on the first element alone makes the check sensitive to where
+        someone happened to add a second origin.
+        """
+        env = {"ALLOWED_ORIGINS": "http://localhost:5173,http://localhost:3100"}
+        self.assertEqual(doctor.stale_port_keys(env, PORTS), [])
+
+    def test_a_list_containing_none_of_them_is_stale(self):
+        env = {"ALLOWED_ORIGINS": "http://localhost:5173,http://localhost:3000"}
+        self.assertEqual(len(doctor.stale_port_keys(env, PORTS)), 1)
+
+    def test_absent_keys_and_absent_ports_are_skipped(self):
+        self.assertEqual(doctor.stale_port_keys({}, PORTS), [])
+        self.assertEqual(doctor.stale_port_keys({"FOO": "bar"}, PORTS), [])
+        # No compose ports parsed: nothing to compare against, so nothing said.
+        self.assertEqual(
+            doctor.stale_port_keys({"NEXTAUTH_URL": "http://localhost:3000"}, {}),
+            [],
+        )
+
+    def test_a_portless_value_is_not_reported(self):
+        env = {"DATABASE_URL": "postgresql://postgres:postgres@localhost/contoso-db"}
+        self.assertEqual(doctor.stale_port_keys(env, PORTS), [])
+
+
+class PublishedPortParseTests(unittest.TestCase):
+    def test_the_real_compose_file_parses_non_empty(self):
+        """The fail-open guard.
+
+        Every assertion above is about a function that is only reached when
+        this parser returns something. If compose's formatting drifts past the
+        parser, it returns `{}` and the whole check quietly becomes a no-op —
+        so this is asserted against the real file rather than a fixture.
+        """
+        ports = doctor.published_ports()
+        self.assertEqual(
+            set(ports),
+            {"web", "chat", "db"},
+            f"parsed {ports} from the real docker-compose.yml; the drift "
+            f"warning is a no-op whenever this is empty",
+        )
+        for service, port in ports.items():
+            self.assertIsInstance(port, int, f"{service} port is not an int")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_published_ports.py
+++ b/tests/scripts/test_published_ports.py
@@ -1,0 +1,201 @@
+"""Guard the published host ports and everything that has to agree with them.
+
+A published port is not one number in one file. `docker-compose.yml` decides
+what the host can reach, and at least six other places have to name the same
+number or the stack is subtly wrong rather than obviously broken:
+
+- `NEXTAUTH_URL` is what NextAuth builds absolute redirect URLs from. Leave it
+  behind and *sign-out* sends the browser to a port nothing serves, because
+  `signOut()` assigns `window.location.href` from a server-derived URL that
+  falls back to this value's origin. Sign-in is unaffected -- the login page
+  passes `redirect: false` and navigates itself -- and it is not a cookie
+  problem either, since cookies are not isolated by port (RFC 6265 s8.5).
+- `make e2e-smoke` and `scripts/e2e_smoke.py` probe literal addresses and
+  cannot be aimed elsewhere, so a stale one reports a healthy stack that is
+  not the stack, or a dead one that is running.
+- CI's `E2E_BASE_URL` and Playwright's default aim the journeys.
+
+None of those fails loudly on drift, which is why they are asserted together
+here rather than left to whoever moves a port next.
+
+The ports themselves are read out of `docker-compose.yml` rather than written
+down here, so this measures *agreement* — the property that matters — instead
+of restating one number in an eighth place. What is pinned is the separate
+claim the move was made for: that none of them is the contended default.
+
+`yaml` is deliberately not imported: CI's script-test job builds a bare
+virtualenv, so a third-party import passes locally and fails there.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = REPO_ROOT / "docker-compose.yml"
+
+# The ports every other project on a developer machine wants. Moving off these
+# is the whole point of the arrangement this guards; see #245 for the incident.
+CONTENDED = {"web": 3000, "chat": 8000, "db": 5432}
+
+
+def read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def published_ports() -> dict[str, tuple[int, int]]:
+    """`{service: (host_port, container_port)}` from the compose file.
+
+    Slices on the top-level service keys rather than matching `"N:M"` anywhere,
+    so a port that appears in a comment or an environment value cannot be
+    mistaken for a published mapping.
+    """
+    lines = COMPOSE.read_text(encoding="utf-8").splitlines()
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if re.fullmatch(r"  (\w[\w-]*):\s*", line)
+    ]
+    ports: dict[str, tuple[int, int]] = {}
+    for position, start in enumerate(starts):
+        name = lines[start].strip().rstrip(":")
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        for line in lines[start:end]:
+            match = re.fullmatch(r'\s*-\s*"(\d+):(\d+)"\s*', line)
+            if match:
+                ports[name] = (int(match.group(1)), int(match.group(2)))
+                break
+    return ports
+
+
+class PublishedPortTests(unittest.TestCase):
+    def setUp(self):
+        self.ports = published_ports()
+
+    def test_every_service_publishes_a_port(self):
+        """Vacuity guard: a parse that finds nothing satisfies every claim below."""
+        self.assertEqual(
+            set(self.ports),
+            {"web", "chat", "db"},
+            f"parsed published ports {self.ports} out of {COMPOSE}",
+        )
+
+    def test_published_ports_are_off_the_contended_defaults(self):
+        for service, default in CONTENDED.items():
+            host, _ = self.ports[service]
+            self.assertNotEqual(
+                host,
+                default,
+                f"{service} publishes the contended default {default}. Another "
+                f"project on the same machine takes it and this stack either "
+                f"fails to bind or, for db, silently resolves to their server "
+                f"(#245).",
+            )
+
+    def test_container_ports_stay_on_the_defaults(self):
+        """The move is host-side only.
+
+        Container ports are what `CHAT_ENDPOINT=http://chat:8000` and the
+        `db:5432` URLs inside the compose network resolve to. Moving one of
+        those breaks service-to-service traffic while every host-side check
+        here keeps passing, so it is asserted rather than assumed.
+        """
+        for service, default in CONTENDED.items():
+            _, container = self.ports[service]
+            self.assertEqual(
+                container,
+                default,
+                f"{service}'s container port moved to {container}; the compose "
+                f"network addresses it by the default {default}",
+            )
+
+    def test_nextauth_url_names_the_published_web_port(self):
+        host, _ = self.ports["web"]
+        for source in ("docker-compose.yml", ".env.example"):
+            content = read(source)
+            match = re.search(r"NEXTAUTH_URL=http://localhost:(\d+)", content)
+            self.assertIsNotNone(match, f"no NEXTAUTH_URL found in {source}")
+            self.assertEqual(
+                int(match.group(1)),
+                host,
+                f"{source} names a port the stack does not answer on, so a "
+                f"NextAuth-driven redirect — sign-out is the reachable one — "
+                f"sends the browser somewhere nothing is served",
+            )
+
+    def test_smoke_probes_the_published_ports(self):
+        web, _ = self.ports["web"]
+        chat, _ = self.ports["chat"]
+        makefile = read("Makefile")
+        self.assertIn(f'--web-url "http://127.0.0.1:{web}"', makefile)
+        self.assertIn(f'--chat-url "http://127.0.0.1:{chat}"', makefile)
+
+        smoke = read("scripts/e2e_smoke.py")
+        self.assertIn(f'default="http://127.0.0.1:{web}"', smoke)
+        self.assertIn(f'default="http://127.0.0.1:{chat}"', smoke)
+
+    def test_journeys_are_aimed_at_the_published_web_port(self):
+        host, _ = self.ports["web"]
+        self.assertIn(f"E2E_BASE_URL: http://localhost:{host}", read(".github/workflows/ci.yml"))
+        self.assertIn(
+            f"'http://localhost:{host}'",
+            read("apps/web/playwright.config.ts"),
+        )
+
+    def test_the_dev_server_uses_the_same_port_as_the_composed_web_service(self):
+        """The hybrid flow reads the same `.env`, so it needs the same port.
+
+        `.env.example` has one `NEXTAUTH_URL`, and both options in the README
+        use it: Option 1 runs `web` in Docker, Option 2 runs `next dev` against
+        a Dockerised `db` and `chat`. Before the ports moved, one number served
+        both because `next dev` and compose happened to share 3000. Moving only
+        compose splits them, and the half that breaks is the quiet one --
+        `next dev` serves 3000 and NextAuth's redirects point at a 3100 that
+        nothing is serving, which surfaces on sign-out rather than sign-in.
+
+        It would also have left the dev server holding the contended port this
+        whole change exists to give up.
+        """
+        host, _ = self.ports["web"]
+        dev = re.search(r'"dev":\s*"next dev([^"]*)"', read("apps/web/package.json"))
+        self.assertIsNotNone(dev, "no `dev` script found in apps/web/package.json")
+        port = re.search(r"-p\s+(\d+)", dev.group(1))
+        self.assertIsNotNone(
+            port,
+            f"`next dev` names no port, so it serves Next's default 3000 while "
+            f"compose publishes {host}",
+        )
+        self.assertEqual(int(port.group(1)), host)
+
+    def test_host_side_chat_endpoint_names_the_published_chat_port(self):
+        """The third host-side coupling, and the one that carries a credential.
+
+        `apps/web/src/app/api/chat/service/route.ts` reads `CHAT_ENDPOINT` with
+        no fallback and posts to it with `CHAT_API_KEY` attached. In the hybrid
+        flow that value comes from `.env`, so a stale port sends the request and
+        the key to whatever else owns the old one — which on the machine that
+        prompted this change is another project's service. It fails by
+        succeeding against the wrong server, so nothing else here would notice.
+        """
+        host, _ = self.ports["chat"]
+        match = re.search(r"CHAT_ENDPOINT=http://localhost:(\d+)", read(".env.example"))
+        self.assertIsNotNone(match, "no host-side CHAT_ENDPOINT in .env.example")
+        self.assertEqual(int(match.group(1)), host)
+
+    def test_host_side_database_url_names_the_published_db_port(self):
+        host, _ = self.ports["db"]
+        for source in (".env.example", "services/chat/.env.example"):
+            content = read(source)
+            match = re.search(r"DATABASE_URL=postgresql://[^@]+@localhost:(\d+)/", content)
+            self.assertIsNotNone(match, f"no host-side DATABASE_URL in {source}")
+            self.assertEqual(
+                int(match.group(1)),
+                host,
+                f"{source} points host-side Prisma at a port this stack does "
+                f"not publish. On a machine where something else holds it, that "
+                f"is another project's database (#245)",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #245. Closes #240.

## Why

Another project on this machine wants 3000, 8000 and 5432 — and every developer machine has something that does.

The `db` collision is not a loud one. contoso's container cannot bind, so it never starts, and every host-side Prisma command then resolves `localhost:5432` to **the other project's server**. #245 measured it: a single `make migrate-deploy` created a full contoso schema inside an unrelated project's Postgres, and `make docker-init-fresh` would have seeded data into it.

| | before | after |
|---|---|---|
| web | `3000:3000` | **`3100:3000`** |
| chat | `8000:8000` | **`8100:8000`** |
| db | `5432:5432` | **`55432:5432`** |

**Only the host side moved.** Container ports stay at the defaults, so `CHAT_ENDPOINT=http://chat:8000` and the `db:5432` URLs inside the compose network are untouched.

## A published port is not one number

The places coupled to it fail by *reaching something else* rather than by erroring, so they move together:

- **`NEXTAUTH_URL`** — what NextAuth builds absolute redirect URLs from. A stale one lands **sign-out** on a dead port. Not sign-in: `login/page.tsx` passes `redirect: false` and navigates itself. And not the session cookie, which is not isolated by port at all.
- **The smoke probes** in `Makefile` and `scripts/e2e_smoke.py` are literal and cannot be aimed elsewhere, so a stale one reports a healthy stack that is not the stack, or a dead one that is running.
- **`CHAT_ENDPOINT`** — `route.ts` reads it with no fallback and posts with `CHAT_API_KEY` attached.
- Plus `ALLOWED_ORIGINS`, CI's `E2E_BASE_URL`, Playwright's default, CI's chat health probes, and the docs and agent runbooks.

`tests/scripts/test_published_ports.py` reads the ports out of compose and asserts the rest agree, rather than writing 3100 down a ninth time. Nine assertions, demonstrated against a fixture tree for every drift mode including **moving the container port instead of the host port**.

## The dev server moved too

`apps/web/package.json` is now `next dev -p 3100`. Leaving it on 3000 would have made every file agree while contoso still held the port this change exists to give up — a fix that passes its own guard and solves nothing. Verified live: the dev server answers on 3100 and **3000 answers nothing**.

## Existing `.env` files cannot be migrated by a commit

Neither `.env` nor `services/chat/.env` is tracked, so this change cannot fix them — and a stale `CHAT_ENDPOINT` posts the request and its API key to whatever now owns 8000.

`make agent-doctor` now names every drifted key in **both** files. The chat one matters more: it is what `load_dotenv()` finds when the service runs from its own directory, and those queries are hand-written **asyncpg rather than Prisma**, so a stale port runs raw SQL against someone else's database. Both READMEs carry a migration note, placed in the flow that actually reads each file.

## Also fixes a false claim

`.github/workflows/ci.yml` said `E2E_BASE_URL` must match `NEXTAUTH_URL` "or the session cookie is set for a different origin". Cookies are not port-scoped (RFC 6265 §8.5), and #240 measured a remapped stack signing in fine. Corrected there and in the four places I had initially repeated the same misconception.

## Deliberately unchanged

Container-internal ports: `.devcontainer` `forwardPorts`, `Dockerfile` `EXPOSE 3000`/`PORT=3000`, `apps/web`'s `start` script. Local processes: chat's `uvicorn --port 8000`. Different things entirely: `docs/DATABASE.md` and `dev_db_proxy.sh` (Cloud SQL Auth Proxy), Terraform's Cloud Run `container_port`, and fixture DSNs in tests.

## Verification

Five rounds. `make ci` exit 0; `make test-scripts` **177/177**; the full **130-journey** suite against a composed stack on the new ports; `make e2e-smoke` passing; `auth.spec.ts` 5/5 — which proves the auth coupling end to end rather than merely consistent; `make docker-init-fresh` correctly deriving 55432 and seeding the right database; hybrid `next dev` verified live.

## Filed, not fixed here

#262 (nothing enforces square catalogue images), #263 (the category grid's own optimiser contention), #265 (`next dev` writes into `apps/web/AGENTS.md`), #266 (`scripts/*.py` outside every lint gate), #267 (does the devcontainer still work?).

Refs #245, #240