### PR TITLE
fix(infra): constrain GCP seeding dependencies

### DIFF
--- a/infrastructure/scripts/seed_gcp_all.py
+++ b/infrastructure/scripts/seed_gcp_all.py
@@ -59,37 +59,6 @@ def run_script(script_path: Path, script_name: str) -> bool:
         logger.error(f"Error running {script_name}: {e}")
         return False
 
-def install_requirements():
-    """Install required Python packages."""
-    requirements = [
-        "google-cloud-discoveryengine",
-        "google-cloud-aiplatform",
-        "vertexai"
-    ]
-
-    logger.info("📦 Installing required packages...")
-
-    for package in requirements:
-        try:
-            import importlib
-            importlib.import_module(package.replace('-', '_'))
-            logger.debug(f"Package {package} already installed")
-        except ImportError:
-            logger.info(f"Installing {package}...")
-            result = subprocess.run(
-                [sys.executable, "-m", "pip", "install", package],
-                capture_output=True,
-                text=True
-            )
-
-            if result.returncode != 0:
-                logger.error(f"Failed to install {package}")
-                logger.error(result.stderr)
-                return False
-
-    logger.info("✅ All required packages are available")
-    return True
-
 def check_gcp_auth():
     """Check if GCP authentication is configured."""
     try:
@@ -133,10 +102,6 @@ def main():
 
     # Check environment variables
     if not check_requirements():
-        sys.exit(1)
-
-    # Install required packages
-    if not install_requirements():
         sys.exit(1)
 
     # Check GCP authentication

--- a/infrastructure/scripts/setup_project.sh
+++ b/infrastructure/scripts/setup_project.sh
@@ -187,12 +187,16 @@ cd ../..
 
 # --- Data Seeding ---
 echo "Seeding data into GCP..."
-# Ensure python dependencies are installed
-pip install -r services/chat/src/api/requirements-core.txt
+# Install the constrained runtime dependencies into the project virtualenv.
+make venv
+.venv/bin/python -m pip uninstall --yes vertexai
+.venv/bin/python -m pip install \
+  -r services/chat/src/api/requirements-core.txt \
+  -c services/chat/constraints.txt
 # Generate python prisma client
 prisma generate --schema=apps/web/prisma/schema.prisma
 # Run the master seeding script (skip DataStore seeding if it doesn't exist yet)
