### PR TITLE
fix(web): make the navigation drawer the dialog it looks like

### DIFF
--- a/apps/web/src/components/header.test.tsx
+++ b/apps/web/src/components/header.test.tsx
@@ -49,6 +49,85 @@ describe('Header', () => {
     await act(async () => {
       fireEvent.click(hamburger)
     })
-    expect(screen.getByRole('complementary')).toBeDefined()
+    expect(screen.getByRole('dialog')).toBeDefined()
+  })
+
+  // The trigger is the only thing on the page that says whether the drawer is
+  // open. Before #306 it said nothing: `aria-expanded` was absent before and
+  // after, and the label stayed "Open menu" while the menu was open, so a
+  // screen reader user got no signal that the click had done anything.
+  it('announces whether the drawer is open, and what it controls', async () => {
+    vi.mocked(useSession).mockReturnValue({ status: 'unauthenticated' } as any)
+    await act(async () => {
+      render(<Header />)
+    })
+
+    const trigger = screen.getByRole('button', { name: 'Open menu' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await act(async () => {
+      fireEvent.click(trigger)
+    })
+
+    const reopened = screen.getByRole('button', { name: 'Close menu' })
+    expect(reopened).toHaveAttribute('aria-expanded', 'true')
+    // Points at the dialog itself, not at a wrapper that happens to contain it.
+    expect(document.getElementById(reopened.getAttribute('aria-controls')!))
+      .toHaveAttribute('role', 'dialog')
+  })
+
+  // Closing left focus on <body>, so the next Tab restarted at the top of the
+  // document. `chat.tsx` fixes the same thing for its launcher; the drawer's
+  // trigger lives here rather than in `sidebar.tsx`, so the return does too.
+  it('returns focus to the trigger when the drawer closes', async () => {
+    vi.mocked(useSession).mockReturnValue({ status: 'unauthenticated' } as any)
+    await act(async () => {
+      render(<Header />)
+    })
+
+    const trigger = screen.getByRole('button', { name: 'Open menu' })
+    await act(async () => {
+      fireEvent.click(trigger)
+    })
+    expect(document.activeElement).not.toBe(trigger)
+
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    })
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Open menu' }),
+    )
+  })
+
+  // Asserts the option, not the scroll position, and knowingly: jsdom has no
+  // layout, so nothing here can scroll. What it measures is the call, which is
+  // the mechanism -- the effect was measured in a browser, on /faq at 390x844,
+  // opening the drawer and *then* scrolling to 900: closing returned 900 with
+  // this option and 0 without it. The header is in normal flow rather than
+  // sticky, so a plain `focus()` scrolls the off-screen trigger back into view
+  // and takes the reader's place with it. It reads clean at the top of a page,
+  // which is where it was first checked and passed.
+  //
+  // 900 is the size of the effect, not of the exposure: the trigger leaves the
+  // viewport at scrollY=43, so the drawer cannot be opened past that and the
+  // reachable jump is bounded there. `header.tsx` carries the derivation.
+  it('returns focus without dragging the page back to the top', async () => {
+    vi.mocked(useSession).mockReturnValue({ status: 'unauthenticated' } as any)
+    await act(async () => {
+      render(<Header />)
+    })
+
+    const trigger = screen.getByRole('button', { name: 'Open menu' })
+    const focusSpy = vi.spyOn(trigger, 'focus')
+
+    await act(async () => {
+      fireEvent.click(trigger)
+    })
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    })
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
   })
 })

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,17 +1,41 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Block from "@/components/block";
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import { useSession, signOut } from "next-auth/react";
 import Link from "next/link";
 import SidebarWrapper from "./sidebar-wrapper";
