### PR TITLE
docs(web): point the dev-churn comments at the right issues

### DIFF
--- a/apps/web/next-dev-origins.test.ts
+++ b/apps/web/next-dev-origins.test.ts
@@ -32,8 +32,9 @@ import { describe, expect, it } from 'vitest'
  * and a second one exits 1 with "Another next dev server is already running".
  * So `make test-web` failed for anyone who had `make dev` up -- green in CI,
  * where nothing else is running, and broken on exactly the machines doing the
- * development. It also had to snapshot and restore two tracked files the dev
- * server rewrites on boot, which is #275.
+ * development. It also had to snapshot and restore two tracked files a dev
+ * server rewrites: `next-env.d.ts` on boot, which is #260, and `tsconfig.json`
+ * once it has served a page, which is #275.
  */
 
 // `require` rather than `import`, matching `next.config.test.ts` beside it:

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -67,8 +67,9 @@ const nextConfig = {
   // and carries no marker block -- measured, and the branch that decides it is
   // in `generate-agent-files.js`.
   //
-  // The rest of what `next dev` rewrites on boot is #275 and is not fixed here.
-  // This one is, because it lands in an instruction file rather than a
+  // The rest of what a dev server rewrites is #260 (`next-env.d.ts`, on boot)
+  // and #275 (`tsconfig.json`, once it has served a page), and is not fixed
+  // here. This one is, because it lands in an instruction file rather than a
   // generated one.
   agentRules: false,
 


### PR DESCRIPTION
Follow-up to #282, which merged with two comments pointing at #275 for everything `next dev` rewrites.

Cleaning up afterwards, two of the three files #275 covered turned out to be tracked by issues that were already open and that I had failed to check for before filing:

- **`next-env.d.ts` was already #260.** That issue now also records something that changes its fix: `next dev` and `next build` write *different* contents, derived from `distDir`, so committing either version leaves the other dirty. Pinning to what `next build` emits — the obvious reading of #260 — would leave every `make dev` user permanently dirty.
- **`apps/web/AGENTS.md` was already #265**, filed before mine with better analysis. #282 fixed it via `agentRules: false` without referencing it. Now closed, with two details added that were not in it: the write only fires under a detected coding agent, and `CLAUDE.md` was never at risk because `generate-agent-files.js` explicitly skips it.

#275 is re-scoped to the one part nothing else tracked — the doubled, non-existent `.next/dev/dev/types/**/*.ts` include appended to `tsconfig.json` — so a bare "#275" no longer covers what these comments claimed.

## The change

Comment text only, four lines. Each reference now names the file beside the number, so a future re-scope cannot strand it — the reviewer's point that the drift protection is the filename, not the number.

It also corrects the timing while in these lines: the `tsconfig.json` append happens once a dev server has **served a page**, not at boot. That is why it did not show up alongside the boot-time writes when this was first measured, and "on boot" would have sent someone looking for it in the wrong place.

## Verification

`make -C apps/web ci` — lint clean at zero warnings, type-check, 157 tests across 37 files, production build. `code-review` approved with no defects; both refinements it offered are applied (naming the files, and the reflow).

**One thing to flag:** the first `make -C apps/web ci` run on this branch **failed**, then passed unchanged. That is filed as **#283** — `src/app/page.test.tsx` exceeds vitest's default 5s timeout under machine load (measured at 8640ms and 5280ms on failing runs, reported at the `it` declaration rather than the assertion). It reproduced 2 runs in 3 while the machine was busy and has been green ~10 runs since. Not caused by this change, which is comment-only, but I am not reporting a green gate without saying that the first one was red.

The final gate run here was clean end to end.

Refs #260, #275