### PR TITLE
fix(tooling): make the local development path do what it says

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,10 @@ docs/workshop/site
 # apps/web/package-lock.json. Anchored so that one, which the exception above
 # deliberately keeps, stays tracked.
 /package-lock.json
+
+# Machine-local compose overrides. `docker compose` auto-loads this file without
+# being asked, so a committed one applies to everyone and to CI silently — which
+# is worse than no override at all. It is the standard way to carry a port remap
+# around a collision on a shared machine, so it wants ignoring rather than
+# discouraging. Anchored to the root, where compose looks for it. See #247.
+/docker-compose.override.yml

--- a/apps/web/Makefile
+++ b/apps/web/Makefile
@@ -13,8 +13,14 @@ setup: ## Install web dependencies and generate Prisma client
 	$(NPM) ci --workspaces=false --include=dev --no-audit --no-fund
 	$(MAKE) prisma-generate
 
+# `../../.env`, not `../.env`. The recipe runs with apps/web as its working
+# directory, so `../.env` is `apps/.env` — a file that has never existed,
+# because `apps/` holds only `web/`. The `-f` guard then made it silent: the
+# whole body sat behind a condition that was always false, so it exited 0 and
+# printed nothing on every run, and a missing root .env looked identical to a
+# wrong path. See #212.
 sync-env: ## Sync repo root .env into apps/web/.env when present
-	@if [ -f ../.env ]; then cp ../.env .env; fi
+	@if [ -f ../../.env ]; then cp ../../.env .env; fi
 
 dev: ## Run web app locally with hot reload
 	$(MAKE) sync-env

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -36,11 +36,6 @@ const nextConfig = {
     // !! WARN !!
     ignoreBuildErrors: false,
   },
-  eslint: {
-    // Warning: This allows production builds to successfully complete even if
-    // your project has ESLint errors.
-    ignoreDuringBuilds: false,
-  },
 }
 
 module.exports = nextConfig

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -34,7 +34,7 @@ Access the private database locally using the **Cloud SQL Proxy**.
 With the proxy running, set your `DATABASE_URL` and execute:
 ```bash
 export DATABASE_URL="postgresql://prismauser:<password>@localhost:5432/contoso-db"
-cd apps/web && npx prisma migrate dev --schema prisma/schema.prisma
+cd apps/web && npx prisma migrate dev --name <migration-name> --schema prisma/schema.prisma
 ```
 
 ### 3. Database Tools (psql, pgAdmin)

