### PR TITLE
chore(web): load the vitest config the way Vite is going to load it

### DIFF
--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -14,7 +14,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      // `__dirname` is unavailable under `configLoader: 'native'`, which is
+      // planned to become Vite's default. Vite still bundles this file today
+      // and defines both, so this is forward compatibility rather than a fix
+      // for anything currently broken.
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
 })

--- a/tests/scripts/test_e2e_journey_wiring.py
+++ b/tests/scripts/test_e2e_journey_wiring.py
@@ -180,8 +180,27 @@ class JourneyWiringTests(unittest.TestCase):
 
         Collected by vitest they fail on `@playwright/test` imports it cannot
         run, which reads as a broken unit suite rather than a config problem.
+
+        The config is located rather than named. This read `vitest.config.ts`
+        by hand until #281 renamed it to `.mts`, at which point it raised
+        `FileNotFoundError` -- a stack trace about a missing path, rather than
+        the exclusion being gone.
+
+        Extensions are enumerated rather than globbed because the list is then
+        exactly the set vitest will load: no sibling -- an editor backup, an
+        `.orig` left by a conflict, a stray bundled artifact -- can be counted
+        as the config.
         """
-        self.assertIn("e2e/**", read("apps/web/vitest.config.ts"))
+        candidates = [
+            path
+            for extension in ("ts", "mts", "cts", "js", "mjs", "cjs")
+            if (path := REPO_ROOT / f"apps/web/vitest.config.{extension}").exists()
+        ]
+        # Vacuity guard: `assertIn` against a missing file cannot run at all,
+        # and against two configs would pass on whichever came first while
+        # vitest read the other.
+        self.assertEqual(len(candidates), 1, f"expected one vitest config, found {candidates}")
+        self.assertIn("e2e/**", candidates[0].read_text(encoding="utf-8"))
 
     def test_retries_are_not_enabled(self):
         """A retried failure is a failure that gets ignored.


### PR DESCRIPTION
Fixes #281.

## Two blockers, and the second only appeared once the first was gone

Every `make test-web` run warned the config uses features unsupported by `configLoader: 'native'`, which is planned to become Vite's default — at which point the config stops loading rather than warning.

The issue proposed renaming to `.mts`. That clears the ESM-loaded-as-CommonJS complaint and reveals a second warning from the same check: `` `__dirname` (vitest.config.mts:17:25). Use `import.meta.dirname` instead ``.

Measured warning count:

| state | warnings |
| --- | --- |
| before | 1 |
| after the rename alone | **1** |
| after rename + `import.meta.dirname` | 0 |

So the suggested fix on its own would have left the deprecation in place while looking handled.

## Nothing is broken today

Vite still bundles this file and defines **both** `__dirname` and `import.meta.dirname` in that mode, so this is forward compatibility rather than a fix for a live failure. The comment says that, after review caught it claiming the file was "now read by" the native loader — which is not true yet.

## Why the Python guard is in the same commit

`tests/scripts/test_e2e_journey_wiring.py` read `apps/web/vitest.config.ts` by hardcoded name to assert vitest excludes the Playwright specs. The rename turns that into `FileNotFoundError` — a stack trace about a missing path rather than a statement about the exclusion — so this change is what breaks it.

It now enumerates the extensions vitest will load and asserts exactly one exists. The vacuity guard matters in both directions: zero matches would otherwise raise `IndexError` from `candidates[0]`, and two would let the assertion pass against whichever extension came first in the tuple while vitest loaded the other.

| Mutation | Result |
| --- | --- |
| config extension outside the enumerated set | `AssertionError: 0 != 1 : expected one vitest config, found []` |
| `e2e/**` removed from the config | original assertion fails on the file contents |

## The `@` alias

It is the only thing `import.meta.dirname` feeds. My first evidence was "157 tests pass, many import through `@/`" — `verifier` correctly pointed out the spec I had in mind uses `import type`, which is erased at compile time and proves nothing about runtime resolution. The real witnesses are six specs importing *values* through `@/lib/...` (`api/signup`, `api/profile`, `api/categories`, `products/category/[slug]`, …), and `path.resolve` would throw at config load if the value were undefined.

## Verification

`make -C apps/web ci` (157 tests / 37 files, production build) and `make test-scripts` (183). The warning is confirmed gone rather than relocated by grepping raw `npx vitest run` output for `configLoader`. No other reference to `vitest.config.ts` survives anywhere in the repo. `import.meta.dirname` is stable since Node 20.11 against this repo's Node 22 baseline.

Rendered UI review is not applicable: test configuration only, `next build` output unaffected.

## Review caught one thing worth naming

The rename was **staged** by `git mv` while the `import.meta.dirname` edit was **unstaged** — so a plain `git commit` would have shipped a `.mts` file still containing `__dirname`, the exact state this fixes. Both paths were staged explicitly and the staged blob checked before committing.

I also had the enumeration justified by a mechanism that does not exist — I claimed vitest writes `vitest.config.*.timestamp-*.mjs` beside the config; it writes to `node_modules/.vite-temp/`, and the alongside path is a fallback unreachable here. The enumeration is still right, for the reason now recorded.

Refs #281