### PR TITLE
fix(web): give the vitest suite a chosen budget and a flake policy

### DIFF
--- a/apps/web/src/test/runner-budget.test.ts
+++ b/apps/web/src/test/runner-budget.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * The suite's own budget and flake policy, read back from the runner.
+ *
+ * `task.timeout` and `task.retry` are what the runner will enforce on this
+ * test, resolved from the config it actually loaded. A regex over
+ * `vitest.config.mts` would instead assert that a line is written there, and
+ * the two come apart in the case worth catching: #281 had this config loaded
+ * three different ways, and a config vitest cannot load leaves the implicit
+ * 5000ms in force with the declaration still sitting in the file.
+ *
+ * Demonstrated by mutating `vitest.config.mts` and watching the named
+ * assertion fail:
+ *
+ * | mutation                    | result                                    |
+ * | --------------------------- | ----------------------------------------- |
+ * | `testTimeout` line deleted  | budget fails, reporting 5000              |
+ * | `testTimeout: 10_000`       | budget fails, reporting 10000             |
+ * | `retry: 2`                  | retries fails, and retried itself 3x      |
+ * | `retry: { count: 2 }`       | retries fails                             |
+ * | `retry: { delay: 10 }`      | both pass -- `count` defaults to 0, and a |
+ * |                             | forced failure ran once, not twice        |
+ *
+ * What nothing here catches, starting with the asymmetry in the table above:
+ * deleting the `retry: 0` line leaves both assertions green, because an unset
+ * `retry` resolves to 0 as well, and these assert effective policy rather than
+ * the presence of a declaration. Deleting `testTimeout` is caught only because
+ * its fallback is a different number. Also uncaught: a per-file or per-test
+ * override (`it(..., 100)`, `describe.configure`), which is local by design;
+ * `hookTimeout`, a separate 10s budget left at its default because every hook
+ * in this suite is mock setup rather than work; and load beyond the budget,
+ * which no fixed number is proof against.
+ */
+
+// The floor, not the value -- `vitest.config.mts` carries the measurement that
+// chose 20s and may raise it without touching this file.
+const MIN_TEST_TIMEOUT_MS = 20_000
+
+function retryCount(retry: number | { count?: number } | undefined): number {
+  return typeof retry === 'object' ? (retry.count ?? 0) : (retry ?? 0)
+}
+
+describe('runner budget', () => {
+  it('gives a test more room than the implicit 5s default', ({ task }) => {
+    expect(task.timeout).toBeGreaterThanOrEqual(MIN_TEST_TIMEOUT_MS)
+  })
+
+  // The policy `playwright.config.ts` states for the journeys, for the same
+  // reason: a retried failure is a failure that gets ignored. #283 exists
+  // because a real timeout went green on the next run, which is exactly the
+  // observation retries would have deleted.
+  it('retries nothing', ({ task }) => {
+    expect(retryCount(task.retry)).toBe(0)
+  })
+})

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -11,6 +11,29 @@ export default defineConfig({
     // Playwright specs match vitest's default glob. Left in, vitest picks them
     // up and fails on `@playwright/test` imports it cannot run.
     exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'e2e/**'],
+    // Chosen, unlike the implicit 5000ms this suite ran on until #283. The
+    // slowest test here is `src/app/page.test.tsx` at 1.6-2.0s idle, with nine
+    // more between 0.6s and 1.2s, so the default left under 3x of headroom and
+    // two files crossed it during a run that was roughly 4-5x slower per test
+    // than an idle one. Nothing in those tests is non-deterministic in content;
+    // they were losing a race against machine load.
+    //
+    // #283 asked whether raising this hides the signal that a test is slow, and
+    // it does not -- the signal is absent either way: `npm test` here is
+    // `vitest run` with the default reporter, which prints per-test durations
+    // for failures only, so on a green run the 20 tests over 300ms are
+    // invisible at any timeout, this one included. `vitest run
+    // --reporter=verbose` prints all 159, which is where the numbers above came
+    // from. #302 carries the cost itself -- the slowest test spends 793ms of its
+    // ~2000ms inside one `getByRole` call, against 120ms to render the page it
+    // queries.
+    testTimeout: 20_000,
+    // Same policy `playwright.config.ts` states for the journeys: a retried
+    // failure is a failure that gets ignored. #283 was found because a real
+    // timeout went green on the next run, which is the observation retries
+    // would delete. It is also vitest's default, and stated here so that
+    // turning it on is a visible decision rather than a line nobody wrote.
+    retry: 0,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes #283.

The suite ran on vitest's implicit 5000ms, which nobody chose. This states a budget and a flake policy, and adds a guard that reads both back from the runner.

## The decision #283 left open, settled by measurement

The issue offered two options: a longer timeout, or making `src/app/page.test.tsx` render less. Instrumenting the test says the second one is aimed at the wrong cost — the DOM it builds is 120ms of a ~2000ms test:

```
read categories.json      3ms
await Home()              5ms
render(tree)            120ms
getByRole('link', …)    793ms
```

More decisive: **page.test.tsx is only the first test to cross the line, not the only one within reach of it.** On an idle 24-core machine it runs 1.6–2.0s and nine others sit between 0.6s and 1.2s — `src/lib/user.test.ts` at 1189ms is real bcrypt work. The failing run in #283 was roughly 4–5x slower per test than an idle one, which is exactly where a 1189ms test also crosses 5000ms, and #283 recorded **two** files failing with only one identified. Speeding up one test hands the same flake to the next one.

So the fix is the budget, and the query cost is filed separately as #302 — where a located-element assertion measured 9ms against `getByRole`'s 851ms while still catching the defect the test exists for. Both are worth doing; neither substitutes for the other.

## Reproduced, then fixed

Synthetic CPU load, full suite, base config:

```
Test timed out in 5000ms.
 × src/app/page.test.tsx > Home page > names a product card once 6200ms
   reported at page.test.tsx:21, the `it(...)` line
```

That is the failure in #283, including the misleading line number. With `testTimeout: 20_000` at comparable load the same suite passes 159/159 across repeated runs, with the home page test between 1.6s and 3.9s.

## Honest limit of this fix

At an extreme synthetic load — around 4-5x oversubscription, `tests` reporting 204s against an idle 20s — one run had a single test cross 20s as well. A repeat at the same load passed everything, and I could not name the test from the reporter output before it went green again. **No fixed budget is proof against unbounded load.** What this changes is the multiplier: from under 3x of the slowest test's idle cost to about 10x. #302 is the other lever.

## #283's other worry, checked twice and wrong both times before this

The issue said raising the timeout hides the signal that the test is slow. My first draft of the config comment claimed the reporter keeps printing durations over `slowTestThreshold`, so nothing was lost. I checked:

```
$ npx vitest run          # what `npm test` runs
 Test Files  38 passed (38)
      Tests  159 passed (159)
```

No per-test output at all on a green run. The default reporter prints durations for failures only, so the 20 tests over 300ms were already invisible before this change and stay invisible after it, at any timeout. `vitest run --reporter=verbose` prints all 159, which is where every number in this PR came from.

My second draft then overcorrected, saying raising the timeout *does* hide the signal — immediately before the evidence that it is invisible at any timeout. `code-review` caught that (refinement 1 below). The accurate statement, and the one now in the config, is that the budget costs nothing that was working, because the signal was never in the default output. #302 carries the cost itself.

Worth noting as a pattern rather than as an apology: this is the repository's signature defect — a comment claiming more than is true — appearing twice in one four-line comment, in opposite directions, about a check I had already measured correctly.

## The guard reads the runner, not the config file

`src/test/runner-budget.test.ts` asserts on `task.timeout` and `task.retry` — the values the runner resolved for the test it is running. A regex over `vitest.config.mts` would assert that a line is written in a file, and those come apart in the case worth catching: a config vitest fails to load leaves the implicit 5000ms in force with the declaration still sitting there, which is not hypothetical for this file (#281 moved it between three loading modes). Demonstrated by mutating the config:

| mutation | result |
| --- | --- |
| `testTimeout` line deleted | budget assertion fails, reporting 5000 |
| `testTimeout: 10_000` | budget assertion fails, reporting 10000 — a floor, not a presence check |
| `retry: 2` | retries assertion fails, and the runner retried the guard 3x, which is the setting proving itself |
| `retry: { count: 2 }` | retries assertion fails — the object form is normalised |
| `retry: { delay: 10 }` | both pass, correctly: `count` defaults to 0, confirmed by forcing a failure and counting one attempt, against four for `{ count: 3 }` |

The `retries nothing` assertion had no red phase, since retries are already off by default — the mutations above are what demonstrate it is not vacuous.

**What nothing here catches**, stated so it is not mistaken for covered: a per-file or per-test override (`it(..., 100)`, `describe.configure`), which is local by design; `hookTimeout`, a separate 10s budget left at its default because every hook in this suite is mock setup rather than work; and load beyond the budget, per the limit above.

## Notes

- `retry: 0` is vitest's default. Stated anyway, so that turning it on is a visible decision — the same thing `playwright.config.ts` does for the journeys, where `retries: 0` is explicit and guarded by `tests/scripts/test_e2e_journey_wiring.py`.
- The policy lives in the config comment and its guard rather than in `apps/web/AGENTS.md`, following how the journeys' identical policy is already recorded.
- `tests/scripts/test_e2e_journey_wiring.py` reads this config to assert the `e2e/**` exclusion, so `make test-scripts` is coupled to this diff even though no script changed. It was run.

## Verification

`verifier` ran `make -C apps/web ci` twice and `make test-scripts` (192 tests), plus five standalone vitest runs: 38 files / 159 tests green every time, no flakes, suite wall-clock unchanged at 9.5–10.3s. It confirmed by tracing the Makefile chain that `make -C apps/web ci` and root `make test-web` both invoke vitest with `apps/web` as the working directory — worth checking because from the repository root no config loads at all and `task.timeout` reports the 5000ms default, which is a way to see this guard fail for a reason that has nothing to do with the config.

Not run, and why: `make ci` and `make docs-check` (no chat, schema, or Markdown changes), `make test-e2e` / `make e2e-smoke` (`e2e/**` is excluded from vitest and `playwright.config.ts` is untouched, so no stack was built or needed).

It also regenerated `apps/web/next-env.d.ts` through `next build` — that is #260, already filed, and reverted here.

A re-run after the review refinements below confirmed the comment edits did not break the config.

## Review

`code-review`: **no defects**, two refinements, both applied. It re-derived the evidence rather than taking the summary, including reading the vitest 4.1.10 runner source to confirm the guard measures the enforced value: `chunk-artifact.js` computes `options.timeout ?? runner.config.testTimeout`, stores it on the task, and passes *that variable* to `withTimeout`, and the runner's own `getRetryCount` normalises `retry` exactly as `retryCount()` here does.

Refinements applied:

1. The config comment said raising the budget "does" hide the slow-test signal, immediately before evidence that the signal is absent at any timeout — the comment stated the conclusion the rest of its own sentence refutes. This is the second time in this change that this comment overstated in one direction or the other; it now says the signal was never there.
2. The guard's *what nothing here catches* list recorded the `testTimeout` deletion case but not the `retry` one. Deleting `retry: 0` leaves both assertions green, because an unset `retry` also resolves to 0 — the asymmetry is that `testTimeout`'s fallback is a *different* number. Now written down.

It answered the three questions I asked and agreed with the calls: 20s is right and a floor is the right assertion shape, no `tests/scripts` regex guard should be added alongside a runner-read one, and the policy should not be restated in `apps/web/AGENTS.md`.

One finding outside this change, filed as **#303**: the journeys' no-retry policy is guarded by `re.search(r"retries:\s*0", config)` over the text of `playwright.config.ts`, which would pass on a `retries: 0` in a comment while the live value was 2. That is the declaration-reading shape this repository's review rules reject, and this change makes the journey half the weaker one of the pair. `testInfo.project.retries` is the resolved value a journey could assert instead — I checked the type exists (`FullProject.retries: number`) rather than assuming the API.

The reviewer noted one limit on its own work: it could not assess how the 20s budget behaves on CI runner hardware, since #283's failure is load-dependent and all measurements here are from one machine.