--- a/tests/scripts/test_local_dev_surface.py
+++ b/tests/scripts/test_local_dev_surface.py
@@ -1,0 +1,224 @@
+"""Guard the local development surface against defects that pass silently.
+
+The three things asserted here had one property in common before they were
+fixed: none of them could fail. `sync-env`'s whole body sat behind a path test
+that was always false, so it exited 0 and printed nothing on every run for as
+long as it has existed. A `docker-compose.override.yml` that is not ignored
+looks exactly like one that is, until someone commits it. A `prisma migrate
+dev` with no `--name` looks fine until the schema has actually changed, and
+then it blocks on a prompt no non-TTY can answer and exits 130 — a
+cancellation, not a missing argument.
+
+So each assertion here measures the effect rather than the text:
+
+- `sync-env` is **run**, in a fixture tree, and the copied file is compared to
+  the original. Separately its source path is **resolved** from the directory
+  the recipe runs in, because `../.env` and `../../.env` are both plausible
+  strings and only one names a file that exists — that one gives the useful
+  failure message, and the execution catches the mistakes a parse cannot see.
+- `git check-ignore` is asked whether the override is ignored, rather than
+  `.gitignore` being grepped for a line that could be anchored wrong, negated
+  later, or shadowed;
+- every `npx prisma migrate dev` in tracked documentation is checked, not the
+  one file that happened to be wrong, and not only the ones inside fences.
+
+Not covered: the unsupported `eslint` key removed from `next.config.js` at the
+same time. Asserting a key is absent is a declaration check, and the thing that
+actually reports it is `next build`, which CI already runs — the key never
+enforced anything, since lint runs as its own step.
+"""
+
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEB_DIR = REPO_ROOT / "apps/web"
+WEB_MAKEFILE = WEB_DIR / "Makefile"
+OVERRIDE = "docker-compose.override.yml"
+
+
+def sync_env_sources() -> list[str]:
+    """Every path the `sync-env` recipe reads, as written in the Makefile."""
+    lines = WEB_MAKEFILE.read_text(encoding="utf-8").splitlines()
+    body: list[str] = []
+    inside = False
+    for line in lines:
+        if line.startswith("sync-env:"):
+            inside = True
+            continue
+        if inside:
+            # A recipe line is tab-indented; anything else ends the target.
+            if not line.startswith("\t"):
+                break
+            body.append(line)
+    return re.findall(r"(\.\.[./]*\.env)", "\n".join(body))
+
+
+def tracked_docs() -> list[Path]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [REPO_ROOT / name for name in listed.stdout.split()]
+
+
+class SyncEnvTests(unittest.TestCase):
+    def test_the_recipe_reads_a_path(self):
+        """Vacuity guard: an empty parse satisfies the resolution check below."""
+        self.assertTrue(
+            sync_env_sources(),
+            f"parsed no .env path out of sync-env in {WEB_MAKEFILE}",
+        )
+
+    def test_every_source_resolves_to_the_repo_root_env(self):
+        """Resolved, not matched.
+
+        The recipe runs with `apps/web` as its working directory, so the string
+        is only correct relative to that. `../.env` resolves to `apps/.env`,
+        which has never existed — and because the recipe guards on `-f`, that
+        wrong path and an absent root `.env` produce identical output.
+        """
+        for source in sync_env_sources():
+            resolved = (WEB_DIR / source).resolve()
+            self.assertEqual(
+                resolved,
+                (REPO_ROOT / ".env").resolve(),
+                f"sync-env reads {source!r}, which from {WEB_DIR.name} resolves "
+                f"to {resolved} rather than the repo root .env. The `-f` guard "
+                f"makes that silent (#212).",
+            )
+
+
+class SyncEnvExecutionTests(unittest.TestCase):
+    """Run the real recipe, rather than reading it.
+
+    The parse above catches the class of bug that was actually there — a path
+    correct from the wrong directory. It cannot catch the next one: a quoting
+    mistake, a `make` variable that expands to nothing, a `cp` whose argument
+    order slipped. Those all leave a recipe that reads correctly and copies
+    nothing, which is precisely the failure `sync-env` already had once.
+
+    `apps/web/Makefile` has no `include` and no state outside itself, so it can
+    be copied into a fixture tree and invoked there. Nothing here touches the
+    checkout.
+    """
+
+    def run_sync_env(self, root: Path) -> subprocess.CompletedProcess[str]:
+        web = root / "apps/web"
+        web.mkdir(parents=True)
+        shutil.copy(WEB_MAKEFILE, web / "Makefile")
+        return subprocess.run(
+            ["make", "sync-env"],
+            cwd=web,
+            capture_output=True,
+            text=True,
+            # Nothing in the recipe can block on input, so this should never
+            # fire. It is here so that if it ever does — a shell rc doing
+            # something unexpected under `SHELL := /bin/bash`, say — the test
+            # fails with a timeout rather than consuming the job's budget.
+            timeout=60,
+        )
+
+    def test_it_copies_the_repo_root_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env").write_text("MARKER=from-repo-root\n", encoding="utf-8")
+
+            result = self.run_sync_env(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            copied = root / "apps/web/.env"
+            self.assertTrue(
+                copied.exists(),
+                "sync-env exited 0 without copying anything — which is exactly "
+                "how the `../.env` bug looked for as long as it existed (#212)",
+            )
+            self.assertEqual(copied.read_text(encoding="utf-8"), "MARKER=from-repo-root\n")
+
+    def test_it_stays_quiet_when_there_is_no_root_env(self):
+        """The `-f` guard's legitimate case, which is why it is there.
+
+        CI creates no `.env`, so the target has to be a no-op rather than a
+        failure. Asserted so that a future fix for the silence above cannot
+        turn this into a hard error.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = self.run_sync_env(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((root / "apps/web/.env").exists())
+
+
+class ComposeOverrideTests(unittest.TestCase):
+    def test_a_local_compose_override_is_ignored(self):
+        """Asked of git, not of `.gitignore`.
+
+        `docker compose` auto-loads this file, so a committed one applies to
+        everyone and to CI without being asked for. Grepping `.gitignore` would
+        pass on a pattern that is anchored wrong or negated further down; git
+        is the tool that decides.
+
+        This covers more than the pattern: `git check-ignore` reports a tracked
+        path as *not* ignored even when a matching rule exists, so an override
+        that was force-added fails here too, which is the case that actually
+        hurts.
+        """
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", OVERRIDE],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"git does not ignore {OVERRIDE}, so a machine-local override can "
+            f"be committed and will then apply to everyone and to CI (#247)",
+        )
+
+
+class MigrateCommandTests(unittest.TestCase):
+    def test_documented_migrate_dev_commands_name_the_migration(self):
+        """Keyed on `npx`, which is what separates a command from a mention.
+
+        Prose refers to the command by name too — `docs/DATABASE.md` explains
+        that seeding runs "during `prisma migrate dev`" — and appending
+        `--name` to a sentence would be nonsense. An earlier version of this
+        excluded prose by only reading fenced blocks, which also excluded
+        `CONTRIBUTING.md`'s invocation: it is runnable, carries `--name`, and
+        lives in an inline code span. Keying on the invocation form admits all
+        three real commands and still leaves the sentence out, because the
+        sentence names the subcommand without ever invoking it.
+        """
+        offenders = []
+        seen = 0
+        for doc in tracked_docs():
+            for line in doc.read_text(encoding="utf-8").splitlines():
+                if "npx prisma migrate dev" not in line:
+                    continue
+                seen += 1
+                if "--name" not in line:
+                    offenders.append(f"{doc.relative_to(REPO_ROOT)}: {line.strip()}")
+        # Vacuity: if no document mentions the command, the loop above proves
+        # nothing and this test would pass on a docs tree that lost it.
+        self.assertGreater(seen, 0, "no tracked document shows `prisma migrate dev`")
+        self.assertEqual(
+            offenders,
+            [],
+            "`prisma migrate dev` without --name stops at an interactive prompt "
+            "once the schema has changed, which a non-TTY cannot answer: it "
+            "exits 130 with no migration created, and reads as a cancellation "
+            "rather than a missing argument (#246). Offenders: "
+            + "; ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #212, #246, #247, #207.

Four defects on the same surface, sharing one property: **none of them could fail.**

## #212 — `sync-env` has never synced anything

`apps/web/Makefile` ran `cp ../.env .env`. The recipe's working directory is `apps/web`, so `../.env` is **`apps/.env`** — a path that has never existed, because `apps/` holds only `web/`.

The `-f` guard is what made it silent. The whole body sat behind an always-false condition, so it exited 0 and printed nothing on every run since it was written, and a missing root `.env` looked identical to a wrong path.

So `make dev-web` has never handed the dev server a `DATABASE_URL`, a `NEXTAUTH_URL` or a `CHAT_ENDPOINT`. Measured before and after:

```
$ ls apps/web/.env
ls: cannot access 'apps/web/.env': No such file or directory
$ make -C apps/web sync-env && ls apps/web/.env
-rw-rw-r-- 1 ... 2659 apps/web/.env        # byte-identical to the root .env
```

## #247 — the compose override was not ignored

`docker compose` auto-loads `docker-compose.override.yml`, so a committed one applies to everyone and to CI *without being asked for* — worse than having no override, and it is the standard way to carry a port remap around a collision on a shared machine.

## #246 — the last bare `prisma migrate dev`

Once the schema has actually changed, that command stops at an interactive prompt no non-TTY can answer: exit 130, no migration created, and it reads as a cancellation rather than a missing argument.

## #207 — an `eslint` key Next 16 does not read

Not merely redundant. `next lint` was removed in Next 16, the option is absent from the installed config schema, and there is no ESLint invocation left in the build. Lint runs as its own CI step and is unchanged. Measured: **1 unrecognized-key warning on `main`, 0 on this branch.**

## The guard

`tests/scripts/test_local_dev_surface.py`, 6 tests, each measuring the effect rather than the text:

- **Runs `sync-env`** in a fixture tree and compares the copied file — because a recipe that reads correctly and copies nothing is exactly the failure this already had once. A second test asserts it stays a silent no-op with no root `.env`, which is the `-f` guard's legitimate case in CI. A separate parse resolves the source path from the recipe's working directory, so the failure message names *why*.
- **Asks git** whether the override is ignored rather than grepping `.gitignore`. That also covers a force-added override, since `check-ignore` reports a tracked path as not-ignored.
- **Checks every documented `npx prisma migrate dev`**, including the inline-code-span one in `CONTRIBUTING.md` that an earlier fenced-blocks-only version of this same guard silently skipped — the same shape of defect as the bugs it guards, one level up. The prose mention in `docs/DATABASE.md` stays excluded, because it names the subcommand without invoking it.

`#207` deliberately has no guard: asserting a key's absence is a declaration check, and `next build` already reports a reintroduction as the warning measured above.

## Verification

`make -C apps/web ci` (154/154 vitest, clean `next build`), `make test-scripts` 183/183, `make docs-check` clean. Repo-wide `make ci` judged unnecessary — no chat input moved — and independently agreed by `verifier`.

Every assertion demonstrated against a fixture tree, each mistake caught by exactly one: wrong path, no path at all, override not ignored, bare migrate command, and a prose-only docs tree tripping the vacuity guard rather than the `--name` check. Plus direct demonstrations that restoring the original `../.env` fails both sync-env tests, and that stripping `--name` from the CONTRIBUTING inline command now fails where the fenced version passed green.

`ui-review` is not applicable: nothing renders differently and no rendering dependency moves.

## Worth knowing

This is what makes `apps/web/.env` start existing on contributors' machines for the first time. It is gitignored by the existing bare `.env` pattern and is the target's stated purpose, but the footprint change is real, not just a bug fix.

## Observed, not fixed

Three spellings of the same placeholder across three documents — `your_migration_name` in `README.md`, `<migration-name>` in `CONTRIBUTING.md` and `docs/DATABASE.md`, `add-order-status` in `AGENTS.md`. Cosmetic, and outside a diff about commands that cannot run.

Refs #212, #246, #247, #207