### PR TITLE
docs(agents): cover the MCP browser failure ui-review actually hits

### DIFF
--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -41,7 +41,25 @@ cd apps/web && node -e 'const p = require("@playwright/test").chromium.executabl
 
 Ask Playwright where its browser is and then check that the file exists. Two ways of answering this question look right and are not: `npx playwright install --dry-run` prints an "Install location:" line for browsers that are *not* installed and exits 0 either way, so it cannot distinguish the cases at all; and a hardcoded cache path is platform-specific — browsers live under `~/.cache/ms-playwright` on Linux and `~/Library/Caches/ms-playwright` on macOS, so a Linux-shaped glob reports "no browser" on every Mac. A probe built on the first of those reported "no browser" on a machine with a working Chromium, and every UI change got a source review that claimed to be the real thing.
 
-Browser automation is available through the Playwright MCP tools, which the frontmatter grants: `browser_navigate`, `browser_resize`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_press_key`, `browser_hover`, `browser_evaluate`, `browser_console_messages`. Load their schemas with `ToolSearch` before the first call. Where the MCP server is not connected, `Bash` still reaches the same browser — `npx playwright screenshot --viewport-size "390, 844" <url> <file>` for stills, or a short script in a scratch directory outside the repository for anything interactive.
+Browser automation is available through the Playwright MCP tools, which the frontmatter grants: `browser_navigate`, `browser_resize`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_press_key`, `browser_hover`, `browser_evaluate`, `browser_console_messages`. Load their schemas with `ToolSearch` before the first call.
+
+Those tools failing is not the same question as the probe above, and a green probe does not predict them. **The probe is about whether `Bash` can render**, though not as directly as it looks: it resolves `@playwright/test`'s full Chromium, while a headless run opens the `chrome-headless-shell` sitting beside it. `make -C apps/web install-e2e-browsers` fetches the pair, so on a machine set up that way the one vouches for the other. The MCP server drives a browser of its own, and there are two ways it comes up empty:
+
+- **Not connected**, in which case the tools are simply absent.
+- **Connected, and every call fails** with `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`. `@playwright/mcp` drives branded Google Chrome by default — it sets `channel: "chrome"` whenever no browser is named. Any machine with a working Chromium and no Google Chrome hits this on the first call. See #279.
+
+  Not unfixable, and do not report it as such — but the two settings that address it are not interchangeable, so name the right one. `--executable-path`, or `PLAYWRIGHT_MCP_EXECUTABLE_PATH`, points the server at a binary you name, and so at the one the probe just found. `--browser chromium` does not: it selects the server's *own* bundled Chromium, whose revision the server pins independently of this repository's, and measured here that is 1237 against the 1234 `apps/web` installed — one missing browser traded for another.
+
+  Either way it is the server's configuration and not a review's to set. Say what it needs and carry on rendering through `Bash`. Whether this repository should configure a server of its own is #279's question to settle.
+
+Neither is a reason to fall back to reviewing source, and the second is the more dangerous one, because the tools appear to be available right up until they are used. `Bash` renders in both cases, provided it reaches the same Playwright the probe used — which takes one deliberate step in each direction:
+
+- **Stills:** `cd apps/web && npx playwright screenshot --viewport-size "390, 844" <url> <file>`. The `cd` is load bearing. `npx` from elsewhere resolves an install of its own choosing, pinning a Chromium revision that need not be present — the same class of mismatch as `--browser chromium` above, arriving by a different route.
+- **Anything interactive:** a short script in a scratch directory outside the repository, requiring Playwright by absolute path — `require('<repo>/apps/web/node_modules/playwright')`. `cd` does not help here, because Node resolves a script's imports from the script's own directory rather than the working one, so a bare `require('playwright')` from a scratch directory fails whatever you `cd` to. Measured both ways.
+
+Keep the script outside the repository either way. Moving it inside to fix the import would be modifying the tree you were asked to assess.
+
+Say in the writeup which path you rendered through. "The MCP tools were unavailable so I drove Chromium through `Bash`" is a complete answer; silence reads as though the tools worked.
 
 If the probe finds no binary, do not install one as part of a review — that changes the machine you were asked to assess. Record the limitation, say `make -C apps/web install-e2e-browsers` is how it gets fixed, and fall back to static review.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,15 @@ was unavailable, rather than skipping the step or reporting it as done.
 Where none is installed it falls back to reviewing source and must say so; a
 review that claims viewports it never rendered is worse than none.
 