+import { SIDEBAR_DIALOG_ID } from "./sidebar";
 import { Suspense } from "react";
 import { ACTION_BOUNDARY, ACTION_FOCUS } from "@/lib/control-classes";
 
 export const Header = () => {
   const { data: session, status } = useSession();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Focus return, after the close rather than during it, because the drawer
+  // moves focus into itself on open and closing would otherwise drop it on
+  // <body> -- where the next Tab restarts at the top of the document.
+  // `chat.tsx` fixes the same thing for its launcher.
+  //
+  // Three of the four close routes, not four. Following a link ends on <body>
+  // instead: this effect focuses the trigger and Next's route-change reset then
+  // moves focus off it. Left to the router, which announces the new route.
+  //
+  // `preventScroll` because the header is in normal flow rather than sticky, so
+  // a plain `focus()` scrolls the off-screen trigger into view and takes the
+  // reader's place with it. The reachable jump is small -- the trigger's rect
+  // is [-1, 43], so the drawer cannot be opened past scrollY=43 -- and this is
+  // kept for when the header goes sticky, which would widen that to the page.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (wasOpen.current && !isSidebarOpen) {
+      triggerRef.current?.focus({ preventScroll: true });
+    }
+    wasOpen.current = isSidebarOpen;
+  }, [isSidebarOpen]);
 
   return (
     <>
@@ -20,11 +44,24 @@ export const Header = () => {
         innerClassName="h-12 flex flex-row center items-center"
       >
         <div className="text-slate-800">
+          {/* Before #306 this said nothing: `aria-expanded` absent in both
+              states, and the label stuck at "Open menu" while the menu was
+              open. Both track the state now.
+
+              `aria-expanded="true"` is rarely perceived, since `aria-modal` on
+              the panel confines assistive technology to the dialog while it is
+              open -- so in practice a user hears the collapsed state and the
+              dialog. It is still the conventional pairing with
+              `aria-controls`, and the label is what actually reports the open
+              state. */}
           <button
+            ref={triggerRef}
             type="button"
             className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
-            onClick={() => setIsSidebarOpen(true)}
-            aria-label="Open menu"
+            onClick={() => setIsSidebarOpen((open) => !open)}
+            aria-label={isSidebarOpen ? "Close menu" : "Open menu"}
+            aria-expanded={isSidebarOpen}
+            aria-controls={SIDEBAR_DIALOG_ID}
           >
             <Bars3Icon className="h-6 w-6" aria-hidden="true" />
           </button>

--- a/apps/web/src/components/sidebar.test.tsx
+++ b/apps/web/src/components/sidebar.test.tsx
@@ -18,10 +18,12 @@ vi.mock('next/link', () => ({
 }))
 
 describe('Sidebar Component', () => {
+  // `dialog`, not `complementary`: the panel became a dialog in #306. Querying
+  // the old role here would return null whether the drawer rendered or not,
+  // which is a guard that cannot fail rather than a guard that passes.
   it('should not be visible when isOpen is false', () => {
     render(<Sidebar isOpen={false} onClose={() => {}} sections={[]} />)
-    const sidebar = screen.queryByRole('complementary')
-    expect(sidebar).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('should be visible when isOpen is true', () => {
@@ -29,11 +31,22 @@ describe('Sidebar Component', () => {
     expect(screen.getByText('Test')).toBeDefined()
   })
 
+  // One match now, not two: the backdrop kept its click handler but lost its
+  // name and its place in the accessibility tree, so the positional index this
+  // used to need is gone with it.
   it('should call onClose when clicking the close button', () => {
     const onClose = vi.fn()
     render(<Sidebar isOpen={true} onClose={onClose} sections={[]} />)
-    const closeButtons = screen.getAllByLabelText(/close/i)
-    fireEvent.click(closeButtons[1]) // Index 1 is the actual X button
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('should call onClose when clicking the backdrop', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <Sidebar isOpen={true} onClose={onClose} sections={[]} />,
+    )
+    fireEvent.click(container.querySelector('button[aria-hidden="true"]')!)
     expect(onClose).toHaveBeenCalled()
   })
 
@@ -44,5 +57,179 @@ describe('Sidebar Component', () => {
     const link = screen.getByText('Hiking')
     fireEvent.click(link)
     expect(onClose).toHaveBeenCalled()
+  })
+})
+
+/**
+ * The drawer covers the page, so it has to behave like the modal it looks like.
+ * `chat.tsx` already carries this contract below `lg` and its comment on
+ * `isModal` is the reasoning these tests encode: `aria-modal` without a trap
+ * tells assistive technology something false.
+ *
+ * Demonstrated by mutating `sidebar.tsx` and `header.tsx` and watching the
+ * named assertion fail:
+ *
+ * | mutation                         | result                                |
+ * | -------------------------------- | ------------------------------------- |
+ * | `aria-modal` removed             | names itself as a modal dialog        |
+ * | focus-in effect disabled         | moves focus into the drawer           |
+ * | Tab trap disabled                | wraps focus at both ends              |
+ * | Escape handler disabled          | closes on Escape                      |
+ * | Escape containment check removed | leaves Escape alone for another layer |
+ * | backdrop back in the tab order   | keeps the backdrop out of it          |
+ * | `aria-expanded` removed          | announces whether the drawer is open  |
+ * | focus-return effect disabled     | returns focus to the trigger          |
+ * | scroll lock neutralised          | stops the page behind it scrolling    |
+ * | `preventScroll` dropped          | returns focus without scrolling       |
+ * | backward wrap narrowed to first  | wraps backwards from the panel        |
+ *
+ * Three of those knock out more than one test, which is worth knowing before
+ * reading a failure: disabling focus-in also fails the Escape and focus-return
+ * cases, because both depend on focus having been moved in first.
+ *
+ * The last row was added after every row above it was green and two rendered
+ * passes had walked the tab order in a browser: a tab walk starts forward, and
+ * the wrap test starts from a control, so nothing began from the state the
+ * drawer opens in. A hole sits under a complete table when every entry in it
+ * starts from the same place.
+ *
+ * What none of this covers, and what found the defect in the first place: what
+ * the browser does with a real Tab. jsdom does not move focus on a Tab keydown
+ * at all, so the wrap tests below assert that the handler moved focus, not that
+ * tabbing works. The rendered pass at step 6 is what checks the real thing.
+ *
+ * Also uncovered: that the drawer's contents are actually unreachable behind it.
+ * `chat.tsx` marks the page `inert` below `lg`; this cannot, because `Header`
+ * renders per page and so the drawer is a descendant of `<main>` rather than a
+ * sibling of it. The backdrop covers the pointer case by dismissing on click,
+ * and `aria-modal` carries the claim to assistive technology, but no test here
+ * measures either.
+ */
+describe('Sidebar as a modal dialog', () => {
+  const sections = [
+    { title: 'Shop', links: [{ title: 'Hiking', href: '/hiking' }] },
+  ]
+
+  it('names itself as a modal dialog', () => {
+    render(<Sidebar isOpen={true} onClose={() => {}} sections={sections} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAccessibleName()
+  })
+
+  it('moves focus into the drawer, not onto whatever opened it', () => {
+    const { container } = render(
+      <Sidebar isOpen={true} onClose={() => {}} sections={sections} />,
+    )
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog?.contains(document.activeElement)).toBe(true)
+  })
+
+  it('wraps focus at both ends rather than letting Tab leave the page', () => {
+    const { container } = render(
+      <Sidebar isOpen={true} onClose={() => {}} sections={sections} />,
+    )
+    const dialog = container.querySelector('[role="dialog"]') as HTMLElement
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>('a[href], button:not([disabled])'),
+    )
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    expect(first).not.toBe(last)
+
+    last.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    first.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+  })
+
+  // The panel is where focus sits immediately after opening, and it is not in
+  // the focusable list -- `tabindex="-1"` excludes it. So it is neither `first`
+  // nor `last`, and the wrap test above starts from a control and can never
+  // reach this state. Backward from here the browser's default took focus to
+  // the header's Sign Up link, underneath the backdrop: #306's defect surviving
+  // in the direction nobody walks.
+  //
+  // Reachable two ways -- Shift+Tab as the first keystroke after opening, and
+  // Shift+Tab after clicking any non-interactive part of the panel, which
+  // focuses the panel because `tabindex="-1"` makes it the nearest focusable
+  // ancestor. Both confirmed in a browser, at two viewports, along with six
+  // other routes into the panel-focused state.
+  //
+  // What this asserts is a proxy for that, and the gap is worth stating: the
+  // defect was the *browser's* default backward navigation running because the
+  // handler declined to act, and jsdom runs no default Tab behaviour at all. So
+  // this measures that the handler focused the right element, and it cannot
+  // tell that failure apart from one where the handler never ran. It is a
+  // regression lock on the condition -- narrow it back to `first` and it goes
+  // red in milliseconds -- not a replica of what a browser does.
+  it('wraps backwards from the panel itself, not just from its first control', () => {
+    const { container } = render(
+      <Sidebar isOpen={true} onClose={() => {}} sections={sections} />,
+    )
+    const dialog = container.querySelector('[role="dialog"]') as HTMLElement
+    expect(document.activeElement).toBe(dialog)
+
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>('a[href], button:not([disabled])'),
+    )
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(focusable[focusable.length - 1])
+  })
+
+  // Dispatched from inside the drawer rather than at `document`, because that
+  // is where a real Escape lands once focus has been moved in -- and because
+  // the handler is scoped to its own subtree on purpose. `chat.tsx` records why
+  // in the other direction: an unscoped Escape there dismissed the chat
+  // underneath this drawer and left the drawer standing.
+  it('closes on Escape from inside the drawer', () => {
+    const onClose = vi.fn()
+    render(<Sidebar isOpen={true} onClose={onClose} sections={sections} />)
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('leaves Escape alone when it belongs to another layer', () => {
+    const onClose = vi.fn()
+    render(<Sidebar isOpen={true} onClose={onClose} sections={sections} />)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    fireEvent.keyDown(outside, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+    outside.remove()
+  })
+
+  // A declaration check, and knowingly so: jsdom has no layout, so it cannot
+  // scroll and cannot tell you whether the page actually stopped moving. What
+  // it does catch is the effect being dropped or failing to restore. The
+  // measurement that matters -- a wheel gesture over the backdrop moving the
+  // document 0 -> 600 behind the open drawer -- came from the rendered pass and
+  // is what put this here.
+  it('stops the page behind it scrolling, and gives the scroll back', () => {
+    const { rerender } = render(
+      <Sidebar isOpen={true} onClose={() => {}} sections={sections} />,
+    )
+    const scroller = document.documentElement
+    expect(scroller.style.overflow).toBe('hidden')
+
+    rerender(<Sidebar isOpen={false} onClose={() => {}} sections={sections} />)
+    expect(scroller.style.overflow).not.toBe('hidden')
+  })
+
+  // A screen-sized `<button>` is a screen-sized tab stop, and it was one of the
+  // stops in the walk that produced #306. It stays a button so the click that
+  // dismisses the drawer keeps working; what goes is its place in the tab order
+  // and in the accessibility tree, both of which the header's Close button and
+  // Escape already cover.
+  it('keeps the backdrop out of the tab order', () => {
+    const { container } = render(
+      <Sidebar isOpen={true} onClose={() => {}} sections={sections} />,
+    )
+    const backdrop = container.querySelector('button[aria-hidden="true"]')
+    expect(backdrop).not.toBeNull()
+    expect(backdrop).toHaveAttribute('tabindex', '-1')
   })
 })

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { NavSection } from "@/lib/navigation";
+
+// Shared with `header.tsx`, whose trigger points `aria-controls` here. A
+// constant rather than a prop because the id has to survive the trip through
+// `SidebarWrapper`, which owns neither end of the relationship.
+export const SIDEBAR_DIALOG_ID = "site-navigation-drawer";
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -11,19 +20,150 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ isOpen, onClose, sections }: SidebarProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Opening left focus on the trigger, so the next Tab continued into the page
+  // behind the drawer rather than into it. The panel takes focus rather than
+  // its first control, so the dialog's name is announced before its contents.
+  //
+  // `preventScroll` for the same reason the trigger's focus return carries it,
+  // pre-emptively rather than for a measured symptom: the panel is
+  // `fixed inset-0` today, so focusing it scrolls nothing. That is a property
+  // of the layout rather than of this call, and the layout is the part that can
+  // change.
+  useEffect(() => {
+    if (isOpen) panelRef.current?.focus({ preventScroll: true });
+  }, [isOpen]);
+
+  // The drawer covers the page but sits *inside* it -- `Header` renders per
+  // page, so this markup is a descendant of `<main>`. That rules out the
+  // mechanism `chat.tsx` uses one layer over, where the widget is a sibling of
+  // `<main>` and can mark everything beside it `inert`. Inerting an ancestor
+  // here would inert the drawer with it.
+  //
+  // So containment rests on this trap for the keyboard, and on the backdrop for
+  // the pointer: it covers the viewport at `z-50` and dismisses on click, so a
+  // control behind it cannot be reached without the drawer closing first.
+  // `aria-modal` is what carries the same claim to assistive technology.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      // Focus outside the panel entirely -- the address bar can put it there
+      // even though a click on the backdrop cannot, because that closes.
+      if (!panel.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+      // `active === panel` is the state the drawer opens in, and the panel is
+      // not in `focusable` -- `tabindex="-1"` excludes it -- so without naming
+      // it here it is neither `first` nor `last`, no branch fires, and the
+      // browser's default backward navigation takes focus to the header's
+      // Sign Up link underneath the backdrop. That is the defect this component
+      // was rewritten to fix, in the direction a forward tab walk never
+      // reaches. Reachable by Shift+Tab as the first keystroke after opening,
+      // and by Shift+Tab after clicking any non-interactive part of the panel.
+      //
+      // Forward from the panel needs no branch: it is not `last`, so the
+      // default lands on `first`, which is where it should go.
+      if (event.shiftKey && (active === panel || active === first)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+
+  // `aria-modal` says the page behind is unavailable, and a wheel gesture over
+  // the backdrop made that false: measured on /faq at 390x844, the document
+  // scrolled 0 -> 600 behind the open drawer and stayed there after it closed.
+  // The backdrop stops clicks, not scrolling. `chat.tsx` carries the same
+  // effect for the same reason.
+  //
+  // On `<html>` rather than `body`, and not because `body` would fail --
+  // measured, both work, because with the root element's overflow `visible` the
+  // viewport takes its used overflow from the body. `chat.tsx:124` locks the
+  // same page through `body` and is correct to.
+  //
+  // The reason is that `chat.tsx` owns `body`'s inline overflow. Nothing today
+  // can hold both locks at once -- chat's `inert` covers the header below `lg`,
+  // the `z-50` backdrop covers the launcher, and chat's focus-out closes it at
+  // `lg` and up -- so this is not fixing a live collision. It is that two owners
+  // of one inline property would interleave their save and restore, and
+  // separate elements mean a future path that lets them coexist cannot.
+  //
+  // `document.scrollingElement` names the same node in a browser and is the
+  // more obviously correct expression, but it is `undefined` under jsdom, which
+  // turned the guard below it into a silent no-op.
+  useEffect(() => {
+    if (!isOpen) return;
+    const root = document.documentElement;
+    const previous = root.style.overflow;
+    root.style.overflow = "hidden";
+    return () => {
+      root.style.overflow = previous;
+    };
+  }, [isOpen]);
+
+  // Scoped to events originating inside the drawer, for the reason `chat.tsx`
+  // records from the other side: its Escape handler used to be unscoped, and
+  // dismissed the chat underneath this drawer while leaving the drawer up.
+  // Unscoped here would be the same mistake pointing the other way.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!panelRef.current?.contains(event.target as Node)) return;
+      onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex">
-      {/* Backdrop */}
-      <button 
-        className="fixed inset-0 bg-black/30 backdrop-blur-xs w-full h-full border-0 p-0" 
+      {/* Backdrop. Still a button so the click that dismisses the drawer keeps
+          working, but out of the tab order and out of the accessibility tree:
+          a screen-sized tab stop was one of the stops in the walk that produced
+          #306, and Escape and the Close button already cover dismissal. */}
+      <button
+        className="fixed inset-0 bg-black/30 backdrop-blur-xs w-full h-full border-0 p-0"
         onClick={onClose}
-        aria-label="Close sidebar"
+        tabIndex={-1}
+        aria-hidden="true"
       />
 
       {/* Sidebar Content */}
-      <div className="relative flex w-full max-w-xs flex-col overflow-y-auto bg-white pb-12 shadow-xl animate-in slide-in-from-left duration-300" role="complementary">
+      <div
+        ref={panelRef}
+        id={SIDEBAR_DIALOG_ID}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+        tabIndex={-1}
+        // `focus:outline-none` on the panel only. `tabIndex={-1}` plus the
+        // programmatic focus above makes Chromium match `:focus-visible` here,
+        // which drew the UA default `outline: auto 1px` around the whole 320px
+        // panel -- on the keyboard path only, and confirmed in rendered pixels
+        // rather than computed styles. The panel is a focus target, not a
+        // control, and every control inside keeps its own ring.
+        className="relative flex w-full max-w-xs flex-col overflow-y-auto bg-white pb-12 shadow-xl animate-in slide-in-from-left duration-300 focus:outline-none"
+      >
         <div className="flex px-4 pb-2 pt-5">
           <button
             type="button"


### PR DESCRIPTION
Closes #306.

Opening the drawer by keyboard left focus on the trigger, so tabbing forward walked straight out of it:

```
Sign In > Sign Up > Close sidebar > Close > Home > ... > FAQ >
TrailMaster X4 Tent > Alpine Explorer Tent
```

Those last stops are product links underneath the backdrop — visually obscured, still focusable. The trigger announced nothing either: `aria-expanded` absent in both states, label stuck at "Open menu" while the menu was open.

## What it does now

The contract `chat.tsx` already implements one component over: `role="dialog"` + `aria-modal` + a name, focus moved into the panel on open, Tab trapped and wrapping at both ends, Escape scoped to its own subtree, the page behind held still, the backdrop out of the tab order and the accessibility tree, and focus returned to the trigger with `preventScroll` on close.

Rendered against a production build (#290: the dev overlay changes tab order, so a keyboard journey on a dev server measures the dev server):

```
open   -> DIV "Site navigation"
 1 Close   2 Home   3 Sign In   4 Sign Up   5 About Us   6 Contact   7 FAQ
 8 Close  <- wraps
```

Twelve stops, never leaving the dialog, **byte-identical at 390x844, 768x1024 and 1440x900**. axe-core: 0 violations with the drawer open, and `aria-hidden-focus` explicitly *passes* on the backdrop.

## The one part that does not transfer: no `inert`

`chat.tsx` marks everything beside its widget `inert`. That cannot be copied. `Chat` is a sibling of `<main>`; `Header` renders per page, so the drawer is a *descendant* of `<main>` and inerting an ancestor would inert the drawer with it.

Containment therefore rests on the trap for the keyboard and the backdrop for the pointer — it covers the viewport at `z-50` and dismisses on click, so nothing behind it can be reached without the drawer closing. `aria-modal` carries the claim to assistive technology. The test file records that **no test here measures that last part**, rather than leaving it implied.

## Eleven mutations, and why the eleventh matters most

| mutation | assertion that fires |
| --- | --- |
| `aria-modal` removed | names itself as a modal dialog |
| focus-in disabled | moves focus into the drawer |
| Tab trap disabled | wraps focus at both ends |
| Escape disabled | closes on Escape |
| Escape containment removed | leaves Escape alone for another layer |
| backdrop back in tab order | keeps the backdrop out of it |
| `aria-expanded` removed | announces whether the drawer is open |
| focus-return disabled | returns focus to the trigger |
| scroll lock neutralised | stops the page behind it scrolling |
| `preventScroll` dropped | returns focus without scrolling |
| backward wrap narrowed to `first` | wraps backwards from the panel |

**The last row was added after the other ten were green and two rendered passes had walked the tab order in a real browser.** Shift+Tab from the panel still left the dialog, landing on the header's Sign Up link under the backdrop — the panel is excluded from the focusable list by its own `tabindex="-1"`, so it was neither `first` nor `last` and no branch fired. Every check began by tabbing *forward*, and forward from the panel happens to work.

A hole sits under a complete table when every entry in it starts from the same state.

The fix was then confirmed across **eight entry states at two viewports** — keyboard open, three different non-interactive click targets, Space-open, mouse-open, re-entry, and on two routes — plus 25 further Shift+Tabs with a capturing `focusin` listener recording zero escapes.

## Four defects found in review, three of them mine to introduce

- A focus ring drawn around the whole 320px panel: `tabIndex={-1}` plus programmatic focus makes Chromium match `:focus-visible`. Confirmed in rendered pixels, fixed with `focus:outline-none` on the panel only, and every control inside still rings.
- The page scrolling behind an `aria-modal` dialog — a wheel over the backdrop moved `/faq` from `scrollY=0` to `600`.
- Closing from a scrolled position jumping to the top, on all three close routes.
- The backward-wrap hole above.

## Two comment claims corrected rather than shipped

Both were checked because they were load-bearing, and both were wrong:

- I wrote that setting `body`'s overflow "moves nothing" here. **False** — overflow propagates from the body to the viewport when the root's is `visible`, and `chat.tsx:124` locks this same page through `body` correctly. That comment would have sent someone to fix working code.
- I then wrote that using `documentElement` avoids a live save/restore collision with `chat.tsx`. **Also false** — nothing can hold both locks today: chat's `inert` covers the header below `lg`, the `z-50` backdrop covers the launcher, and chat's focus-out closes it above. It now says it is preventing a future collision, not fixing a present one.

A third: the trigger is not "the only thing that says whether the drawer is open". With `aria-modal` on the panel, assistive technology is confined to the dialog, so `aria-expanded="true"` is rarely perceived and the label is what reports state.

## Verification

- `make -C apps/web ci` — lint, typecheck, **171 tests** (159 on `main`), production build. Green.
- `make test-scripts` — 192/192.
- `make e2e-smoke` / `make test-e2e` **not run and not applicable**: `verifier` confirmed no e2e spec touches the drawer and nothing anywhere depends on the old `role="complementary"`, so the role change cannot regress a journey. That absence is itself #315.
- Three rendered review rounds, two `verifier` rounds, two `code-review` rounds; the second returned no defects.

## Filed while working, none fixed here

**#315** (drawer controls use the UA default focus ring, and no spec covers them), **#316** (an open chat panel makes the drawer unreachable at phone width), **#317** (the trigger has no focus indicator — which this change turns into a focus *destination*), **#318** (every page fetches `/api/categories` for a drawer most visitors never open), plus notes on **#219** (the duplicate `<main>` is three pages, not one), **#307** (`/contact` has no header either), **#308** (`useState([])` infers `never[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)