### PR TITLE
fix(web): correct contact page semantics

### DIFF
--- a/apps/web/src/app/contact/page.tsx
+++ b/apps/web/src/app/contact/page.tsx
@@ -2,7 +2,7 @@ import ContactForm from "@/components/contact-form";
 
 export default function ContactPage() {
   return (
-    <main className="relative min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
+    <div className="relative min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
       {/* Background Image with Overlay */}
       <div 
         className="absolute inset-0 z-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700"
@@ -24,6 +24,6 @@ export default function ContactPage() {
         
         <ContactForm />
       </div>
-    </main>
+    </div>
   );
 }

--- a/apps/web/src/app/contact/thanks/page.tsx
+++ b/apps/web/src/app/contact/thanks/page.tsx
@@ -2,7 +2,7 @@ import ContactThanks from "@/components/contact-thanks";
 
 export default function ContactThanksPage() {
   return (
-    <main className="relative min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
+    <div className="relative min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
       {/* Background Image with Overlay */}
       <div 
         className="absolute inset-0 z-0 bg-cover bg-center bg-no-repeat"
@@ -15,6 +15,6 @@ export default function ContactThanksPage() {
       <div className="relative z-10 w-full max-w-lg bg-white/90 backdrop-blur-xs p-12 rounded-xl shadow-2xl">
         <ContactThanks />
       </div>
-    </main>
+    </div>
   );
 }

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -64,7 +64,7 @@ export default function ProfilePage() {
     return (
       <>
         <Header />
-        <main className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+        <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
           <h1 className="text-4xl font-semibold text-zinc-800">
             Sign in to view your profile
           </h1>
@@ -77,7 +77,7 @@ export default function ProfilePage() {
           >
             Sign in to continue
           </Link>
-        </main>
+        </div>
       </>
     );
   }

--- a/apps/web/src/app/route-semantics.test.tsx
+++ b/apps/web/src/app/route-semantics.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSession } from 'next-auth/react'
+import ContactPage from './contact/page'
+import ContactThanksPage from './contact/thanks/page'
+import ProfilePage from './profile/page'
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+  signOut: vi.fn(),
+}))
+
+vi.mock('@/components/header', () => ({
+  default: () => <header />,
+}))
+
+function renderInsideApplicationMain(route: ReactNode) {
+  render(<main>{route}</main>)
+}
+
+describe('route landmark semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the contact route inside the application main landmark', () => {
+    renderInsideApplicationMain(<ContactPage />)
+
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+  })
+
+  it('keeps the contact thanks route inside the application main landmark', () => {
+    renderInsideApplicationMain(<ContactThanksPage />)
+
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+  })
+
+  it('keeps the signed-out profile route inside the application main landmark', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: vi.fn(),
+    })
+    renderInsideApplicationMain(<ProfilePage />)
+
+    expect(screen.getAllByRole('main')).toHaveLength(1)
+  })
+})

--- a/apps/web/src/components/contact-form.test.tsx
+++ b/apps/web/src/components/contact-form.test.tsx
@@ -26,6 +26,13 @@ describe('ContactForm', () => {
     expect(screen.getByRole('button', { name: /send message/i })).toBeDefined()
   })
 
+  it('identifies the contact fields to browser autofill', () => {
+    render(<ContactForm />)
+
+    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveProperty('autocomplete', 'name')
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveProperty('autocomplete', 'email')
+  })
+
   it('shows error if required fields are missing and submitted', async () => {
     render(<ContactForm />)
     const submitButton = screen.getByRole('button', { name: /send message/i })

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -66,6 +66,7 @@ export default function ContactForm() {
           type="text"
           id="name"
           name="name"
+          autoComplete="name"
           required
           value={formData.name}
           onChange={handleChange}
@@ -85,6 +86,7 @@ export default function ContactForm() {
           type="email"
           id="email"
           name="email"
+          autoComplete="email"
           required
           value={formData.email}
           onChange={handleChange}


### PR DESCRIPTION
## Summary

- remove nested `main` landmarks from `/contact`, `/contact/thanks`, and signed-out `/profile` so the application layout owns the sole main landmark
- expose standard `name` and `email` autocomplete tokens on the contact form
- add rendered route-composition and browser-IDL regression coverage

## Root cause

The shared layout already wraps routes in `<main>`, but these three route states declared another main landmark. The contact fields also omitted their browser autofill purpose metadata.

## Validation

- focused red/green: three duplicate-main failures and missing autocomplete; 7/7 final tests green
- independent mutations proved each route landmark assertion and each autocomplete assertion
- rendered UI review at 390x844, 834x1112, and 1440x900: one main per route, keyboard/focus behavior, responsive states, form validation/loading/error states, and browser IDL autocomplete values
- `make -C apps/web ci` plus exact-source physical-dependency production build: 175 tests and 230 static paths
- `make test-scripts` (194 tests)
- GCP-profile composed smoke
- full Playwright journeys (135/135)
- exact committed range: `CHANGED_BASE=577185cc237bb2aaebecef7848f6c30e566ca3d9 CHANGED_HEAD=c12a47a make quick-ci-changed`
- required code review: approved with zero defects and refinements

## Follow-ups

- #326 tracks contact submission errors not being announced to assistive technology
- #327 tracks the measured phone overlap between the chat launcher and submit button

Closes #219