### PR TITLE
fix(web): defer the category grid's images too

### DIFF
--- a/apps/web/e2e/image-deferral.spec.ts
+++ b/apps/web/e2e/image-deferral.spec.ts
@@ -25,15 +25,13 @@ import { test, expect, type Page } from '@playwright/test'
  * nothing. What went wrong is only visible in what the browser actually asked
  * the server for.
  *
- * **Only the home page, for now.** The category grid is worse, not merely
- * similar: measured the same way at 1440x900, `/products/category/tents`
- * requests **21 of its 21** images before any scrolling, on a 3965px document
- * that Chrome's threshold swallows whole. It is tracked in #263 and left out
- * here as a slice boundary, not because it is hard to reach — the composed
- * stack these journeys run against has the seeded database, and
- * `image-delivery.spec.ts` already measures that surface across 21 widths.
- * What keeps it out is that its `priority={i < 3}` cutoff is an open question
- * of its own in #180, and answering both at once would tangle them.
+ * **Both listing surfaces.** The category grid was worse than the home page,
+ * not merely similar: at 1440x900 `/products/category/tents` requested **21 of
+ * its 21** images before any scrolling, on a 3965px document that Chrome's
+ * threshold swallows whole. The two surfaces share `DeferredImage` but not
+ * their bounds, because they differ in card count and in what is preloaded —
+ * the category grid keeps `priority={i < 3}`, whose cutoff is measured against
+ * largest-contentful-paint rather than against anything here. See #263.
  */
 
 /** Distinct optimiser URLs requested, recorded from navigation onward. */
@@ -64,6 +62,39 @@ const PRODUCT_CARD =
  */
 const MAX_INITIAL_REQUESTS = 12
 
