### PR TITLE
fix(agents): make ui-review's browser probe launch a browser

### DIFF
--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -36,19 +36,49 @@ It also affects the UI if it moves a rendering dependency in `apps/web/package.j
 Check for a browser before planning to use one:
 
 ```bash
-cd apps/web && node -e 'const p = require("@playwright/test").chromium.executablePath(); console.log(require("fs").existsSync(p) ? "browser: " + p : "browser: MISSING at " + p)'
+cd apps/web && node -e 'require("@playwright/test").chromium.launch({ timeout: 20000 }).then(async b => { const v = b.version(); await b.close(); console.log("browser: ok " + v) }).catch(e => console.log("browser: UNUSABLE - " + String(e).split("\n").filter(l => /launch:|\[err\]|Missing librar/.test(l)).slice(0, 2).join(" | ")))'
 ```
 
-Ask Playwright where its browser is and then check that the file exists. Two ways of answering this question look right and are not: `npx playwright install --dry-run` prints an "Install location:" line for browsers that are *not* installed and exits 0 either way, so it cannot distinguish the cases at all; and a hardcoded cache path is platform-specific — browsers live under `~/.cache/ms-playwright` on Linux and `~/Library/Caches/ms-playwright` on macOS, so a Linux-shaped glob reports "no browser" on every Mac. A probe built on the first of those reported "no browser" on a machine with a working Chromium, and every UI change got a source review that claimed to be the real thing.
+Start a browser and stop it again. Anything short of that answers a nearby question instead of this one, and three ways of doing so look right:
+
+- `npx playwright install --dry-run` prints an "Install location:" line for browsers that are *not* installed and exits 0 either way, so it cannot distinguish the cases at all.
+- A hardcoded cache path is platform-specific — browsers live under `~/.cache/ms-playwright` on Linux and `~/Library/Caches/ms-playwright` on macOS, so a Linux-shaped glob reports "no browser" on every Mac.
+- `existsSync(chromium.executablePath())` checks a file no headless run opens. `executablePath()` resolves the full Chromium; a headless `launch()` runs the `chrome-headless-shell` beside it.
+
+The first of those reported "no browser" on a machine with a working Chromium, and every UI change got a source review that claimed to be the real thing. The third disagrees with reality on two configurations and only those, measured against installs carrying one binary but not the other:
+
+```
+                            both installed   full only        shell only   neither
+existsSync(executablePath)  "browser: <..>"  "browser: <..>"  "MISSING"    "MISSING"
+launch()                    ok 151.0…        UNUSABLE         ok 151.0…    UNUSABLE
+```
+
+The file check observes one of the two binaries, so it can only split four configurations two ways: it groups `both installed` with `full only`, and `shell only` with `neither`. `launch()` groups them across that line — `both installed` with `shell only`, `full only` with `neither`. The two disagree exactly where the groupings cross, which is `full only` and `shell only`.
+
+The two outer columns are why the file check survived this long: it agrees with reality on both configurations this repository actually produces — nothing installed, and the pair that `make -C apps/web install-e2e-browsers` and CI both fetch. No machine set up either way ever contradicted it.
+
+A third configuration it gets wrong has no column at all, because a table of which files exist cannot show it: a browser that is present and will not start. The file check calls that present; *Launching also catches* below is where that one is dealt with.
+
+Shell-only is not hypothetical: `playwright install --only-shell` is what Playwright recommends for CI images. There the file check reports MISSING and sends you to a source review on a machine that would have rendered every viewport.
+
+Launching also catches a browser that cannot start — missing system libraries, most often — which a file check calls present. That is the point rather than a side effect: a browser that will not launch is not a browser this review can use.
+
+It is the reason the probe filters the error rather than taking its first line. A browser that starts and dies reports `Target page, context or browser has been closed`, which names no cause; the loader's complaint arrives several lines down under `Browser logs:`. Taking the top line loses exactly the case that needs distinguishing from a missing download.
 
 Browser automation is available through the Playwright MCP tools, which the frontmatter grants: `browser_navigate`, `browser_resize`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_press_key`, `browser_hover`, `browser_evaluate`, `browser_console_messages`. Load their schemas with `ToolSearch` before the first call.
 
-Those tools failing is not the same question as the probe above, and a green probe does not predict them. **The probe is about whether `Bash` can render**, though not as directly as it looks: it resolves `@playwright/test`'s full Chromium, while a headless run opens the `chrome-headless-shell` sitting beside it. `make -C apps/web install-e2e-browsers` fetches the pair, so on a machine set up that way the one vouches for the other. The MCP server drives a browser of its own, and there are two ways it comes up empty:
+Those tools failing is not the same question as the probe above, and a green probe does not predict them. **The probe answers whether `Bash` can render**, because it launches the browser `Bash` would drive. The MCP server drives a browser of its own, and there are two ways it comes up empty:
 
 - **Not connected**, in which case the tools are simply absent.
 - **Connected, and every call fails** with `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`. `@playwright/mcp` drives branded Google Chrome by default — it sets `channel: "chrome"` whenever no browser is named. Any machine with a working Chromium and no Google Chrome hits this on the first call. See #279.
 
