### PR TITLE
fix(web): show drawer trigger focus

### DIFF
--- a/apps/web/e2e/action-controls.spec.ts
+++ b/apps/web/e2e/action-controls.spec.ts
@@ -187,6 +187,38 @@ test.describe('page controls', () => {
   })
 })
 
+test.describe('drawer trigger', () => {
+  // Mutation coverage:
+  // - Removing Header's focus-return effect fails the focused-element check.
+  // - Restoring the trigger's clipped top position leaves too few changed
+  //   pixels to meet the full-perimeter check.
+  test('returns focus to a fully visible indicator at the top of the page', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+
+    const selector = 'button[aria-controls="site-navigation-drawer"]'
+    const trigger = page.locator(selector)
+    await expect(trigger).toBeVisible()
+
+    const change = await focusChange(page, selector, async () => {
+      await trigger.click()
+      await expect(page.getByRole('dialog', { name: 'Site navigation' })).toBeVisible()
+      await page.keyboard.press('Escape')
+
+      await expect(trigger).toBeFocused()
+      expect(await page.evaluate(() => window.scrollY)).toBe(0)
+    })
+
+    expect(
+      change.qualifying,
+      `the drawer trigger's returned focus indicator covers ${change.qualifying} pixels ` +
+        `changing by ${REQUIRED_RATIO}:1 or more, against the ${Math.round(change.required)} ` +
+        `a 2px perimeter needs (${change.changed} changed at all, median ` +
+        `${change.median.toFixed(2)}:1)`,
+    ).toBeGreaterThanOrEqual(change.required)
+  })
+})
+
 for (const scheme of ['light', 'dark'] as const) {
   test.describe(`action controls in forced colors (${scheme})`, () => {
     test.use({ contextOptions: { forcedColors: 'active', colorScheme: scheme } })

--- a/apps/web/e2e/support/boundary.ts
+++ b/apps/web/e2e/support/boundary.ts
@@ -431,8 +431,16 @@ async function settled(page: Page) {
  * it "completely invisible"; by the criterion it paints a new 2px perimeter
  * over pixels that were background, which is compliant. Both arguments were
  * plausible and neither was a measurement.
+ *
+ * `focusControl` lets a journey produce focus through the behavior under test,
+ * such as closing a dialog, instead of replacing that behavior with `focus()`.
  */
-export async function focusChange(page: Page, selector: string) {
+export async function focusChange(
+  page: Page,
+  selector: string,
+  focusControl: () => Promise<void> = () =>
+    page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).focus(), selector),
+) {
   const control = page.locator(selector)
   // Before the box, and before either screenshot: `focus()` scrolls a control
   // that is off screen, and the two images are only comparable if nothing
@@ -458,7 +466,7 @@ export async function focusChange(page: Page, selector: string) {
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
   await settled(page)
   const unfocused = (await page.screenshot({ clip })).toString('base64')
-  await page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).focus(), selector)
+  await focusControl()
   await settled(page)
   const focused = (await page.screenshot({ clip })).toString('base64')
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -27,7 +27,7 @@ export const Header = () => {
   // `preventScroll` because the header is in normal flow rather than sticky, so
   // a plain `focus()` scrolls the off-screen trigger into view and takes the
   // reader's place with it. The reachable jump is small -- the trigger's rect
-  // is [-1, 43], so the drawer cannot be opened past scrollY=43 -- and this is
+  // is [4, 44], so the drawer cannot be opened past scrollY=44 -- and this is
   // kept for when the header goes sticky, which would widen that to the page.
   const wasOpen = useRef(false);
   useEffect(() => {
@@ -57,7 +57,7 @@ export const Header = () => {
           <button
             ref={triggerRef}
             type="button"
-            className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
+            className={`-mx-2 inline-flex items-center justify-center rounded-md p-2 text-gray-700 focus-visible:outline-indigo-600 ${ACTION_FOCUS}`}
             onClick={() => setIsSidebarOpen((open) => !open)}
             aria-label={isSidebarOpen ? "Close menu" : "Open menu"}
             aria-expanded={isSidebarOpen}


### PR DESCRIPTION
## Summary

- give the mobile drawer trigger a fully visible shared action-focus treatment
- keep the 40px target four pixels below the viewport edge so the 2px outline and offset are not clipped
- extend the rendered focus helper so journeys can produce focus through real behavior
- guard Escape close, focus return, scroll preservation, and the effective changed-pixel perimeter

## Root cause

#306 made the trigger the focus-return destination, but its negative top margin left the returned indicator clipped and too small to satisfy the rendered focus perimeter.

## Validation

- focused rendered red: 256 qualifying pixels versus 331 required
- green plus mutations: removing focus return failed `toBeFocused`; restoring clipped geometry failed at 178/331 pixels
- rendered UI review at 390x844, 834x1112, and 1440x900; 316 qualifying pixels versus 299.4 required; keyboard trap, Escape return, and zero scroll movement passed
- `make -C apps/web ci` via an exact-source physical-dependency snapshot: 171 tests and 230 static paths
- `make test-scripts` (194 tests)
- GCP-profile composed smoke
- full Playwright journeys (136/136)
- exact committed range: `CHANGED_BASE=577185cc237bb2aaebecef7848f6c30e566ca3d9 CHANGED_HEAD=459f7d8 make quick-ci-changed`
- required code review: approved with zero defects and refinements

Closes #317