### PR TITLE
fix(web): let next dev serve its chunks over the loopback address

### DIFF
--- a/apps/web/next-dev-origins.test.ts
+++ b/apps/web/next-dev-origins.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The dev server has to serve `/_next/*` to a browser that reached it over the
+ * loopback address.
+ *
+ * Next's dev server blocks cross-origin requests to its own internal routes,
+ * and the allowlist it compares against is `localhost`, `**.localhost` and the
+ * hostname the server was bound with -- `127.0.0.1` is in none of those. So a
+ * dev server opened at `http://127.0.0.1:<port>` answered 403 to three of its
+ * client chunks, React never hydrated, and every client component on the page
+ * was inert. Clicking the chat launcher did nothing, which is how #228 was
+ * reported: the panel looked broken, and the component was fine.
+ *
+ * What is asserted here is Next's own decision function, fed this repository's
+ * own `allowedDevOrigins`. Not a re-implementation of the rule -- the rule is
+ * Next's and changes with Next, and a copy of it here would keep agreeing with
+ * itself after the original moved.
+ *
+ * **What this does not cover, and how that was established instead.** It does
+ * not prove the dev server calls this function, nor that the config key reaches
+ * it. That was measured directly rather than asserted, against a real
+ * `next dev` at both hostnames:
+ *
+ *     before  http://127.0.0.1:3177  403s=3  hydrated=false  dialogAfterClick=0
+ *             http://localhost:3177  403s=0  hydrated=true   dialogAfterClick=1
+ *     after   http://127.0.0.1:3178  403s=0  hydrated=true   dialog=1 focus=chat
+ *
+ * A guard that started its own server would have been the stronger check, and
+ * it was written that way first. It does not survive contact with ordinary use:
+ * Next 16 keeps one dev server per `distDir`, enforced through `.next/dev/lock`,
+ * and a second one exits 1 with "Another next dev server is already running".
+ * So `make test-web` failed for anyone who had `make dev` up -- green in CI,
+ * where nothing else is running, and broken on exactly the machines doing the
+ * development. It also had to snapshot and restore two tracked files the dev
+ * server rewrites on boot, which is #275.
+ */
+
+// `require` rather than `import`, matching `next.config.test.ts` beside it:
+// both of these are CommonJS, and the gate is reached by file path.
+const nextConfig = require('./next.config.js')
+// The gate itself. A Next upgrade that moves or retires it fails this file
+// loudly, which is the correct outcome: the protection this repository is
+// relying on would have moved with it.
+const {
+  blockCrossSiteDEV,
+} = require('next/dist/server/lib/router-utils/block-cross-site-dev.js')
+
+/**
+ * Ask the gate about one origin, the way a browser asks for a client chunk.
+ *
+ * The path names no real chunk on purpose: the gate runs before routing and
+ * looks only at the URL prefix, so nothing here depends on a content hash.
+ *
+ * `hostname` is `undefined` because `next dev` without `-H` binds every
+ * interface and passes no hostname through to the gate -- which is why
+ * `127.0.0.1` was not already allowed as the address the server answered on.
+ */
+function isBlocked(origin: string): boolean {
+  const req = {
+    url: '/_next/static/chunks/probe-no-such-chunk.js',
+    headers: { origin },
+  }
+  const res = { statusCode: 200, end() {} }
+  return blockCrossSiteDEV(req, res, nextConfig.allowedDevOrigins, undefined)
+}
+
+describe('next dev cross-origin gate', () => {
+  it('serves an internal route to a browser on 127.0.0.1', () => {
+    expect(isBlocked('http://127.0.0.1:3100')).toBe(false)
+  })
+
+  it('serves an internal route to a browser on [::1]', () => {
+    // The other loopback address, and reachable: the dev server answers 200 on
+    // `http://[::1]:<port>/contact`. Bracketed because that is the hostname
+    // `parseUrl` produces; a bare `::1` in the allowlist matches nothing.
+    expect(isBlocked('http://[::1]:3100')).toBe(false)
+  })
+
+  it('serves an internal route to a browser on localhost', () => {
+    // Pinning Next's own hardcoded default, not anything this repository
+    // configures: the gate builds its allowlist as `['**.localhost',
+    // 'localhost', ...allowedDevOrigins ?? []]`, so no config value can
+    // displace this one and it passes with the key absent entirely. What it
+    // would catch is Next dropping `localhost` from those defaults, which
+    // would send everyone here to the same 403 by a different route.
+    expect(isBlocked('http://localhost:3100')).toBe(false)
+  })
+
+  it('still blocks a foreign origin', () => {
+    // The control. Without it this file passes just as well against an
+    // allowlist widened to everything, which is a different change from the one
+    // that was made and a worse one -- and it is what proves the probe reaches
+    // the gate at all rather than being waved through for some reason of its
+    // own.
+    expect(isBlocked('http://evil.example')).toBe(true)
+  })
+})

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -26,6 +26,52 @@ const nextConfig = {
   // Emit a traced, self-contained server bundle so the Docker runtime image
   // ships only the dependencies actually reached at runtime.
   output: 'standalone',
+
+  // Dev only, and it is the loopback address rather than a host: the dev
+  // server's allowlist for its own `/_next/*` routes is `localhost`,
+  // `**.localhost` and whatever hostname it was bound with, and `127.0.0.1` is
+  // in none of those. Reaching it by IP therefore got 403 on the client chunks,
+  // React never hydrated, and every client component on the page was inert --
+  // #228, reported as the chat panel refusing to open, which it was not.
+  //
+  // Worth adding rather than telling people to type `localhost`. `make dev`
+  // and `make dev-web` serve on 3100, and a developer or a browser driver
+  // reaching that by IP is the ordinary case rather than an unusual one.
+  //
+  // Not `make e2e-smoke`, which does probe `127.0.0.1:3100` literally but
+  // against the compose stack -- that runs `next start` on a production build,
+  // where this key is never consulted.
+  //
+  // Both loopback forms, because both are reachable and both were blocked --
+  // the dev server answers 200 on `http://[::1]:<port>/contact` while 403ing
+  // that page's chunks, so covering only IPv4 leaves the identical bug one
+  // address over. Bracketed is the spelling that matches: `parseUrl` yields
+  // `[::1]` as the hostname, and a bare `::1` entry does not match it.
+  //
+  // This widens nothing outside development. The gate exists so that a page on
+  // another site cannot read this server's dev resources; loopback is this
+  // machine, and `next build` never consults the key at all.
+  allowedDevOrigins: ['127.0.0.1', '[::1]'],
+
+  // `next dev` otherwise appends a block of its own to `apps/web/AGENTS.md`,
+  // on every boot under a coding agent -- which is every `make dev` in this
+  // repository's workflow, though not one run from a plain shell: the write is
+  // gated on agent detection, so it fires on `CLAUDECODE`, `GEMINI_CLI`,
+  // `CURSOR_AGENT`, a `COPILOT_*` variable and their equivalents, and not
+  // otherwise. That file is this repository's authoritative runbook for coding
+  // agents and is written by hand: `AGENTS.md` says generated content does not
+  // belong in it, and the appended block closes by asking to be committed
+  // along with whatever change was in flight.
+  //
+  // Only `AGENTS.md`. The sibling `CLAUDE.md` is left alone, because it exists
+  // and carries no marker block -- measured, and the branch that decides it is
+  // in `generate-agent-files.js`.
+  //
+  // The rest of what `next dev` rewrites on boot is #275 and is not fixed here.
+  // This one is, because it lands in an instruction file rather than a
+  // generated one.
+  agentRules: false,
+
   images: {
     deviceSizes,
   },


### PR DESCRIPTION
Fixes #228.

## What was wrong

Not the chat panel. React never hydrated, and every client component on the page was inert — the launcher was just the one that got clicked.

Next's dev server blocks cross-origin requests to its own `/_next/*` routes, against an allowlist of `localhost`, `**.localhost` and the hostname it was bound with (`node_modules/next/dist/server/lib/router-utils/block-cross-site-dev.js`). `127.0.0.1` is in none of those, so a dev server opened at `http://127.0.0.1:<port>` returned **403** for three client chunks — one of which contains `chat.tsx`.

```
http://127.0.0.1:3177  403s=3  hydrated=false  dialogAfterClick=0
http://localhost:3177  403s=0  hydrated=true   dialogAfterClick=1
```

Only three of sixteen script tags are affected because only those carry `crossorigin` and therefore send an `Origin` header; the gate waves through requests with no origin. That is also why `curl` returned 200 for the exact URL the browser 403'd on, which is what made this look like it was not a network problem.

The dev server had been printing the cause, once per chunk, from the first run:

```
⚠ Blocked cross-origin request to Next.js dev resource /_next/static/chunks/... from "127.0.0.1".
To allow this host in development, add it to "allowedDevOrigins" in next.config.js
```

The StrictMode / focus-out mechanism proposed in #228 is not involved. The panel is never mounted and never unmounted — a `MutationObserver` records no `[role=dialog]` node being added, and the launcher's `aria-label` stays `"Open chat"`. The measurement and the two pieces of evidence that pointed the wrong way are written up [in a comment on the issue](https://github.com/scottdensmore/contoso/issues/228#issuecomment-5305157450).

## The change

`allowedDevOrigins: ['127.0.0.1', '[::1]']` in `apps/web/next.config.js`. Both loopback forms, because both are reachable and both were blocked — the server answers 200 on `http://[::1]:3178/contact` while 403ing its chunks, so fixing only IPv4 would leave the identical bug one address over. The bracketed spelling is what the gate matches; `'::1'` does not (`parseUrl` yields `[::1]` as the hostname).

This widens nothing outside development. `next build` never consults the key.

### Also here, and why it is not separate

`agentRules: false`. `next dev` was appending a block of its own to `apps/web/AGENTS.md` on every boot — the repository's authoritative, hand-maintained agent runbook, whose first rule is that generated content does not go in it. The appended text also instructs the reader to commit it along with whatever change is in flight.

That is fixed here rather than filed because leaving it made this change unverifiable: the guard below reads `next.config.js` and the first version of it started a dev server, so `make test-web` rewrote the runbook underneath the thing being tested.

## The guard

`apps/web/next-dev-origins.test.ts` asserts Next's own decision function against this repository's own `allowedDevOrigins` — not a re-implementation of the rule, which would keep agreeing with itself after Next's moved.

Three assertions, and what each catches, demonstrated by breaking the input:

| Mutation | Assertion that fails |
| --- | --- |
| `allowedDevOrigins` removed | `serves an internal route to a browser on 127.0.0.1` — `expected true to be false` |
| `allowedDevOrigins` widened with `evil.example` | `still blocks a foreign origin` — `expected false to be true` |

The foreign-origin case is the control: without it the file passes just as well against an allowlist widened to everything, and it is what proves the probe reaches the gate rather than being waved through for a reason of its own.

**What the guard does not cover, and how that was covered instead.** It does not prove the dev server calls that function, nor that the config key reaches it. That was measured directly, against a real `next dev`, before and after:

```
before  http://127.0.0.1:3177  403s=3  hydrated=false  dialogAfterClick=0
after   http://127.0.0.1:3178  403s=0  hydrated=true   dialog=1 input=1 focus=chat
                               aria-modal=true (390x844) / absent (1280x720), stays open
```

A guard that started its own server was written first and does not survive ordinary use: Next 16 keeps one dev server per `distDir` via `.next/dev/lock`, and a second exits 1 with "Another next dev server is already running". `make test-web` then failed for anyone with `make dev` up — green in CI, where nothing else runs, and broken on exactly the machines doing the development. The rejected version also had to snapshot and restore two tracked files the dev server rewrites on boot.

## Verification

`make -C apps/web ci` — lint, type-check, 157 tests across 37 files, and the production standalone build. Clean, with no config-schema complaint about either new key.

`ui-review` rendered the change at 390x844, 834x1112 and 1440x900 against a dev server, on both `127.0.0.1` and `localhost`: zero 403s, zero hydration errors, and chat panel, header nav drawer, contact form and sidebar all live at the loopback address. Modal contracts held on both sides of `lg` — `aria-modal` with siblings `inert` and `body overflow:hidden` below it, absent above — the full tab cycle wrapped in both directions, Escape returned focus to the launcher, and every measured contrast ratio passed.

`verifier` independently reproduced the mechanism against a live `next dev` on 3100 rather than taking the unit guard's word for it:

```
Origin: http://127.0.0.1:3100  -> 200      (403 before this change)
Origin: http://[::1]:3100      -> 200
Origin: http://localhost:3100  -> 200
Origin: http://evil.example    -> 403      control
```

The journey suite and `e2e-smoke` were deliberately not run. The composed stack runs `next start` against a production build, which neither key can reach; the production build in the merge gate is the check that applies.

## Review

`code-review` returned one defect and one refinement, both applied:

- **Defect** — `apps/web/next-env.d.ts` was sitting modified in the worktree from the dev and build runs (#275 churn) and would have been swept into the commit. Restored.
- **Refinement** — the `allowedDevOrigins` comment justified itself with `make e2e-smoke`, which does probe `127.0.0.1:3100` literally but against the compose stack, where `next start` serves a production build and the key is never consulted. The comment now cites `make dev` / `make dev-web` and says explicitly that `e2e-smoke` is not affected.

It also independently reproduced the guard's red phase against the real gate under six mutated allowlists, and confirmed something worth recording: with a non-`/_next` URL, `isInternalEndpoint` short-circuits and every origin is allowed, so the three positive assertions would pass vacuously and only the `evil.example` control catches it. The control is load-bearing rather than decorative.

A second round returned **no defects** and two more refinements, both applied — both were comments of mine that overstated what the code does:

- The `agentRules` comment said the unwanted `AGENTS.md` write happens "on every boot, on every machine". It does not: `ensureAgentRulesForDev` returns early when `getAgentName()` is null, so it fires under a coding agent (`CLAUDECODE`, `GEMINI_CLI`, `CURSOR_AGENT`, a `COPILOT_*` variable and their equivalents) and not from a plain shell. Verified against `detect-agent` and `app-info-log.js` rather than taken on trust.
- The guard's `localhost` assertion was documented as catching a config change that replaced Next's defaults. That is unreachable — the gate prepends `['**.localhost', 'localhost', ...]` unconditionally, so it passes with the key absent entirely. The comment now says what it actually pins: Next's own hardcoded default.

### One finding recorded as disputed

The review argued `agentRules: false` is more strongly justified than stated, because the default also writes `apps/web/CLAUDE.md`, which `make agent-docs-check` gates in CI — so every `make dev` would arm a CI failure.

The conclusion is right but that specific mechanism is not what happens here. Measured on a clean tree, `next dev` with the default modified `apps/web/AGENTS.md` and `apps/web/next-env.d.ts` and left `apps/web/CLAUDE.md` untouched — the pointer file already exists, so nothing is written to it. The justification rests on the `AGENTS.md` write, which is real and was observed directly, not on a CI gate that would have fired.

Raised back with the reviewer, which agreed and supplied the mechanism: `generate-agent-files.js` takes the branch `if (agentsMdExists && (agentsMdHostsBlock || !claudeMdHostsBlock))` and returns `claudeMd: 'skipped'`. `apps/web/CLAUDE.md` exists and carries no marker block, so that branch is always the one taken here. Left in the commit body as a recorded disagreement and its resolution.

## Filed, not fixed here

- **#275** — `next dev` rewrites tracked `next-env.d.ts` and `tsconfig.json` on every boot, and appends a doubled, non-existent `.next/dev/dev/types/**/*.ts` include to `tsconfig.json`. Found because the first version of the guard started a dev server. Pre-existing and independent of this change.
- **#276** — whether a focus landing on `document.body` should close the chat panel, the closing question of #228. It was never firing on the reported repro, so it is a real question about the component and stands on its own.
- **#277** — Next's dev-tools indicator sits on top of the chat input on the phone sheet, rendering the placeholder as "bout a product…". `ui-review` recommended `devIndicators: false` in this same file; left out, because switching off a diagnostic for everyone who clones the repository to unobstruct one component at one width is a trade rather than a fix. The issue records the options.
- **#278** — the chat sheet's header buttons are 36x36 where the send button beside them is 44x44, on the sheet where Close is the only way out. Pre-existing.
- **#279** — the Playwright MCP server is pinned to branded Chrome, which is not installed, so `ui-review` had to build its own harness to render anything. One step away from the source-only-review failure the runbook warns about.
- **#280** — root-level test files in `apps/web` are type-checked by nothing, this new one and the pre-existing `next.config.test.ts` alike.
- **#281** — `apps/web/vitest.config.ts` warns on every `make test-web` run and stops loading altogether when `configLoader: 'native'` becomes the Vite default.

## Not done here

The `playwright.config.ts` comment #228 calls out is now half-true rather than misleading: chat *message* journeys do cross web, chat and the database, but opening the panel does not, and with this fix chat UI is reviewable on a plain dev server. Left alone to keep the diff to the defect.
