### PR TITLE
chore(tooling): classify the dependabot config instead of letting it fall through

### DIFF
--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -19,6 +19,13 @@ RUNTIME_PATTERNS = (
     ".github/CODEOWNERS",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/**",
+    # Reached runtime through the unknown fallback before this, so the routing
+    # was right by accident and indistinguishable from an oversight -- which is
+    # how #253 was found. Runtime for the same reason as the three entries above
+    # it: repository metadata that changes no runtime code, gated as runtime
+    # anyway. It also keeps the effective routing byte-identical to the fallback
+    # it replaces, so this narrows `unknown` without changing what CI runs.
+    ".github/dependabot.yml",
     "Makefile",
     "mise.toml",
     "package.json",

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -228,6 +228,29 @@ class DetectChangedSurfacesTests(unittest.TestCase):
         self.assertFalse(flags["unknown"], "should match a pattern, not fall through")
         self.assertIn("test-scripts", detect_changed.recommended_targets(flags))
 
+    def test_dependabot_config_is_runtime(self):
+        """The Dependabot config is repo tooling, not an unclassified path.
+
+        Same shape as the agent definitions above, and the same reason: it
+        reaches runtime through the unknown fallback, so the routing has always
+        been right by accident. `unknown` is the catch-all for paths nobody has
+        classified, and every known file that leans on it makes the flag mean
+        less -- it cannot then be tightened without silently reclassifying
+        whatever else was sheltering there.
+
+        Runtime rather than something narrower for two reasons, neither of
+        which is about the guards that read the file: `test-scripts` runs for
+        every non-empty change regardless of surface, so those run either way.
+        It is the same class of repository metadata as `.github/CODEOWNERS` and
+        the templates beside it, which are already runtime; and runtime is the
+        one option that leaves the effective routing identical to the fallback
+        it replaces, so `unknown` narrows with no change to what CI runs.
+        """
+        flags = detect_changed.classify([".github/dependabot.yml"])
+        self.assertTrue(flags["runtime"])
+        self.assertFalse(flags["unknown"], "should match a pattern, not fall through")
+        self.assertIn("test-scripts", detect_changed.recommended_targets(flags))
+
     def test_changed_files_from_range_includes_deletions(self):
         """A deletion-only change must still classify its surface.
 


### PR DESCRIPTION
Fixes #253.

## What was wrong

`.github/dependabot.yml` matched no pattern in `detect_changed_surfaces.py`, so a change touching only it classified as `unknown` — and `unknown` force-falls-back to the full runtime recommendation. The routing was right **by accident**, and indistinguishable from an oversight. That is how #253 was found.

## Behaviour does not change

Measured, not assumed: recommended targets for `.github/dependabot.yml` and for an unrecognised path are identical lists, and `unknown` is the only flag that moves. `verifier` confirmed the same by diffing the module against a copy with the entry deleted, across four file sets.

Nothing in `ci.yml` gates on `unknown` either — it is exported as a job output and read by no `if:`.

What changes is what the flag *means*. `unknown` is the catch-all for paths nobody has classified, and every known file leaning on it makes the flag harder to tighten later without silently reclassifying whatever else was sheltering there.

## Why runtime rather than narrower

#253 floated three options. This takes the third — classify deliberately, leave routing alone — for two reasons:

- It is the same class of repository metadata as `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/**`, all already runtime **by explicit pattern**, not by fallback.
- It is the only option leaving effective routing untouched. Narrower would drop `env-contract`, `web-ci`, `chat-ci`, `integration-e2e` and `onboarding-smoke` for this file — a real change to what gates a real file, which #253 did not establish is safe.

Narrower is also not reachable in one line: `ALL_PATTERNS` is the union of the four surface tuples, so "known but on no surface" is a new concept in `classify`, and it reopens CODEOWNERS and the templates with it. That is a design change with its own review.

## The first version of this comment was false, and that matters here

I justified runtime by saying the guards reading this file live in `tests/scripts`, itself a runtime pattern. **That is wrong.** `recommended_targets` appends `test-scripts` under `if not flags["none"]`, and `ci.yml`'s script-tests job gates on `none != 'true'` — so those guards run for any non-empty change whatever its surface. A docs-only change measures as `['test-scripts', 'docs-check']`.

Worth recording because the sentence was not invented — I **copied it** from the `docker-compose.yml` entry three lines below, where it was true when written in #111 and was invalidated the next day by #124.

**The comment is this change's entire deliverable.** Behaviour is unchanged, so a recorded reason that does not hold would have been worse than the accident it replaced: right by accident, and now *falsely explained*, which reads as audited. `code-review` caught it.

## Verification

`make test-scripts` — 191, up from 190. `make -C apps/web ci` and `make docs-check` do not apply: the detector reports `web=false`, `docs=false` for this diff and no Markdown changed. Rendered UI review is not applicable.

Red phase: before the pattern was added the new test failed with `AssertionError: True is not false : should match a pattern, not fall through` — `runtime` already True via the fallback, only `unknown` wrong. `assertFalse(flags["unknown"])` is the discriminating assertion; the other two pin the no-routing-change half.

## Filed, not fixed here

- **#296** — the `docker-compose.yml` rationale this one was copied from is still stale, in the comment and in `test_compose_changes_are_runtime`'s docstring, whose `assertIn("test-scripts", ...)` passes with or without the entry.
- **#297** — git C-quotes paths containing a space or non-ASCII, and this module reads them literally, so `"apps/web/a b.ts"` misses `apps/web/**` and classifies as `unknown`. Fails safe, but lands on the same flag from the other direction.

Refs #253