+/** The category surface, which has more cards on a shorter document. */
+const CATEGORY_PATH = '/products/category/tents'
+
+/**
+ * The category grid's `priority={i < 3}` cutoff, named because two assertions
+ * below depend on it meaning the same thing: the preload count *is* this
+ * number, and the first-screen journey only asserts anything once a card
+ * beyond it is visible. Those cards carry an image whatever `eager` is set to,
+ * since `priority` implies eager, so a floor at or below this measures nothing.
+ */
+const CATEGORY_PRIORITY_CARDS = 3
+
+/**
+ * The category grid's own bound. Higher than the home page's because the grid
+ * is denser and the document shorter — 21 cards in 3965px against 20 in 5038 —
+ * so a margin measured for one surface reaches proportionally more of the
+ * other. Measured after the fix: 12 at desktop, 8 at tablet, 6 at phone,
+ * against 21, 16 and 7 before it. Phone is 6 rather than 4 because
+ * `eager={i < 6}` covers two cards outside the margin at that width — the
+ * price of a whole first screen, paid where the grid is a single column.
+ *
+ * 15 leaves room for the grid gaining a row without this reading as the
+ * regression it is meant to catch, which is the whole page being fetched at
+ * once. Anything at or near 21 is that regression.
+ *
+ * This bounds the count from *above* only, which is deliberately not enough on
+ * its own: narrowing `eager` makes every number here smaller and every
+ * assertion greener while putting first-screen cards back behind hydration.
+ * That direction is held by the first-screen journey below, not by this
+ * constant.
+ */
+const MAX_INITIAL_CATEGORY_REQUESTS = 15
+
 test.describe('listing image deferral', () => {
   test('the home page does not optimise every card before it is scrolled to', async ({
     page,
@@ -88,6 +119,121 @@ test.describe('listing image deferral', () => {
       requested.size,
       `${requested.size} optimiser requests for ${cards} cards before scrolling`,
     ).toBeLessThanOrEqual(MAX_INITIAL_REQUESTS)
+  })
+
+  test('the category grid does not optimise every card before it is scrolled to', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const requested = trackOptimiserRequests(page)
+
+    await page.goto(CATEGORY_PATH)
+    await page.waitForTimeout(3000)
+
+    const cards = await page.locator(PRODUCT_CARD).count()
+    // Vacuity: this surface needs a database, so an empty grid is a plausible
+    // way for the bound below to be satisfied by nothing rendering at all.
+    expect(cards, `${CATEGORY_PATH} rendered no product grid to measure`).toBeGreaterThan(
+      MAX_INITIAL_CATEGORY_REQUESTS,
+    )
+
+    expect(
+      requested.size,
+      `${requested.size} optimiser requests for ${cards} cards before scrolling`,
+    ).toBeLessThanOrEqual(MAX_INITIAL_CATEGORY_REQUESTS)
+  })
+
+  test('every card on the first screen is server-rendered, not waiting on hydration', async ({
+    page,
+  }) => {
+    // 834x1112, because that is where the hole was: the grid is
+    // `sm:grid-cols-2` here, so card 3 opens the second row and sits 251px on
+    // screen -- the same 251px #180 records. At 1440x900 the equivalent cards
+    // are only 63px down, which is why this asserts at the tablet width.
+    await page.setViewportSize({ width: 834, height: 1112 })
+
+    // Hydration is blocked, not JavaScript. `javaScriptEnabled: false` would
+    // be the obvious way and is worse than useless here: with scripting off,
+    // `<noscript>` content becomes live DOM, so `DeferredImage`'s fallback
+    // makes every card report an image and this passes on 21 of 21 whether or
+    // not anything was server-rendered -- it passes with `eager` deleted.
+    // Blocking the chunks instead leaves scripting on and the observer never
+    // running, so nothing can heal the state before it is read. Measured, the
+    // two approaches differ 6 against 21.
+    //
+    // The `*.js` suffix is deliberate, not decoration: Next 16.3 with Turbopack
+    // serves the stylesheet out of `_next/static/chunks/` alongside the script
+    // chunks, so the obvious `**/_next/static/chunks/**` blocks the CSS and
+    // collapses the grid to one column -- which would trip the floor below
+    // with a message about cards while the real cause was the stylesheet.
+    let aborted = 0
+    await page.route('**/_next/static/**/*.js', (route) => {
+      aborted += 1
+      return route.abort()
+    })
+
+    await page.goto(CATEGORY_PATH)
+
+    // The abort is this journey's precondition, and a glob that stops matching
+    // fails open: measured, pointing it at `**/*.mjs` or at `_next/chunks/**`
+    // leaves `aborted` at 0 and every assertion below still passes, because on
+    // a fast machine the read beats hydration anyway. That would quietly turn a
+    // deterministic check into a race -- green here, and green-while-broken on
+    // the two-core runner this file keeps citing. Measured at 10 aborts.
+    expect(aborted, 'blocked no script chunks, so hydration was not prevented').toBeGreaterThan(0)
+
+    const naked = await page.evaluate((selector) => {
+      const boxes = [...document.querySelectorAll(`${selector} div.aspect-square`)]
+      const onScreen = boxes.filter((box) => {
+        const rect = box.getBoundingClientRect()
+        return rect.top < window.innerHeight && rect.bottom > 0
+      })
+      return {
+        onScreen: onScreen.length,
+        withoutImage: onScreen.filter((box) => !box.querySelector('img')).length,
+      }
+    }, PRODUCT_CARD)
+
+    // Vacuity, and the literal is the `priority` cutoff rather than a round
+    // number: cards below it carry an image whatever `eager` is, so unless a
+    // card *beyond* it is on screen this journey asserts nothing about the
+    // thing it exists for. Relaxing this to `> 0` would look like loosening a
+    // brittle constant and would silently restore that vacuity.
+    expect(
+      naked.onScreen,
+      `only ${naked.onScreen} cards on the first screen, so this asserts ` +
+        `nothing past the priority cutoff of ${CATEGORY_PRIORITY_CARDS}`,
+    ).toBeGreaterThan(CATEGORY_PRIORITY_CARDS)
+
+    // What this catches that the request-count journeys cannot: they bound the
+    // count from above, so narrowing `eager` back makes every one of them
+    // greener while returning a visitor to a grey box for up to 2.4s on a
+    // throttled device. That asymmetry is how the hole got in once already.
+    expect(
+      naked.withoutImage,
+      'cards on the first screen with no server-rendered image',
+    ).toBe(0)
+  })
+
+  test('the category grid still preloads its first row', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(CATEGORY_PATH)
+
+    // What this catches that a request count cannot: deferral swallowing the
+    // `priority` cutoff. Those three preloads are tuned against
+    // largest-contentful-paint — the reasoning is in the page, and it measured
+    // 2892ms against 4048 at this width — and a component that deferred them
+    // would leave every count here looking better while the page got slower.
+    // Scoped to the optimiser, the way `image-delivery.spec.ts` scopes its
+    // own preload counts and for the same reason: `header.tsx` renders the
+    // signed-in avatar as a plain non-lazy `<img>`, which react-dom preloads
+    // in its own right. The suite runs signed out today, so an unscoped count
+    // would pass for the right reason now and fail with this message -- which
+    // would then be false -- the day the shared header gains one.
+    const preloaded = await page
+      .locator('link[rel="preload"][as="image"][imagesrcset*="/_next/image"]')
+      .count()
+    expect(preloaded, 'the first row is no longer preloaded').toBe(CATEGORY_PRIORITY_CARDS)
   })
 
   test('scrolling loads the images that were deferred', async ({ page }) => {

--- a/apps/web/src/app/products/category/[slug]/page.tsx
+++ b/apps/web/src/app/products/category/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Block from "@/components/block";
 import Header from "@/components/header";
 import { getProductsByCategory } from "@/lib/products";
 import { notFound } from "next/navigation";
-import Image from "next/image";
+import DeferredImage from "@/components/deferred-image";
 
 type CategoryProductCard = {
   id: string;
@@ -46,15 +46,13 @@ export default async function CategoryPage({
             >
               <div className="aspect-square w-full overflow-hidden rounded-3xl bg-gray-200">
                 {product.image ? (
-                  <Image
+                  <DeferredImage
                     src={product.image}
                     // Decorative, because the link already says it. The card
                     // is one link whose heading is the product's name, so
                     // `alt={product.name}` made its accessible name the name
                     // twice. See e2e/browse.spec.ts.
                     alt=""
-                    width={350}
-                    height={350}
                     // The card is the container split by the column count, less
                     // the gaps and the container's own padding — so it tracks
                     // the viewport between each breakpoint and only settles
@@ -101,6 +99,52 @@ export default async function CategoryPage({
                     // card 3 is eager and card 4 is lazy, both 251px above the
                     // fold, and the second arrives about 2.7s later. See #180.
                     priority={i < 3}
+                    // Everything below the fold waits until it is nearly on
+                    // screen. Before this the grid fetched every card at once
+                    // -- 21 of 21 on `tents`, measured at 1440x900 on a 3965px
+                    // document, because Chrome's lazy threshold (~3900px)
+                    // covers the whole page. See #263.
+                    //
+                    // Six, not three. `priority` implies eager inside the
+                    // component -- a preloaded image that is also deferred is a
+                    // contradiction -- so leaving this off would have made the
+                    // preload cutoff the only thing rendering server-side, and
+                    // that cutoff is three because three is the widest the grid
+                    // gets. It is not the widest the *fold* gets: at `sm` the
+                    // grid is two columns, so card 3 opens the second row and
+                    // sits 251px on screen at 834x1112 -- the same 251px the
+                    // note above records for #180.
+                    //
+                    // A deferred card cannot be requested until this component
+                    // hydrates, and measured at 834x1112 that wait is 245ms
+                    // unthrottled, 1155ms at 4x CPU and 2385ms at 6x. So three
+                    // would have traded a request the browser used to start at
+                    // parse for a grey box a tablet visitor watches for over
+                    // two seconds.
+                    //
+                    // Six rather than four, and 1440x900 is the wrong reason.
+                    // There the second row is a 63px sliver and four would look
+                    // sufficient. It is the taller desktops that decide it: the
+                    // same row measures 243px at 1440x1080, 145px at 1512x982
+                    // and 363px at 1920x1200 -- most of a card. Four would fill
+                    // card 3 and leave 4 and 5 grey beside it, ragged within a
+                    // single row, which reads worse than a row that is
+                    // uniformly not there yet.
+                    //
+                    // The price is two requests on a phone, where the grid is
+                    // one column and cards 4 and 5 are about 2.2 and 2.7
+                    // viewports down: that surface goes 7 unaided, 4 with
+                    // deferral alone, 6 with this. Desktop and tablet pay
+                    // nothing, because those cards already sit inside the
+                    // 1200px margin and this only moves them out of the
+                    // post-hydration path and into the HTML.
+                    //
+                    // `eager` and `priority` are separate on purpose. Preload
+                    // is a bet on which card paints last and is measured
+                    // against LCP; eager is about which cards a visitor is
+                    // already looking at. Widening the first to cover the
+                    // second would preload six cards and lose that measurement.
+                    eager={i < 6}
                     className="h-full w-full object-cover object-center group-hover:opacity-75 transition-opacity"
                   />
                 ) : (

--- a/apps/web/src/components/deferred-image.test.tsx
+++ b/apps/web/src/components/deferred-image.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import DeferredImage from './deferred-image'
+
+/**
+ * The props the category grid needs and the home grid does not.
+ *
+ * `listing-image.test.tsx` covers the shared mechanism through the home grid's
+ * composition of this component — deferral, the observer margin, the box
+ * surviving the swap. What is here is the `priority` path, which only the
+ * category grid uses and which is the one way this component can quietly make
+ * a page slower: a preloaded image that gets deferred is not preloaded at all,
+ * and every request count in `e2e/image-deferral.spec.ts` would improve while
+ * largest-contentful-paint got worse.
+ */
+
+const PROPS = {
+  src: '/images/1/example.webp',
+  alt: '',
+  sizes: '350px',
+  className: 'h-full w-full object-cover',
+}
+
+let observed: Element[]
+
+beforeEach(() => {
+  observed = []
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      observe = (element: Element) => {
+        observed.push(element)
+      }
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+      takeRecords = () => []
+      root = null
+      rootMargin = ''
+      thresholds = []
+    },
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('DeferredImage', () => {
+  it('renders a priority image immediately and registers no observer', () => {
+    const { container } = render(<DeferredImage {...PROPS} priority />)
+
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    // The load-bearing half. `priority` without this is a contradiction: the
+    // point of preloading is to start the request before layout says the
+    // element is near, and an observer is layout saying exactly that.
+    expect(observed).toHaveLength(0)
+  })
+
+  it('marks a priority image as not lazy, which is what react-dom preloads on', () => {
+    const { container } = render(<DeferredImage {...PROPS} priority />)
+    const image = container.querySelector('img')
+
+    // Deliberately not `fetchpriority`: `next/image` sets none, as the
+    // category page's own comment records. What makes the preload happen is
+    // react-dom preloading any image that is not `loading="lazy"`, so that
+    // attribute is the observable half. An ordinary card below is lazy, which
+    // is what stops the whole grid preloading.
+    expect(image?.getAttribute('loading')).not.toBe('lazy')
+
+    const { container: ordinary } = render(<DeferredImage {...PROPS} eager />)
+    expect(ordinary.querySelector('img')?.getAttribute('loading')).toBe('lazy')
+  })
+
+  it('defers an ordinary image', () => {
+    const { container } = render(<DeferredImage {...PROPS} />)
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+    expect(observed).toHaveLength(1)
+  })
+
+  it('keeps the caller-supplied classes on the image', () => {
+    // A fresh render rather than a rerender: `eager` seeds initial state, so
+    // flipping it on a mounted component does nothing. That is fine — it is a
+    // per-card constant — but a test that used `rerender` would be asserting
+    // against a component that never showed its image.
+    const { container } = render(<DeferredImage {...PROPS} eager />)
+
+    // The caller owns the box, so it also owns how the image sits in it. The
+    // category grid needs `object-cover`; the home grid needs `h-auto`. A
+    // component that imposed one would silently restyle the other.
+    expect(container.querySelector('img')?.className).toBe(PROPS.className)
+  })
+})

--- a/apps/web/src/components/deferred-image.tsx
+++ b/apps/web/src/components/deferred-image.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  src: string;
+  alt: string;
+  sizes: string;
+  /** Classes for the rendered image. The caller owns the box around it. */
+  className: string;
+  /**
+   * Render the image straight away, server-side and in the HTML. For cards on
+   * or near the first screen, where deferring costs more than it saves.
+   */
+  eager?: boolean;
+  /**
+   * Preload the image. Implies `eager` -- a preloaded image that is also
+   * deferred is a contradiction, since the point of preloading is to start the
+   * request before layout says the element is near.
+   */
+  priority?: boolean;
+};
+
+/**
+ * How far ahead of the viewport to start fetching.
+ *
+ * Chrome's own `loading="lazy"` threshold measured at roughly 3900px, which is
+ * what #230 and #263 are about: at 1440x900 that reaches four viewports down
+ * and pulls in almost every card on a listing page.
+ *
+ * The margin buys `1200 / v` seconds of lead at scroll speed `v`, so it hides a
+ * fetch only while the fetch is faster than that. Measured against injected
+ * optimiser latency at a 800px/s reading scroll: at 150ms nothing is ever grey;
+ * at 1000ms, 14 of 20 cards are grey as they enter. 1200 rather than 600
+ * doubles the lead for three extra requests a viewport, which is still under
+ * half of what Chrome does unaided.
+ *
+ * No margin fixes a hard fling on a slow server; nothing short of ~7000px
+ * does, and that is the behaviour this replaces. That case is handled by the
+ * caller's box staying visible rather than by fetching earlier.
+ */
+const ROOT_MARGIN = "1200px";
+
+/**
+ * An image that is fetched when it is nearly on screen.
+ *
+ * `loading="lazy"` is a hint about a threshold the browser picks, not a
+ * viewport test, and the threshold it picks is far too generous for a page
+ * carrying twenty or more separately-optimised images.
+ *
+ * **The caller owns the box.** Both listing surfaces already have one --
+ * `ListingImage` supplies it for the home grid, and the category card's own
+ * wrapper is shared with the empty state it falls back to -- so this renders
+ * into that box rather than bringing another. What matters is that the box
+ * survives the swap: `next/image` renders with `color: transparent` and no
+ * background, so a tone on something that unmounts leaves the state a
+ * scrolling visitor actually sees -- requested, not yet decoded -- as a fully
+ * transparent gap.
+ *
+ * Without JavaScript the deferred images are never requested, so `<noscript>`
+ * carries the unoptimised source. That is roughly 12x the bytes of the
+ * optimiser's variant -- measured at 5.1 MB against about 400 KB across the
+ * home page's twenty cards -- and correct, which is the right way round for a
+ * case this rare. It does not cover JavaScript that loads and then fails: a
+ * blocked chunk leaves the deferred cards as empty boxes, which is why the
+ * caller's tone has to be visible. See #261.
+ */
+export default function DeferredImage({
+  src,
+  alt,
+  sizes,
+  className,
+  eager = false,
+  priority = false,
+}: Props) {
+  const [show, setShow] = useState(eager || priority);
+  const placeholder = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (show) return;
+    const node = placeholder.current;
+    if (!node) return;
+
+    // No feature test for IntersectionObserver. The obvious one --
+    // `typeof IntersectionObserver === "undefined"` -- is also true on the
+    // server, so it would render every image eagerly during SSR and undo the
+    // whole change while looking like a safety net. A correct test would have
+    // to run only on the client and then set state from inside this effect,
+    // which `react-hooks/set-state-in-effect` rejects. The observer has been
+    // in every browser Next supports since 2019, and the case that genuinely
+    // has none -- scripting off -- is served by the `<noscript>` below.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setShow(true);
+        observer.disconnect();
+      },
+      { rootMargin: ROOT_MARGIN },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [show]);
+
+  if (show) {
+    return (
+      <Image
+        src={src}
+        alt={alt}
+        width={350}
+        height={350}
+        sizes={sizes}
+        priority={priority}
+        className={className}
+      />
+    );
+  }
+
+  // Fills the caller's box so the observer measures the geometry the card
+  // actually occupies, rather than a zero-height element that would sit at the
+  // top of it and trigger early on a tall card.
+  return (
+    <div ref={placeholder} className="h-full w-full">
+      <noscript>
+        <img src={src} alt={alt} className={className} />
+      </noscript>
+    </div>
+  );
+}

--- a/apps/web/src/components/listing-image.tsx
+++ b/apps/web/src/components/listing-image.tsx
@@ -1,7 +1,4 @@
-"use client";
-
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import DeferredImage from "./deferred-image";
 
 type Props = {
   src: string;
@@ -15,38 +12,18 @@ type Props = {
 };
 
 /**
- * How far ahead of the viewport to start fetching.
+ * The home grid's product image: a reserved box, and an image fetched when the
+ * box is nearly on screen.
  *
- * Chrome's own `loading="lazy"` threshold measured at roughly 3900px here,
- * which is what #230 is about: at 1440x900 that reaches 4.3 viewports down and
- * pulls in 18 of the home page's 20 cards.
+ * The deferral itself lives in `DeferredImage`, which the category grid uses
+ * too. What is here is this surface's box, and the reasons it looks the way it
+ * does.
  *
- * The margin buys `600 / v` seconds of lead at scroll speed `v`, so it hides a
- * fetch only while the fetch is faster than that. Measured against injected
- * optimiser latency at a 800px/s reading scroll: at 150ms nothing is ever
- * grey; at 1000ms, 14 of 20 cards are grey as they enter. 1200 rather than 600
- * doubles the lead for three extra requests a viewport -- 6 to 9 at desktop --
- * which is still under a half of what Chrome does unaided.
- *
- * No margin fixes a hard fling on a slow server; nothing short of ~7000px
- * does, and that is the behaviour this replaces. That case is handled by the
- * box below staying visible rather than by fetching earlier.
- */
-const ROOT_MARGIN = "1200px";
-
-/**
- * A product-card image that is fetched when it is nearly on screen.
- *
- * `loading="lazy"` is a hint about a threshold the browser picks, not a
- * viewport test, and the threshold it picks is far too generous for a page
- * carrying twenty separately-optimised images. This narrows it.
- *
- * **The box is one element, not two.** The tone has to sit on a wrapper that
- * survives the swap, because `next/image` renders with `color: transparent`
- * and no background of its own: hanging the tone on a placeholder that
- * unmounts means the state a scrolling visitor actually sees -- image
- * requested, not yet decoded -- is a fully transparent gap. Keeping one
- * element also removes an unmount/remount between the two states.
+ * **The box is one element, and it is this one.** `next/image` renders with
+ * `color: transparent` and no background of its own, so the tone has to sit on
+ * something that survives the swap; hanging it on a placeholder that unmounts
+ * leaves the state a scrolling visitor actually sees -- requested, not yet
+ * decoded -- as a fully transparent gap.
  *
  * `bg-zinc-200` measures 1.22:1 against the `bg-inherit` bands and 1.15:1
  * against the `bg-zinc-100` ones, read back as painted sRGB rather than off the
@@ -54,8 +31,8 @@ const ROOT_MARGIN = "1200px";
  * short of 1.4.11's 3:1: reaching it needs about `zinc-400`, and this box is a
  * transient state of a decorative image, so a tone dark enough to pass would
  * flash a heavy grey block on every ordinary load to serve a case that is
- * meant to be brief. It is the same tone the about page's image band uses;
- * the category grid's equivalent box is `bg-gray-200`, a shade off this one.
+ * meant to be brief. It is the same tone the about page's image band uses; the
+ * category grid's equivalent box is `bg-gray-200`, a shade off this one.
  * Where that reasoning stops holding is when the box is *not* brief -- a
  * blocked script leaves it forever -- which is #261 rather than this file.
  *
@@ -72,68 +49,20 @@ const ROOT_MARGIN = "1200px";
  * its box from the source's own ratio via `width`/`height` and `h-auto`. The
  * category grid has the same unheld assumption and crops rather than
  * letterboxes. See #262.
- *
- * Without JavaScript the deferred images are never requested, so `<noscript>`
- * carries the unoptimised source. That is roughly 12x the bytes of the
- * optimiser's variant -- measured at 5.1 MB against about 400 KB across the
- * twenty cards -- and correct, which is the right way round for a case this
- * rare. It does not cover JavaScript that loads and then fails: a blocked
- * chunk leaves the deferred cards as empty boxes, which is the other reason
- * the tone below has to be visible.
  */
-export default function ListingImage({
-  src,
-  alt,
-  sizes,
-  eager = false,
-}: Props) {
-  const [show, setShow] = useState(eager);
-  const box = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (show) return;
-    const node = box.current;
-    if (!node) return;
-
-    // No feature test for IntersectionObserver. The obvious one --
-    // `typeof IntersectionObserver === "undefined"` -- is also true on the
-    // server, so it would render every image eagerly during SSR and undo the
-    // whole change while looking like a safety net. A correct test would have
-    // to run only on the client and then set state from inside this effect,
-    // which `react-hooks/set-state-in-effect` rejects. The observer has been
-    // in every browser Next supports since 2019, and the case that genuinely
-    // has none -- scripting off -- is served by the `<noscript>` below.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (!entries.some((entry) => entry.isIntersecting)) return;
-        setShow(true);
-        observer.disconnect();
-      },
-      { rootMargin: ROOT_MARGIN },
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [show]);
-
+export default function ListingImage({ src, alt, sizes, eager = false }: Props) {
   return (
-    <div
-      ref={box}
-      className="aspect-square w-full overflow-hidden rounded-3xl bg-zinc-200"
-    >
-      {show ? (
-        <Image
-          src={src}
-          alt={alt}
-          width={350}
-          height={350}
-          sizes={sizes}
-          className="w-full h-auto"
-        />
-      ) : (
-        <noscript>
-          <img src={src} alt={alt} className="w-full h-auto" />
-        </noscript>
-      )}
+    <div className="aspect-square w-full overflow-hidden rounded-3xl bg-zinc-200">
+      <DeferredImage
+        src={src}
+        alt={alt}
+        sizes={sizes}
+        eager={eager}
+        // w-full so the image scales into the box; h-auto because the source
+        // is square, so it fills a square box exactly. See #262 for what a
+        // non-square source would do here.
+        className="w-full h-auto"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #263. The sequel to #230.

## What was wrong

The category grid asked the optimiser for **21 of its 21** images before any scrolling, on a **3965px** document. That is worse than the home page was: Chrome's `loading="lazy"` threshold measured ~3900px, so on this surface it swallowed the entire page rather than four viewports of it.

| viewport | before | after | document |
|---|---|---|---|
| phone 390×844 | 7 / 21 | **6 / 21** | 10690px (unchanged) |
| tablet 834×1112 | 16 / 21 | **8 / 21** | 6015px (unchanged) |
| desktop 1440×900 | **21 / 21** | **12 / 21** | 3965px (unchanged) |

Both measured on the same composed stack, baseline first.

## The shape

The mechanism moves out of `ListingImage` into **`DeferredImage`**, which renders into a box the **caller** owns. The category card already has one — `aspect-square … bg-gray-200` — and shares it with the "No image available" empty state, so a component bringing its own would nest two boxes around one image. `ListingImage` is now the home grid's box composing it, and its five tests pass untouched.

## Two cutoffs, deliberately not one

`priority={i < 3}` is **preserved exactly**. Its comment argues it from largest-contentful-paint medians (2892ms against 4048 at 1440), and `priority` now implies eager inside the component — a preloaded image that is also deferred is a contradiction.

`eager={i < 6}` answers a different question: not which card paints *last*, but which cards a visitor is *already looking at*. At `sm` the grid is two columns, so card 3 opens the second row and sits **251px on screen** — and a deferred card cannot be requested until hydration, measured at **245ms** unthrottled and **2385ms at 6× CPU**.

Six rather than four because the taller desktops decide it: that second row measures **243px at 1440×1080** and **363px at 1920×1200**, where four would fill card 3 and leave 4 and 5 grey beside it — ragged within a single row, which reads worse than a row that is uniformly not there yet. The price is two extra requests on phone, below the fold.

## The guard that holds it

`every card on the first screen is server-rendered, not waiting on hydration`.

The request-count journeys bound from *above*, so narrowing `eager` makes every one of them **greener** while putting cards back behind hydration. Demonstrated with a container rebuild in each direction — with `eager` removed:

```
✓ the home page does not optimise every card before it is scrolled to
✓ the category grid does not optimise every card before it is scrolled to
✘ every card on the first screen is server-rendered, not waiting on hydration
✓ the category grid still preloads its first row
✓ scrolling loads the images that were deferred
```

Four green, one red. That asymmetry is how the hole got in during review.

It blocks script chunks rather than disabling JavaScript. **`javaScriptEnabled: false` is worse than useless here**: with scripting off, `<noscript>` becomes live DOM, so every card reports an image whether or not anything was server-rendered — 21 against 6. It also asserts it *blocked* something, because a glob that stops matching fails open; pointing it at a path Next does not use leaves every assertion passing.

## Verification

`make -C apps/web ci` exit 0. **Full journey suite 135/135.** 9 component tests. `ui-review` at phone/tablet/desktop, 1× and 2×: placeholder 1.19:1 against the page versus the home grid's 1.22:1, `object-cover` cards pixel-identical to the untouched priority cards used as an in-page control, CLS 0, 0 of 21 grey on entry at 800px/s under 150ms and 1000ms injected latency, LCP 176/192/224ms still landing on a first-row image.

## Two corrections worth recording

- `ui-review` reported 2× density was not served, inferring ~398px sources. It is served: sources are 1024×1024 and `w=828` returns a genuine 828×828, confirmed by decoding the VP8 bitstreams. `398px` appears verbatim in the page's `sizes` string, which is the likely reading.
- Mid-review the suite failed twice at a 240s ceiling and I spent a long time assuming this change caused it. It did not — the optimiser had **wedged**, returning nothing for 40s on specific variants while neighbours served in milliseconds. A restart cleared it and the test returned to 55.1s against its ~58s baseline. Filed as **#270**, with my own contamination disclosed.

## Filed, not fixed here

#270 (the optimiser wedge), #271 (the header avatar preloading on every signed-in page, which competes with the LCP preloads this page tunes).

Refs #263