### PR TITLE
fix(web): track the next-env.d.ts that the build actually emits

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #260.

`apps/web/next-env.d.ts` is a tracked generated file. Next 16.3.0 began emitting an extra line into it, #225 bumped to that version, and the committed copy was never updated — so since then **every `next build` and every `tsc` has left the worktree dirty**, for everyone.

```diff
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
```

## Demonstrated both directions

On clean `main`: worktree clean → `make -C apps/web build` → `M apps/web/next-env.d.ts`. With the fix: `next build` and then `tsc --noEmit`, and **no unstaged diff remains** after either.

The line is byte-exact with what the pinned Next emits — `code-review` reconstructed the emitter's output from `writeAppTypeDeclarations.js` and MD5'd it against the staged blob, including line endings and trailing newline. It is the artifact, not an approximation of it.

## The risk worth writing down

The added import names a **build artifact**, and the web merge gate typechecks *before* it builds — so on a fresh checkout the target does not exist when `tsc` runs. That could have broken CI.

It does not. Measured by removing `.next` entirely: `tsc --noEmit` exits 0, with `next-env.d.ts` confirmed present in the program via `--listFiles` so the pass is not vacuous. Two independent properties make it safe, and the review corrected my first account of which:

| | `skipLibCheck: true` (this repo) | `skipLibCheck: false` |
| --- | --- | --- |
| side-effect-only import | exit 0 | exit 0 |
| named import | exit 0 | TS2307 |

A side-effect-only import of a missing module never errors, in any cell — and Next always emits this form. `skipLibCheck: true` independently suppresses diagnostics inside `.d.ts` files. I originally attributed the safety to import form alone; both hold, and neither is load-bearing by itself. The pre-existing `routes.d.ts` import above has the same property, which is why CI has always been green.

## Decisions taken, with the evidence

**Tracking rather than gitignoring.** I asked the reviewer to attack this, since the file's own header says it should not be edited and Next's docs arguably favour ignoring it. It is a deliberate, recorded decision: `.gitignore` ignores `next-env.d.ts` at line 19 and re-includes this one at line 134 under `# Exceptions (Do NOT ignore these)`, added in `b9f9dbc`. Ignoring it would revert that and widen scope well past what #260 asked for.

**No comment marking the hand-made edit.** Next's emitter compares whole-file string equality before writing, so any comment makes `currentContent !== content` on every build — the next build overwrites it, reintroducing exactly the drift this fixes and discarding the explanation. A comment here is actively harmful, not merely futile.

**Blast radius is local and CI only.** The `Dockerfile` copies individual files out of `apps/web/` and never `next-env.d.ts`; the builder runs `npm run build`, which regenerates it inside the image. This drift was never reachable from the container path.

## Verification

- `make -C apps/web ci` — lint, typecheck (both tsconfigs), 159/159, production build. Green.
- `make test-scripts` — 192/192.
- `make e2e-smoke` / `make test-e2e` **not run and not applicable**: a type declaration affects no runtime, no rendered output, and is not even present in the image build context. `verifier` agreed and went further, citing the Dockerfile evidence.
- **Step 6 (`ui-review`) not applicable**: a TypeScript ambient declaration renders nothing.
- `code-review`: no defects, no refinements.

## Filed, not fixed here

**#309** — nothing checks that a build leaves the worktree clean, which is why this survived from #225 to now with CI green throughout. That is a new gate affecting every contributor, so it is left as its own decision with the tradeoffs written out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)