### PR TITLE
fix(chat): use keyword mode for pandas markdown

### DIFF
--- a/services/chat/src/api/evaluate.py
+++ b/services/chat/src/api/evaluate.py
@@ -107,7 +107,7 @@ def create_summary(df):
     df.to_markdown('eval_results.md')
     with open('eval_results.md', 'a') as file:
         file.write("\n\nAverages scores:\n\n")
-    mean_df.to_markdown('eval_results.md', 'a')
+    mean_df.to_markdown('eval_results.md', mode='a')
 
     print("Results saved to result_evaluated.jsonl")
 
@@ -119,5 +119,4 @@ if __name__ == "__main__":
    response_results = create_response_data(test_data_df)
    result_evaluated = evaluate()
    create_summary(result_evaluated)
-
 

--- a/services/chat/tests/unit/test_evaluate.py
+++ b/services/chat/tests/unit/test_evaluate.py
@@ -1,9 +1,11 @@
 import json
+import warnings
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 from evaluate import create_response_data, create_summary, evaluate, load_data
+from pandas.errors import Pandas4Warning
 
 
 def test_load_data_reads_jsonl(tmp_path, monkeypatch):
@@ -79,7 +81,9 @@ def test_create_summary_writes_markdown(tmp_path, monkeypatch):
         ]
     )
 
-    create_summary(df)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", Pandas4Warning)
+        create_summary(df)
 
     content = Path("eval_results.md").read_text(encoding="utf-8")
     assert "Averages scores" in content


### PR DESCRIPTION
Closes #311.

## What changed

- Pass `mode="a"` to pandas `to_markdown` by keyword.
- Promote `Pandas4Warning` to an error in the focused summary test.

## Why

Pandas 3.0.5 warns that every `to_markdown` argument except `buf` becomes keyword-only in pandas 4. The existing positional call is exercised today but would fail on the first pandas 4 upgrade.

The regression test failed against the old call with the expected `Pandas4Warning`, then passed after the one-line implementation fix.

## Impact

Evaluation summaries keep appending their averages exactly as before, while remaining compatible with pandas 4. This changes no web UI, API contract, or production chat request path.

## Verification

- Focused test: `test_create_summary_writes_markdown`
- `make -C services/chat ci` — dependency policy, Ruff, mypy, 60 tests; `evaluate.py` 94% coverage
- `CHANGED_BASE=origin/main CHANGED_HEAD=HEAD make quick-ci-changed` — 192 script guards plus chat quick CI
- Lightweight GCP `make e2e-smoke` — six composed-stack checks passed
- `ui-review` — not applicable; no rendered surface changed
- `code-review` — approved, no defects or refinements

The remaining `google-cloud-storage < 3.0.0` warning is pre-existing and tracked in #312.