-  Not unfixable, and do not report it as such — but the two settings that address it are not interchangeable, so name the right one. `--executable-path`, or `PLAYWRIGHT_MCP_EXECUTABLE_PATH`, points the server at a binary you name, and so at the one the probe just found. `--browser chromium` does not: it selects the server's *own* bundled Chromium, whose revision the server pins independently of this repository's, and measured here that is 1237 against the 1234 `apps/web` installed — one missing browser traded for another.
+  Not unfixable, and do not report it as such — but the two settings that address it are not interchangeable, so name the right one. `--executable-path`, or `PLAYWRIGHT_MCP_EXECUTABLE_PATH`, points the server at a binary you name. The probe above does not give you that path -- it reports a version, and the binary it launched is the headless shell -- so read it off separately if you are going to quote one:
+
+```bash
+cd apps/web && node -e 'const p = require("@playwright/test").chromium.executablePath(); console.log(p + (require("fs").existsSync(p) ? "" : "  <- does not exist"))'
+```
+
+Check the existence, do not skip it. That call computes a path from the browsers directory and the pinned revision without consulting the filesystem, so it answers on a `--only-shell` machine too -- naming a full Chromium that was never installed. Quoting it there hands the operator the same "is not found at" failure one path along. `--browser chromium` does not: it selects the server's *own* bundled Chromium, whose revision the server pins independently of this repository's, and measured here that is 1237 against the 1234 `apps/web` installed — one missing browser traded for another.
 
   Either way it is the server's configuration and not a review's to set. Say what it needs and carry on rendering through `Bash`. Whether this repository should configure a server of its own is #279's question to settle.
 
@@ -61,7 +91,7 @@ Keep the script outside the repository either way. Moving it inside to fix the i
 
 Say in the writeup which path you rendered through. "The MCP tools were unavailable so I drove Chromium through `Bash`" is a complete answer; silence reads as though the tools worked.
 
-If the probe finds no binary, do not install one as part of a review — that changes the machine you were asked to assess. Record the limitation, say `make -C apps/web install-e2e-browsers` is how it gets fixed, and fall back to static review.
+If the probe cannot launch a browser, do not install one as part of a review — that changes the machine you were asked to assess. Record the limitation, quote what the probe printed, say `make -C apps/web install-e2e-browsers` is how it gets fixed, and fall back to static review. Quote it because the two failures want different fixes: a missing download is that command's job, and a browser that is present but will not start is the machine's.
 
 To bring the stack up:
 


### PR DESCRIPTION
Fixes #287.

## What was wrong

The probe checked that `chromium.executablePath()` names a file that exists. **That file is the full Chromium; a headless `launch()` opens the `chrome-headless-shell` beside it.** So it checked a binary no review in this repository ever opens — a guard reading a nearby declaration rather than the behaviour it is asked about, which root `AGENTS.md` names directly under *Code Review Rules*.

## Measured

Built with `PLAYWRIGHT_BROWSERS_PATH` and symlinks; the real browser cache was never modified.

| | both installed | full only | shell only | neither |
| --- | --- | --- | --- | --- |
| `existsSync(executablePath)` | present | present | MISSING | MISSING |
| `launch()` | ok | UNUSABLE | ok | UNUSABLE |

The file check observes one of the two binaries, so it splits four configurations two ways and disagrees wherever the groupings cross.

**`shell only` is the dangerous column and is not hypothetical** — `playwright install --only-shell` is what Playwright suggests for CI images. There the old probe reported MISSING and sent the review to source **on a machine that renders every viewport**. That is the incident the paragraph above the probe already memorialises, recurring through the probe written to replace it.

Launching also catches a browser that is present and will not start, which no table of which files exist can show, and which the old check called present.

## Three details the probe would be wrong without

Each of these came out of review and each is measured:

- **`{ timeout: 20000 }`** — `DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT` is *three minutes*, not the 30s general default, and past the 120s `Bash` budget. A stalling browser got the probe killed before `.catch` ran, leaving nothing to quote.
- **The error is filtered by content, not truncated to line one.** A browser that starts and dies reports `Target page, context or browser has been closed` — naming no cause — with the loader's complaint several lines down under `Browser logs:`. Taking the top line loses exactly the case that must be told apart from a missing download, which is what the instruction below it asks for. I initially rejected a multi-line fix after measuring only the missing-download case; reproducing the start-and-die case with a shim showed the gap was taking lines *from the top*, not how many.
- **The `--executable-path` read-off checks the path exists.** `executablePath()` computes from the browsers directory and the pinned revision without consulting the filesystem, so on a `--only-shell` machine it names a full Chromium that was never installed — and a reviewer would have quoted a nonexistent path into a write-up.

## Verification

`make test-scripts` (190), `make docs-check` (8), `make agent-docs-check` — all pass. `make -C apps/web ci` does not apply; nothing under `apps/web/` changed.

Both fenced commands were extracted from the Markdown by regex over the raw bytes and run **verbatim** in every configuration above — they contain nested single quotes, a regex with escaped brackets, and an arrow literal, so a command that only works as retyped would be useless to the agent reading it. No browser process is left behind (checked with `ps`, after `pgrep -f` gave a false positive by matching its own command line).

**Not demonstrated, and not demonstrable in the session that wrote it:** that a `ui-review` run picks the new probe up. Same-session edits to `.claude/agents/*.md` are not reloaded — #285.

## Review

Four rounds, five defects, every one a claim generalised past its evidence — including two in prose I had just written to *correct* an earlier overstatement. Worth recording because nothing in the gates reads an agent definition's body beyond one regex already satisfied by unrelated text (#160), so review is the only thing between this file and confidently wrong instructions.

Refs #287