### PR TITLE
fix(web): stop the dev indicator answering for production keyboard order

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -73,6 +73,58 @@ const nextConfig = {
   // generated one.
   agentRules: false,
 
+  // The dev-tools indicator is a focusable element sitting after the chat
+  // widget in the document, and that makes dev disagree with production about
+  // keyboard behaviour the widget was deliberately designed for. Measured at
+  // 1440x900 with the panel open, tabbing forward from the message input:
+  //
+  //   indicator on                     indicator off
+  //   1. Send message     dialog=1     1. Send message  dialog=1
+  //   2. Close chat       dialog=1     2. Close chat    dialog=1
+  //   3. NEXTJS-PORTAL    dialog=0     3. BODY          dialog=1
+  //                                    4. #name         dialog=0
+  //
+  // `chat.tsx` argues at length that Tab forward off the launcher should leave
+  // the page entirely, fire no `focusin`, and leave the panel up -- closing it
+  // for the address bar would be closing it for something that is not a page
+  // interaction. The indicator is a page interaction, so the panel closes a
+  // keystroke early. The right-hand column is what production does.
+  //
+  // So a chat keyboard journey reviewed on a dev server answered a question
+  // about the dev server. That mattered more after #282, which made the panel
+  // reachable under `next dev` at the loopback address rather than at
+  // `localhost` alone.
+  //
+  // It also covers the message input at 390x844, where the sheet is full width
+  // -- which is what #277 was filed for, and is the smaller half.
+  //
+  // Three things go with it, all separately gated on the same flag: the Dev
+  // Tools menu and its trigger (route info, bundler, preferences, segment
+  // explorer), the cache badge, and the build-activity pill -- so there is no
+  // "compiling" or "rendering" feedback in dev either. For the route's
+  // static/dynamic verdict, which `apps/web/AGENTS.md` does care about, plain
+  // `next build` prints `○` and `ƒ` per route and CI produces it on every run.
+  //
+  // Errors still surface with this off. That is Next's separate issues badge,
+  // and it is also the boundary on everything above: the issues badge is the
+  // same portal in the same place, is focusable in the same way, and appears on
+  // the first logged error -- which this application produces itself, from the
+  // `catch` in `sendChatMessage` (`src/lib/messaging.ts`), on any stack with no
+  // chat service.
+  //
+  // With one edge worth knowing, because it is specific to turning the
+  // indicator off: collapsing the issues badge sets a flag that nothing resets,
+  // so one click on its X hides it for the rest of the page session, later
+  // errors included. On the default path the same click is resynced by the
+  // error count.
+  //
+  // Measured after one failed send, the left-hand column returns with two dev
+  // stops rather than one, and at 390 the badge covers the input's left third.
+  // So this narrows when dev disagrees with production; it does not end it. A
+  // keyboard journey that has to match production belongs on a production
+  // build -- #290. See #277.
+  devIndicators: false,
+
   images: {
     deviceSizes,
   },


### PR DESCRIPTION
Fixes #277.

## What this is really about

#277 was filed as a cosmetic overlap — Next's dev-tools indicator covering the chat message input at 390x844, where the panel is a full-width sheet. The reason to take it is keyboard behaviour.

The indicator is a **focusable element positioned after the chat widget in the document**, so a dev server disagreed with production about the behaviour `chat.tsx` was most deliberately designed for. Measured at 1440x900 with the panel open, tabbing forward from the message input:

```
indicator on                     indicator off
1. Send message     dialog=1     1. Send message  dialog=1
2. Close chat       dialog=1     2. Close chat    dialog=1
3. NEXTJS-PORTAL    dialog=0     3. BODY          dialog=1
                                 4. #name         dialog=0
```

`chat.tsx` argues at length that Tab forward off the launcher should leave the page entirely, fire no `focusin`, and leave the panel **up** — closing it for the browser's address bar would be closing it for something that is not a page interaction. The indicator *is* a page interaction, so the panel closed a keystroke early.

`ui-review` reproduced the right-hand column independently against a dev server running this change, `#name` included, and confirmed the input is unobstructed at 390x844.

This mattered more after #282, which made the panel reachable under `next dev` at the loopback address rather than at `localhost` alone.

## What it costs

Three things gated on the same flag: the Dev Tools menu and its trigger, the cache badge, and the build-activity pill — so no "compiling"/"rendering" feedback in dev. Errors are **not** among them; that is Next's separate issues badge.

For the route static/dynamic verdict that `apps/web/AGENTS.md` cares about, plain `next build` prints the `○`/`ƒ` table and CI produces it every run.

## The boundary, stated rather than left to be found

This narrows when dev disagrees with production; it does not end it. The issues badge is the same portal in the same place, focusable in the same way, and appears on the first logged error — which this application produces itself, from `sendChatMessage`'s `catch` on any stack with no chat service. After one failed send the left-hand column returns with **two** dev stops instead of one.

**#290** carries the general form: nothing tells `ui-review` that a keyboard journey needs a production build.

## No test, deliberately

The effect is DOM tab order on a running dev server, and there is no seam to assert it through. `devIndicators` is a DefinePlugin constant (`process.env.__NEXT_DEV_INDICATOR`) consumed inside the compiled devtools bundle — no analogue to the `blockCrossSiteDEV` call that `next-dev-origins.test.ts` uses. Vitest cannot start a dev server (one per `distDir` via `.next/dev/lock`, the same lock that killed #282's first guard), and the journeys run against `next start`, where the indicator does not exist. Asserting the config key would be the declaration check root `AGENTS.md` rejects.

`verifier` was asked to find a seam rather than accept that reasoning, went looking in `next/dist`, and found none.

## Verification

`make -C apps/web ci` clean — lint, typecheck, 157 tests, production build, no config-schema complaint. Journeys and smoke not run: `devIndicators` cannot reach a `next start` stack.

Review found four of my own overstatements and I corrected each against the source rather than on report: the `console.error` was attributed to `settleWithError`, which is unreachable here because `sendChatMessage` resolves rather than rejects; `--debug` was named as producing the route table when `printTreeView` sits outside that block; the cost was understated as the menu alone; and "#282 made the panel reachable at all" overshot what #282 fixed.

## Filed, not fixed here

- **#289** — on the phone sheet, `Send` appears at exactly the coordinates the launcher was tapped (`{334,788}` both), measurable via its hover fill.
- **#290** — nothing tells `ui-review` that keyboard journeys need a production build.

Refs #277