### PR TITLE
fix(infra): keep GCP seeding provider-specific

### DIFF
--- a/infrastructure/scripts/seed_gcp_all.py
+++ b/infrastructure/scripts/seed_gcp_all.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
-"""
-Master script to seed all data into Google Cloud Platform.
-This script orchestrates the seeding of both products and customers.
-"""
+"""Orchestrate product seeding into Google Cloud Platform."""
 
 import os
 import sys
@@ -119,7 +116,6 @@ def main():
     # Define seeding scripts in order
     seeding_scripts = [
         (script_dir / "seed_gcp_products.py", "Product Data Seeding (GCP)"),
-        (script_dir / "index_products_local.py", "Local Vector Search Indexing")
     ]
 
     # Track results

--- a/infrastructure/scripts/setup_project.sh
+++ b/infrastructure/scripts/setup_project.sh
@@ -193,14 +193,8 @@ make venv
 .venv/bin/python -m pip install \
   -r services/chat/src/api/requirements-core.txt \
   -c services/chat/constraints.txt
-# Generate python prisma client
-prisma generate --schema=apps/web/prisma/schema.prisma
-# Run the master seeding script (skip DataStore seeding if it doesn't exist yet)
-.venv/bin/python infrastructure/scripts/seed_gcp_all.py || {
-  echo ""
-  echo "Warning: Data seeding failed (likely because Discovery Engine DataStore doesn't exist yet)."
-  echo "Re-run this script after the DataStore deletion completes (up to 2 hours from teardown)."
-}
+# Run the master GCP seeding script. Its logs and exit status identify failures.
+.venv/bin/python infrastructure/scripts/seed_gcp_all.py
 
 echo "✅ Project setup and deployment complete!"
 echo "Web App URL: $(cd infrastructure/terraform && terraform output -raw web_app_url)"

--- a/tests/scripts/test_gcp_seed_deployment.py
+++ b/tests/scripts/test_gcp_seed_deployment.py
@@ -36,7 +36,94 @@ def invokes_package_installer(command):
     )
 
 
