### PR TITLE
docs(agents): record how an agent definition reaches the agents, and who checks it

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -39,6 +39,12 @@ Read untracked files directly — they carry no diff. Also read enough surroundi
 
 **Test quality.** Whether new tests would fail if the behaviour regressed. A test that passes against both the old and new implementation verifies nothing. Say so when you see one.
 
+**Workflow obligations against the agent that carries them out.** When a change touches `AGENTS.md`'s numbered steps or its *Sub-agents this workflow depends on* section, or any file under `.claude/agents/`, read both sides. A requirement placed on step 6, 7 or 8 has to be described in the definition of the agent executing that step, and has to be something the tools that agent is granted can actually do.
+
+This is your remit because no test covers it. The guard suite reads names, tool lists, step numbers, and the instructions it matches by regex in the body (that the agent is told not to modify the repository, and that this bullet is still here) — never whether an obligation placed on a step appears in the agent that runs it. It has already happened — a step 6 addition required exercising changes at 2× device pixel ratio, while the executing definition specified three viewports and no notion of density, and none of its granted tools set `deviceScaleFactor`, that being a browser-context property rather than a resize argument. The failure is quiet: the agent does not refuse an obligation it was never given, it omits it and reports the step complete, and the caller reads a green report as the requirement met.
+
+The reverse direction counts too — a definition promising something the step never asked for is drift in the other direction, and the same read catches it.
+
 ## Scoring and filtering
 
 Score each candidate finding 0-100 for confidence that it is real and worth acting on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,73 @@ If one is unavailable — a different assistant, or a session started before the
 definitions landed — carry out that step's intent directly and say which agent
 was unavailable, rather than skipping the step or reporting it as done.
 
+**Changing a definition: check it landed rather than guessing how long to wait.**
+An edit under `.claude/agents/` does not reach the agents immediately. Measured
+by putting a marker string in a definition and asking spawned agents whether
+they had it, with file reads forbidden so the answer describes what they were
+given:
+
+```text
+~1 min after the edit    absent
+~2.5 min                 absent
+~6 min                   present
+```
+
+Nothing changed between the second and third — no edit, no commit, no restart.
+So a commit is not required to publish an edit, and neither is a new session.
+Whether either would *force* a reload was not tested, and nothing between 2.5
+and 6 minutes was probed, so the interval is unbounded at both ends of that gap.
+
+Which is why the instruction is a check rather than a duration. Put a marker in
+the definition and ask the spawned agent to quote it back **from its own
+instructions, without reading any file**, saying so if it cannot tell the two
+apart. Only then trust the run — "a few minutes" is exactly the guess the
+numbers above do not support.
+
+That prohibition is the whole check, not a caveat on it. A spawned agent has
+`Read`, and `code-review`'s own definition tells it to read both sides
+whenever a change touches `.claude/agents/` — which is exactly the situation
+this check runs in. Without it the agent reads the marker off disk and quotes it
+back while running the previous text, and the check confirms the thing it was
+added to catch. The prohibition has to go in the spawn prompt every time,
+because no definition mentions markers.
+
+Take the marker out once the run is trusted, before step 9 commits — nothing
+guards against one being left in. The removal is itself an edit under
+`.claude/agents/`, so a spawn shortly after it can still quote a marker that is
+gone; that is the stale-copy case below, not a failed removal.
+
+Both directions of a stale copy mislead. A spawn too soon runs the old text and
+reports on it, which reads exactly like the new text failing. And the copy
+outlives the file: an agent still returned a marker a minute after it had been
+deleted from disk, so a rollback looks like it did not take either.
+
+An agent change is therefore testable in the session that writes it. Step 8's
+loop is where forgetting that costs most: take a finding, edit, spawn straight
+away, and the run meant to confirm the fix is testing the version before it.
+
+This paragraph is the product of getting the mechanism wrong twice, in opposite
+directions — once as "read at session start", once as "read from `HEAD`" — each
+time from a single observation treated as decisive. So prefer the marker check
+over any theory about what triggers a reload, including the one above. And where
+an agent seems to be missing a definition entirely, that is the *If one is
+unavailable* paragraph above; a wait is worth trying first, since these two look
+alike from the caller's side.
+
+**A requirement this file places on a step has to be described in the agent that
+executes it.** Nothing checks that. The guard suite reads names, tool lists,
+step numbers, and the instructions it matches by regex in a definition's body
+— that an agent is told not to modify the repository, and that `code-review`
+still carries the bullet below — never whether an
+obligation on a step appears in the agent that runs it. So an obligation added
+to step 6, 7 or 8 can name something the executing agent was never told to do,
+and the agent does not refuse: it omits it and reports the step complete, which
+reads as a clean result. That makes it `code-review`'s to catch whenever a
+change touches the numbered steps, this section, or a file under
+`.claude/agents/`, and its definition says so. The instance that found the gap
+was an edit to step 6 alone, so dropping the steps from that list would disarm
+the check for the case that motivated it.
+
 `ui-review` needs a browser to satisfy step 6's rendered-journey requirement.
 Where none is installed it falls back to reviewing source and must say so; a
 review that claims viewports it never rendered is worse than none.

--- a/tests/scripts/test_agent_definitions.py
+++ b/tests/scripts/test_agent_definitions.py
@@ -195,6 +195,35 @@ class AgentDefinitionTests(unittest.TestCase):
                     "are instructed not to",
                 )
 