-python3 infrastructure/scripts/seed_gcp_all.py || {
+.venv/bin/python infrastructure/scripts/seed_gcp_all.py || {
   echo ""
   echo "Warning: Data seeding failed (likely because Discovery Engine DataStore doesn't exist yet)."
   echo "Re-run this script after the DataStore deletion completes (up to 2 hours from teardown)."

--- a/tests/scripts/test_gcp_seed_deployment.py
+++ b/tests/scripts/test_gcp_seed_deployment.py
@@ -1,0 +1,152 @@
+"""Behavioral coverage for the GCP deployment seeding path."""
+
+import importlib
+import importlib.util
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_seed_module():
+    script_path = REPO_ROOT / "infrastructure/scripts/seed_gcp_all.py"
+    spec = importlib.util.spec_from_file_location("seed_gcp_all", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load seed_gcp_all from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+seed_gcp_all = load_seed_module()
+
+
+def invokes_package_installer(command):
+    tokens = [Path(str(token)).name for token in command]
+    pip_token = re.compile(r"^pip(?:\d+(?:\.\d+)*)?$")
+    return any(pip_token.fullmatch(token) for token in tokens) or any(
+        tokens[index : index + 2] == ["uv", "pip"]
+        for index in range(len(tokens) - 1)
+    )
+
+
+class SeedOrchestrationTests(unittest.TestCase):
+    def test_main_never_installs_packages_at_runtime(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with (
+            mock.patch.object(seed_gcp_all, "check_requirements", return_value=True),
+            mock.patch.object(seed_gcp_all, "check_gcp_auth", return_value=True),
+            mock.patch.object(seed_gcp_all, "verify_infrastructure", return_value=True),
+            mock.patch.object(seed_gcp_all, "run_script", return_value=True) as run_script,
+            mock.patch.object(importlib, "import_module", side_effect=ImportError),
+            mock.patch.object(seed_gcp_all.subprocess, "run", return_value=completed) as run,
+            self.assertRaises(SystemExit) as exit_status,
+        ):
+            seed_gcp_all.main()
+
+        self.assertEqual(exit_status.exception.code, 0)
+        self.assertEqual(
+            [call.args[1] for call in run_script.call_args_list],
+            ["Product Data Seeding (GCP)", "Local Vector Search Indexing"],
+        )
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertFalse(
+            any(invokes_package_installer(command) for command in commands),
+            f"the seeder launched a package installer: {commands}",
+        )
+
+
+class SetupProjectSeedTests(unittest.TestCase):
+    def test_setup_uses_the_project_venv_and_constraints(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_root = Path(temp_dir)
+            (fixture_root / "infrastructure/terraform").mkdir(parents=True)
+            (fixture_root / "services/chat/src/api").mkdir(parents=True)
+            (fixture_root / "apps/web/prisma").mkdir(parents=True)
+            fake_bin = fixture_root / "fake-bin"
+            fake_bin.mkdir()
+            venv_bin = fixture_root / ".venv/bin"
+            venv_bin.mkdir(parents=True)
+            command_log = fixture_root / "commands.log"
+
+            shim = """#!/bin/sh
+tool_name=${0##*/}
+printf '%s' "$tool_name" >> "$COMMAND_LOG"
+printf ' %s' "$@" >> "$COMMAND_LOG"
+printf '\\n' >> "$COMMAND_LOG"
+if [ "$tool_name" = "curl" ]; then
+  printf '404'
+elif [ "$tool_name" = "terraform" ] && [ "${1:-}" = "output" ]; then
+  printf 'https://example.invalid'
+fi
+"""
+            for tool in (
+                "curl",
+                "docker",
+                "gcloud",
+                "gsutil",
+                "make",
+                "pip",
+                "prisma",
+                "python3",
+                "terraform",
+            ):
+                path = fake_bin / tool
+                path.write_text(shim, encoding="utf-8")
+                path.chmod(0o755)
+            venv_python = venv_bin / "python"
+            venv_python.write_text(shim, encoding="utf-8")
+            venv_python.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "BILLING_ACCOUNT": "000000-000000-000000",
+                    "COMMAND_LOG": str(command_log),
+                    "CREATE_DATASTORE": "true",
+                    "NEXTAUTH_SECRET": "fixture-secret",
+                    "PATH": f"{fake_bin}:{os.defpath}",
+                    "PROJECT_ID": "fixture-project",
+                }
+            )
+            result = subprocess.run(
+                ["/bin/bash", str(REPO_ROOT / "infrastructure/scripts/setup_project.sh")],
+                cwd=fixture_root,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            commands = command_log.read_text(encoding="utf-8").splitlines()
+
+        self.assertIn("make venv", commands)
+        stale_package_removal = "python -m pip uninstall --yes vertexai"
+        constrained_install = (
+            "python -m pip install -r services/chat/src/api/requirements-core.txt "
+            "-c services/chat/constraints.txt"
+        )
+        self.assertEqual(commands.count(stale_package_removal), 1)
+        self.assertEqual(commands.count(constrained_install), 1)
+        self.assertLess(
+            commands.index(stale_package_removal),
+            commands.index(constrained_install),
+        )
+        self.assertEqual(
+            commands.count("python infrastructure/scripts/seed_gcp_all.py"),
+            1,
+        )
+        self.assertFalse(any(command.startswith("pip ") for command in commands), commands)
+        self.assertFalse(any(command.startswith("python3 ") for command in commands), commands)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove runtime package installation from the GCP seed orchestrator
- run deployment seeding through the repository `.venv`
- remove the stale standalone `vertexai` distribution, then install the core manifest through `services/chat/constraints.txt`
- add behavioral coverage that executes the seeder and the real deployment shell path through an isolated fake toolchain

## Root cause

`seed_gcp_all.py` treated distribution names as import names, so its installed-package check could never succeed for the Google Cloud packages. It consequently ran bare, unconstrained pip installs on every invocation and installed the standalone `vertexai` wrapper that the repository deliberately excludes. The deployment wrapper also used system `pip` and `python3`, bypassing the project virtualenv policy.

## Impact

GCP deployment seeding now uses the supported constrained dependency set exactly once, cleans up environments contaminated by the old standalone wrapper, and no longer mutates dependencies from inside runtime orchestration.

## Validation

- focused red/green tests plus mutations for runtime pip, missing constraints, and cleanup ordering
- `make ci`
- `make release-dry-run RELEASE_TAG=v0.0.0`
- `bash -n infrastructure/scripts/setup_project.sh`
- `shellcheck infrastructure/scripts/setup_project.sh`
- `make -C services/chat deps-check`
- `.venv/bin/python -m pip check`
- `CHANGED_BASE=9172772a2e9972f2ec22037be2aeba6048bc601f CHANGED_HEAD=e5361d2 make quick-ci-changed`
- `ui-review`: not applicable because no rendered surface, payload, asset, or UI dependency changed
- `code-review`: approved with no defects or refinements

A live deployment was not run because it would create or mutate billed GCP resources. The behavioral shell fixture exercises the complete command path without external mutation.

## Related finding

The review also found that the GCP seeder unconditionally launches a local Chromadb/Prisma indexer whose dependencies are absent from the core profile. That independent operational decision is tracked in #321 and intentionally excluded here.

Closes #314