+def run_setup_project(seed_exit_code=None):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fixture_root = Path(temp_dir)
+        (fixture_root / "infrastructure/terraform").mkdir(parents=True)
+        (fixture_root / "services/chat/src/api").mkdir(parents=True)
+        (fixture_root / "apps/web/prisma").mkdir(parents=True)
+        fake_bin = fixture_root / "fake-bin"
+        fake_bin.mkdir()
+        venv_bin = fixture_root / ".venv/bin"
+        venv_bin.mkdir(parents=True)
+        command_log = fixture_root / "commands.log"
+
+        shim = """#!/bin/sh
+tool_name=${0##*/}
+printf '%s' "$tool_name" >> "$COMMAND_LOG"
+printf ' %s' "$@" >> "$COMMAND_LOG"
+printf '\\n' >> "$COMMAND_LOG"
+if [ "$tool_name" = "curl" ]; then
+  printf '404'
+elif [ "$tool_name" = "terraform" ] && [ "${1:-}" = "output" ]; then
+  printf 'https://example.invalid'
+elif [ "$tool_name" = "python" ] && [ "${1:-}" = "infrastructure/scripts/seed_gcp_all.py" ] && [ -n "${SEED_EXIT_CODE:-}" ]; then
+  printf 'seed failed: permission denied\\n' >&2
+  exit "$SEED_EXIT_CODE"
+fi
+"""
+        for tool in (
+            "curl",
+            "docker",
+            "gcloud",
+            "gsutil",
+            "make",
+            "pip",
+            "prisma",
+            "python3",
+            "terraform",
+        ):
+            path = fake_bin / tool
+            path.write_text(shim, encoding="utf-8")
+            path.chmod(0o755)
+        venv_python = venv_bin / "python"
+        venv_python.write_text(shim, encoding="utf-8")
+        venv_python.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "BILLING_ACCOUNT": "000000-000000-000000",
+                "COMMAND_LOG": str(command_log),
+                "CREATE_DATASTORE": "true",
+                "NEXTAUTH_SECRET": "fixture-secret",
+                "PATH": f"{fake_bin}:{os.defpath}",
+                "PROJECT_ID": "fixture-project",
+            }
+        )
+        if seed_exit_code is not None:
+            env["SEED_EXIT_CODE"] = str(seed_exit_code)
+
+        result = subprocess.run(
+            ["/bin/bash", str(REPO_ROOT / "infrastructure/scripts/setup_project.sh")],
+            cwd=fixture_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        commands = command_log.read_text(encoding="utf-8").splitlines()
+
+    return result, commands
+
+
 class SeedOrchestrationTests(unittest.TestCase):
+    def test_main_runs_only_the_gcp_product_seeder(self):
+        with (
+            mock.patch.object(seed_gcp_all, "check_requirements", return_value=True),
+            mock.patch.object(seed_gcp_all, "check_gcp_auth", return_value=True),
+            mock.patch.object(seed_gcp_all, "verify_infrastructure", return_value=True),
+            mock.patch.object(seed_gcp_all, "run_script", return_value=True) as run_script,
+            self.assertRaises(SystemExit) as exit_status,
+        ):
+            seed_gcp_all.main()
+
+        self.assertEqual(exit_status.exception.code, 0)
+        run_script.assert_called_once_with(
+            Path(seed_gcp_all.__file__).parent / "seed_gcp_products.py",
+            "Product Data Seeding (GCP)",
+        )
+
     def test_main_never_installs_packages_at_runtime(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
@@ -54,7 +141,7 @@ class SeedOrchestrationTests(unittest.TestCase):
         self.assertEqual(exit_status.exception.code, 0)
         self.assertEqual(
             [call.args[1] for call in run_script.call_args_list],
-            ["Product Data Seeding (GCP)", "Local Vector Search Indexing"],
+            ["Product Data Seeding (GCP)"],
         )
         commands = [call.args[0] for call in run.call_args_list]
         self.assertFalse(
@@ -65,69 +152,9 @@ class SeedOrchestrationTests(unittest.TestCase):
 
 class SetupProjectSeedTests(unittest.TestCase):
     def test_setup_uses_the_project_venv_and_constraints(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            fixture_root = Path(temp_dir)
-            (fixture_root / "infrastructure/terraform").mkdir(parents=True)
-            (fixture_root / "services/chat/src/api").mkdir(parents=True)
-            (fixture_root / "apps/web/prisma").mkdir(parents=True)
-            fake_bin = fixture_root / "fake-bin"
-            fake_bin.mkdir()
-            venv_bin = fixture_root / ".venv/bin"
-            venv_bin.mkdir(parents=True)
-            command_log = fixture_root / "commands.log"
+        result, commands = run_setup_project()
 
-            shim = """#!/bin/sh
-tool_name=${0##*/}
-printf '%s' "$tool_name" >> "$COMMAND_LOG"
-printf ' %s' "$@" >> "$COMMAND_LOG"
-printf '\\n' >> "$COMMAND_LOG"
-if [ "$tool_name" = "curl" ]; then
-  printf '404'
-elif [ "$tool_name" = "terraform" ] && [ "${1:-}" = "output" ]; then
-  printf 'https://example.invalid'
-fi
-"""
-            for tool in (
-                "curl",
-                "docker",
-                "gcloud",
-                "gsutil",
-                "make",
-                "pip",
-                "prisma",
-                "python3",
-                "terraform",
-            ):
-                path = fake_bin / tool
-                path.write_text(shim, encoding="utf-8")
-                path.chmod(0o755)
-            venv_python = venv_bin / "python"
-            venv_python.write_text(shim, encoding="utf-8")
-            venv_python.chmod(0o755)
-
-            env = os.environ.copy()
-            env.update(
-                {
-                    "BILLING_ACCOUNT": "000000-000000-000000",
-                    "COMMAND_LOG": str(command_log),
-                    "CREATE_DATASTORE": "true",
-                    "NEXTAUTH_SECRET": "fixture-secret",
-                    "PATH": f"{fake_bin}:{os.defpath}",
-                    "PROJECT_ID": "fixture-project",
-                }
-            )
-            result = subprocess.run(
-                ["/bin/bash", str(REPO_ROOT / "infrastructure/scripts/setup_project.sh")],
-                cwd=fixture_root,
-                env=env,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-
-            self.assertEqual(result.returncode, 0, result.stderr)
-            commands = command_log.read_text(encoding="utf-8").splitlines()
-
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("make venv", commands)
         stale_package_removal = "python -m pip uninstall --yes vertexai"
         constrained_install = (
@@ -144,8 +171,18 @@ fi
             commands.count("python infrastructure/scripts/seed_gcp_all.py"),
             1,
         )
+        self.assertFalse(any(command.startswith("prisma ") for command in commands), commands)
         self.assertFalse(any(command.startswith("pip ") for command in commands), commands)
         self.assertFalse(any(command.startswith("python3 ") for command in commands), commands)
+
+    def test_setup_propagates_the_seed_failure_without_guessing_its_cause(self):
+        result, _commands = run_setup_project(seed_exit_code=23)
+        output = result.stdout + result.stderr
+
+        self.assertEqual(result.returncode, 23)
+        self.assertIn("seed failed: permission denied", result.stderr)
+        self.assertNotIn("likely because Discovery Engine DataStore", output)
+        self.assertNotIn("Project setup and deployment complete", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- run only the GCP product seeder during GCP deployment setup
- remove unrelated local Prisma generation
- preserve the seeder stderr and non-zero exit status instead of reporting speculative datastore failures or false success
- add behavioral deployment guards for provider isolation and failure propagation

## Root cause

The GCP orchestration mixed a local Chroma/Prisma indexing path into the hosted deployment profile, while the setup wrapper swallowed all failures and replaced their diagnostics with a guessed datastore warning.

## Validation

- focused red/green plus independent mutations for local-indexer reintroduction, Prisma invocation, hidden stderr, guessed diagnosis, swallowed status, and false success
- `bash -n infrastructure/scripts/setup_project.sh`
- `shellcheck infrastructure/scripts/setup_project.sh`
- `make test-scripts` (196 tests)
- `make release-dry-run RELEASE_TAG=v0.0.0`
- exact committed range: `CHANGED_BASE=577185cc237bb2aaebecef7848f6c30e566ca3d9 CHANGED_HEAD=b76b92f make quick-ci-changed`
- required UI review: not applicable because the patch has no rendered-web or rendering-dependency changes
- required code review: approved with zero defects and refinements

## Follow-ups

- #323 tracks swallowed local-indexing failures that bypass entrypoint retries
- #324 tracks the real GCP child seeder resolving the product catalog from the wrong path

Closes #321