### PR TITLE
fix(infra): resolve GCP product catalog path

### DIFF
--- a/infrastructure/scripts/seed_gcp_products.py
+++ b/infrastructure/scripts/seed_gcp_products.py
@@ -242,7 +242,7 @@ def main():
 
     # Path to products JSON
     script_dir = Path(__file__).parent
-    json_path = script_dir.parents[1] / "public" / "products.json"
+    json_path = script_dir.parents[1] / "apps" / "web" / "public" / "products.json"
 
     if not json_path.exists():
         logger.error(f"Products JSON not found at: {json_path}")

--- a/tests/scripts/test_gcp_seed_deployment.py
+++ b/tests/scripts/test_gcp_seed_deployment.py
@@ -2,6 +2,7 @@
 
 import importlib
 import importlib.util
+import json
 import os
 import re
 import subprocess
@@ -25,6 +26,19 @@ def load_seed_module():
 
 
 seed_gcp_all = load_seed_module()
+
+
+def load_product_seed_module():
+    script_path = REPO_ROOT / "infrastructure/scripts/seed_gcp_products.py"
+    spec = importlib.util.spec_from_file_location("seed_gcp_products", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load seed_gcp_products from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+seed_gcp_products = load_product_seed_module()
 
 
 def invokes_package_installer(command):
@@ -148,6 +162,57 @@ class SeedOrchestrationTests(unittest.TestCase):
             any(invokes_package_installer(command) for command in commands),
             f"the seeder launched a package installer: {commands}",
         )
+
+
+class ProductSeedCatalogTests(unittest.TestCase):
+    def test_main_passes_the_checked_in_web_catalog_to_the_seeder(self):
+        product = {"id": "fixture-product", "name": "Fixture Product"}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_root = Path(temp_dir)
+            fixture_script = fixture_root / "infrastructure/scripts/seed_gcp_products.py"
+            fixture_script.parent.mkdir(parents=True)
+            fixture_script.write_text("# fixture script location\n", encoding="utf-8")
+            fixture_catalog = fixture_root / "apps/web/public/products.json"
+            fixture_catalog.parent.mkdir(parents=True)
+            fixture_catalog.write_text(json.dumps([product]), encoding="utf-8")
+            decoy_catalog = fixture_root / "public/products.json"
+            decoy_catalog.parent.mkdir(parents=True)
+            decoy_catalog.write_text(
+                json.dumps([{"id": "decoy", "name": "Wrong catalog"}]),
+                encoding="utf-8",
+            )
+
+            loaded_catalogs = []
+
+            def seed_products(json_path):
+                path = Path(json_path)
+                loaded_catalogs.append(
+                    (path, json.loads(path.read_text(encoding="utf-8")))
+                )
+                return True
+
+            seeder = mock.Mock()
+            seeder.seed_products.side_effect = seed_products
+
+            with (
+                mock.patch.object(seed_gcp_products, "__file__", str(fixture_script)),
+                mock.patch.dict(
+                    os.environ,
+                    {
+                        "PROJECT_ID": "fixture-project",
+                        "REGION": "us-central1",
+                        "DISCOVERY_ENGINE_DATASTORE_ID": "fixture-datastore",
+                    },
+                    clear=True,
+                ),
+                mock.patch.object(seed_gcp_products, "ProductSeeder", return_value=seeder),
+                self.assertRaises(SystemExit) as exit_status,
+            ):
+                seed_gcp_products.main()
+
+        self.assertEqual(exit_status.exception.code, 0)
+        self.assertEqual(loaded_catalogs, [(fixture_catalog, [product])])
 
 
 class SetupProjectSeedTests(unittest.TestCase):

--- a/tests/scripts/test_gcp_seed_deployment.py
+++ b/tests/scripts/test_gcp_seed_deployment.py
@@ -34,7 +34,25 @@ def load_product_seed_module():
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load seed_gcp_products from {script_path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+
+    discoveryengine = mock.MagicMock()
+    api_exceptions = mock.MagicMock()
+    language_models = mock.MagicMock()
+    google_cloud = mock.MagicMock(discoveryengine_v1=discoveryengine)
+    google_api_core = mock.MagicMock(exceptions=api_exceptions)
+    vertexai = mock.MagicMock(language_models=language_models)
+    import_stubs = {
+        "google": mock.MagicMock(cloud=google_cloud, api_core=google_api_core),
+        "google.cloud": google_cloud,
+        "google.cloud.discoveryengine_v1": discoveryengine,
+        "google.api_core": google_api_core,
+        "google.api_core.exceptions": api_exceptions,
+        "vertexai": vertexai,
+        "vertexai.language_models": language_models,
+    }
+
+    with mock.patch.dict("sys.modules", import_stubs):
+        spec.loader.exec_module(module)
     return module
 
 


### PR DESCRIPTION
## Summary

- resolve the GCP product seeder catalog from `apps/web/public/products.json`
- add an isolated behavioral guard around the real product-seeder `main()` path
- include a valid decoy at the former root path so regressions cannot pass through a nearby file
- isolate import-time Google/Vertex modules so the guard remains runnable without production SDK packages

## Root cause

The child seeder derived the repository root correctly but appended `public/products.json`. The checked-in catalog belongs to the web application at `apps/web/public/products.json`, so real deployment seeding exited before initializing its client.

The initial guard also imported production SDK modules at test-module load time, while the dedicated Script Guardrail job intentionally installs no Google packages. The loader now supplies temporary import-only stubs and restores `sys.modules`; production dependencies and code are unchanged.

## Validation

- focused red: the real `main()` exited 1 while searching the fixture root `public/products.json`
- focused green after the one-line path correction
- deliberate old-path mutation loaded a valid decoy and exited 0, but failed on the exact opened path and sentinel payload
- dependency-free reproduction: `.venv/bin/python -S -m unittest tests.scripts.test_gcp_seed_deployment -v` passed 5/5 with no site packages available
- required UI review: not applicable because no rendered surface, asset contents, or rendering dependency changed
- full verifier after the CI fix: `make ci` passed with 175 web tests, 60 chat tests, 197 root guards, and a 230-page production build
- mypy and Python parsing passed for the changed production script
- the real checked-in catalog parsed with 210 products and all required seeder fields
- release dry-run passed
- exact committed range: `CHANGED_BASE=014f201b6cea05c986a95204e8c6042aaa28084b CHANGED_HEAD=421f6a4 make quick-ci-changed`
- fresh required code review: approved with zero defects and refinements

Real credentialed Discovery Engine writes were not run because they mutate external GCP resources. Local Compose does not package or invoke this host-side seeder.

## Follow-up

- #330 tracks the pre-existing Ruff scope and lint debt in the GCP seeder and deployment guard

Closes #324