+    def test_code_review_carries_the_obligation_check_agents_md_claims(self):
+        """AGENTS.md says `code-review` catches step-versus-definition drift.
+
+        That is a claim about another file's body, which is the class this
+        module exists for — the docstring above records the same shape being
+        caught once already, in the "instructed rather than sandboxed" wording.
+
+        Left unguarded it closes on itself: delete the instruction from
+        `code-review.md` and AGENTS.md still says the check happens, while the
+        only thing that would have noticed is the deleted instruction. Every
+        other assertion here stays green, because none of them reads for it.
+
+        Asserted as one match rather than as separate words. Two presence
+        checks pass on a bullet that keeps the vocabulary and drops the
+        instruction — and, worse, on one narrowed to the `.claude/agents/`
+        trigger alone. AGENTS.md says in the same breath that dropping the
+        numbered steps would disarm the check for the edit that motivated it,
+        so a guard blind to that narrowing measures less than the prose claims.
+        """
+        self.assertRegex(
+            body_of(AGENTS_DIR / "code-review.md"),
+            r"(?is)numbered steps.{0,300}?\.claude/agents/.{0,120}?read both sides",
+            "code-review.md no longer carries the obligation check as AGENTS.md "
+            "describes it: the trigger list must still name the numbered steps "
+            "and .claude/agents/, and still require reading both sides. Dropping "
+            "the steps disarms it for a step-only edit, which is the case that "
+            "produced #160",
+        )
+
     def test_agent_description_matches_the_step_that_invokes_it(self):
         """The step number is read from AGENTS.md, not hardcoded.
 


### PR DESCRIPTION
Fixes #285. Fixes #160.

Two halves of one question — how a change to a sub-agent definition gets validated — landing in the same `AGENTS.md` section, so one change rather than two conflicting edits to the same paragraphs.

## #285: I filed it wrong, then corrected it wrong

The issue claimed definitions are read once at session start. I "corrected" that to say an agent receives what is committed in `HEAD`. **Both wrong**, and each came from a single observation treated as decisive.

An edit reaches the agents after a delay. Marker string in a definition, spawned agents asked whether they had it, file reads forbidden:

```
~1 min after the edit    absent
~2.5 min                 absent
~6 min                   present
```

Nothing changed between the second and third — no edit, no commit, no restart. That disposes of both earlier theories, and the rows that produced them are instructive: a marker read PRESENT shortly after being **deleted from disk** (reads as proof the source is `HEAD`; was a stale copy), and a marker read PRESENT just after a commit (reads as proof committing publishes; the commit fell five minutes after the edit).

**So the guidance is a check, not a duration.** "Wait a few minutes" was the first draft and does not survive its own numbers — two of three observations sit inside what that phrase ordinarily means, and the 2.5-to-6 band was never probed. Put a marker in the definition and have the spawn quote it back **from its own instructions, without reading any file**.

That prohibition is the whole check. A spawned agent has `Read`, and the `code-review.md` bullet added *in this same commit* tells it to read both sides whenever a change touches `.claude/agents/` — the exact situation the check runs in. Without the prohibition it reads the marker off disk and confirms a run of the previous text: the two halves of this change defeating each other, silently, in a way that looks like a verified fix.

## #160: the reviewer's remit, and a guard for the claim

#160 weighed generating both sides from one source against putting the check in `code-review`'s remit, and concluded the second — a keyword check would miss paraphrase or fire on every ordinary word. This takes that.

`code-review` now reads both sides whenever a change touches the numbered steps, the sub-agents section, or a file under `.claude/agents/`. **The numbered steps are in that list deliberately**: the instance that found the gap was an edit to step 6 alone — a 2× device-pixel-ratio obligation against a definition specifying three viewports and no density, with no granted tool able to set `deviceScaleFactor`.

`AGENTS.md` asserting that is itself an unguarded claim about another file's body — the class `test_agent_definitions.py` exists for — and it closes on itself: delete the instruction and `AGENTS.md` still says the check happens, with the deleted instruction the only thing that would have noticed. So there is now a guard, mirroring the existing `never modify` precedent.

| Mutation of `code-review.md` | Guard |
| --- | --- |
| bullet deleted | fails |
| trigger narrowed to `.claude/agents/` alone | fails |
| vocabulary kept, instruction dropped | fails |
| `main`'s version (no bullet) | fails |
| current text | passes |

The first version used two loose presence checks and passed rows 2 and 3 — including the narrowing this same commit calls the disarming case, so the guard was blind to the failure the prose beside it named.

## Also corrected

Both files said the guard suite never reads a definition's body. It does — `body_of()` exists and is regexed for the never-modify instruction. Narrowed to what is true, which leaves the conclusion standing. Then this commit added a *second* regex-matched instruction and made its own inventory stale, so that is corrected too.

Two paragraph-counting cross-references pointed at the wrong paragraphs and now name their referents.

## Verification

`make test-scripts` (192, up from 191), `make docs-check` (9), `make agent-docs-check`. `make -C apps/web ci` does not apply.

`verifier` confirmed the new guard is not vacuous — it fails against `main`'s version, against three mutations, and against a mistyped path, with `AGENTS_DIR` bound to the real checkout per `tests/scripts/AGENTS.md`.

**Known limit, measured:** the regex verifies vocabulary and ordering survive. `verifier` showed a rewrite keeping all three anchors while weakening "read both sides" into a suggestion still matches. It catches deletion and narrowing, which are the failures that close on themselves; it cannot catch deliberate softening.

Four review rounds. The reviewer's own report was the counter-example that broke my second theory — its spawn landed 2.5 minutes after I wrote the block to disk, inside the lag, so it reported honestly and inferred reasonably from where it sat.