+A browser being installed and the *tools* reaching one are different questions,
+and only the first is what "none is installed" describes. The Playwright MCP
+server drives branded Chrome by default and fails every call on a machine that
+has only Playwright's own Chromium — so the tools can be present, and broken,
+while a browser sits there working. That is not a fallback-to-source case:
+`Bash` still drives the installed browser. `ui-review` carries the detail; what
+belongs here is that a rendered review remains required in that state, and that
+the writeup says which path rendered it.
+
 ## Repo map
 
 - `apps/web/src/app/`: Next.js pages and API routes.


### PR DESCRIPTION
Fixes #279.

## What was wrong

`ui-review` told itself to fall back to `Bash` "where the MCP server is **not connected**". #279 is a state that sentence does not describe: the server *is* connected, the tools are listed in its frontmatter, and every call fails with

```
Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
```

An agent reading it literally has no instruction covering its situation. The danger is specific — the tools look available right up until they are used, so the failure lands after the agent has committed to the rendered path.

## #279's own diagnosis was wrong, twice

The issue said the MCP server was *configured* to use branded Chrome and the fix was to drop a `channel: 'chrome'` pinning. There is no pinning: this repository configures no Playwright MCP server, and the plugin's config is a bare `npx @playwright/mcp@latest`. Branded Chrome is `@playwright/mcp`'s default — it sets `channel: "chrome"` whenever no browser is named.

I then corrected it to say `--browser chromium` was "not a thing", which was also wrong — it exists, `--help` is just incomplete. Both corrections are on the issue.

## The change

Names the failure, gives the two settings that address it and the difference between them, and says neither is a review's to set:

- `--executable-path` (or `PLAYWRIGHT_MCP_EXECUTABLE_PATH`) points the server at a binary you name.
- `--browser chromium` selects the server's **own** bundled Chromium, whose revision it pins independently of this repository's — measured here 1237 against the 1234 `apps/web` installed, so it trades one missing browser for another.

Whether this repository should ship a server of its own stays with #279, which is the trade #148 says to surface rather than settle quietly.

### The `Bash` fallback, corrected in the same pass

This change promotes that fallback from a footnote to the primary path, and it had a latent bug in each direction:

- **Stills** need `cd apps/web`, or `npx` resolves an install of its own choosing at a revision that need not be present.
- **Interactive** needed more: Node resolves a script's imports from the *script's* directory, so a bare `require('playwright')` from a scratch directory fails whatever you `cd` to. The absolute path into `apps/web/node_modules` works. Measured all three ways — and I had hit this myself earlier today without recognising it as a documented-path bug.

### Why `AGENTS.md` is in the same commit

Its sub-agent section framed browser availability as binary; the definition it governs now documents a third state. The runbook is what a caller reads when deciding whether a source-only step 6 was legitimate, so the two disagreeing is worse than either being incomplete. Reason stated in the commit body, as the runbook requires for an in-change fix.

## Verification, and its limits

`make docs-check`, `make test-scripts` (183) and `make agent-docs-check` all pass. `make -C apps/web ci` does not apply.

**Not demonstrated at runtime, and it cannot be in the session that wrote it.** Same-session edits to `.claude/agents/*.md` are not picked up by agents invoked afterwards — filed as **#285**, found when a `ui-review` I ran as a demonstration quoted back a sentence I had already deleted. What *is* established: that run hit the confusion with the old text, called the sentence wrong for its case, and proposed this rewording independently.

**Six review rounds found six defects**, all one shape: a real measurement generalised into an impossibility — "cannot be pointed at", "no value selects it", "no commit here fixes it". Worth recording because nothing in either gate reads an agent definition's body beyond one regex already satisfied by unrelated text, so review was the only thing between this file and confident wrong instructions. That is #160's case, where the measurement is recorded.

## Filed, not fixed here

- **#287** — the browser probe resolves `@playwright/test`'s full Chromium while every headless render opens `chrome-headless-shell` beside it. On a shell-only install the probe reports MISSING and the agent falls back to source on a machine that would have rendered — the same incident the paragraph above the probe memorialises, via the probe that replaced it.
- **#285** — stale agent definitions within a session.
- **#286** — the chat launcher overlaps `/contact`'s submit button at phone width.
- **#283** — `page.test.tsx` flakes on a 5s timeout under load.

Refs #279