### PR TITLE
fix(infra): exit nonzero when local product indexing fails

### DIFF
--- a/infrastructure/scripts/index_products_local.py
+++ b/infrastructure/scripts/index_products_local.py
@@ -1,5 +1,7 @@
 import os
+import sys
 import asyncio
+import traceback
 from prisma import Prisma
 import chromadb
 from chromadb.utils import embedding_functions
@@ -65,11 +67,14 @@ async def index_products():
             )
             print(f"Successfully indexed {len(ids)} products to {CHROMA_DB_PATH}")
     except Exception as e:
-        print(f"Error during indexing: {e}")
-        # Don't exit with error to avoid breaking the master seed script
-        # but print the traceback for debugging if needed
-        import traceback
+        print(f"Error during indexing: {e}", file=sys.stderr)
         traceback.print_exc()
+        raise
 
 if __name__ == "__main__":
-    asyncio.run(index_products())
+    try:
+        asyncio.run(index_products())
+    except Exception:
+        # chat-entrypoint.sh retries this command while it exits nonzero, so a
+        # failed attempt has to be visible as one.
+        sys.exit(1)

--- a/tests/scripts/test_local_indexing_retry.py
+++ b/tests/scripts/test_local_indexing_retry.py
@@ -1,0 +1,321 @@
+"""Behavioral coverage for local product indexing and the entrypoint retry loop.
+
+`chat-entrypoint.sh` retries `index_products_local.py` while it exits nonzero, so
+the retry policy is only as good as the indexer's exit status. The indexer used
+to catch every indexing exception and return normally, which made a failed
+attempt indistinguishable from a successful one: the loop broke on the first
+try and the service came up with no vector index (#323).
+
+The existing entrypoint coverage in `test_chat_profile_wiring.py` is `assertIn`
+over the script text, which cannot see an exit status. These tests run the real
+script and the real loop instead.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEXER = REPO_ROOT / "infrastructure/scripts/index_products_local.py"
+ENTRYPOINT = REPO_ROOT / "services/chat/src/api/chat-entrypoint.sh"
+CHAT_DOCKERFILE = REPO_ROOT / "services/chat/Dockerfile"
+
+# The indexer imports these at module scope. `chromadb` is only installed by the
+# full local profile (`make setup-chat-full`), so the stubs keep this guard
+# runnable under the core profile as well as pinning the failure point.
+PRISMA_STUB = '''
+import os
+
+FAIL_AT = os.environ["STUB_FAIL_AT"]
+
+
+class _Product:
+    def __init__(self, index):
+        self.id = f"p{index}"
+        self.name = f"Product {index}"
+        self.slug = f"product-{index}"
+        self.price = 10 + index
+        self.description = "A description."
+        self.category = type("C", (), {"name": "Tents"})()
+        self.brand = type("B", (), {"name": "Contoso"})()
+
+
+class _Products:
+    async def find_many(self, **kwargs):
+        if FAIL_AT == "find_many":
+            raise RuntimeError("stub: database read failed")
+        if FAIL_AT == "empty":
+            return []
+        return [_Product(1), _Product(2)]
+
+
+class Prisma:
+    def __init__(self):
+        self.product = _Products()
+
+    async def connect(self):
+        if FAIL_AT == "connect":
+            raise RuntimeError("stub: database is still starting up")
+
+    async def disconnect(self):
+        pass
+'''
+
+CHROMADB_STUB = '''
+import json
+import os
+
+FAIL_AT = os.environ["STUB_FAIL_AT"]
+RECORD = os.environ["STUB_RECORD"]
+
+
+class _Collection:
+    def upsert(self, documents, metadatas, ids):
+        if FAIL_AT == "upsert":
+            raise RuntimeError("stub: chroma rejected the upsert")
+        with open(RECORD, "w", encoding="utf-8") as handle:
+            json.dump({"ids": list(ids)}, handle)
+
+
+class _Client:
+    def get_or_create_collection(self, name, embedding_function):
+        return _Collection()
+
+
+def PersistentClient(path):
+    if FAIL_AT == "chroma_client":
+        raise RuntimeError("stub: chroma persistence directory is unusable")
+    return _Client()
+'''
+
+CHROMADB_UTILS_STUB = '''
+class _EmbeddingFunction:
+    pass
+
+
+class embedding_functions:
+    DefaultEmbeddingFunction = _EmbeddingFunction
+'''
+
+
+def run_indexer(fail_at):
+    """Run the real indexer against stubbed boundaries. Returns the process."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fixture = Path(temp_dir)
+        stub_root = fixture / "stubs"
+        (stub_root / "chromadb").mkdir(parents=True)
+        (stub_root / "prisma.py").write_text(PRISMA_STUB, encoding="utf-8")
+        (stub_root / "chromadb/__init__.py").write_text(CHROMADB_STUB, encoding="utf-8")
+        (stub_root / "chromadb/utils.py").write_text(CHROMADB_UTILS_STUB, encoding="utf-8")
+
+        record = fixture / "upserted.json"
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(stub_root)
+        env["STUB_FAIL_AT"] = fail_at
+        env["STUB_RECORD"] = str(record)
+        env["CHROMA_DB_PATH"] = str(fixture / "chroma_db")
+
+        completed = subprocess.run(
+            [sys.executable, str(INDEXER)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+        upserted = json.loads(record.read_text(encoding="utf-8")) if record.exists() else None
+        return completed, upserted
+
+
+def run_entrypoint(failures_before_success):
+    """Run the real entrypoint with a stub indexer that fails a set number of times.
+
+    Returns (process, attempts) where `attempts` is how many times the entrypoint
+    actually invoked the indexer.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fixture = Path(temp_dir)
+        fake_bin = fixture / "fake-bin"
+        fake_bin.mkdir()
+        (fixture / "infrastructure/scripts").mkdir(parents=True)
+        (fixture / "local_provider_health.py").write_text("", encoding="utf-8")
+        (fixture / "infrastructure/scripts/index_products_local.py").write_text("", encoding="utf-8")
+
+        attempts_file = fixture / "attempts"
+        attempts_file.write_text("0", encoding="utf-8")
+
+        # Stands in for the indexer and the preflight, so the loop under test is
+        # driven by an exit status we choose rather than by a real database.
+        (fake_bin / "python3").write_text(
+            "#!/bin/bash\n"
+            # The path the entrypoint asks for has to exist. services/chat/Dockerfile
+            # is what puts it there, and nothing else asserts the two agree.
+            '[ -f "$1" ] || { echo "no such script: $1" >&2; exit 127; }\n'
+            'case "$1" in\n'
+            "  *local_provider_health.py) exit 0 ;;\n"
+            "  *index_products_local.py)\n"
+            f'    count=$(cat "{attempts_file}")\n'
+            "    count=$((count + 1))\n"
+            f'    echo "$count" > "{attempts_file}"\n'
+            f"    if [ \"$count\" -le {failures_before_success} ]; then\n"
+            '      echo "stub indexer failed" >&2\n'
+            "      exit 1\n"
+            "    fi\n"
+            "    exit 0 ;;\n"
+            "esac\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        # The entrypoint's last act is `exec uvicorn`; this keeps that a no-op.
+        (fake_bin / "uvicorn").write_text('#!/bin/bash\necho "uvicorn started"\nexit 0\n', encoding="utf-8")
+        # The loop sleeps 5s between attempts. Nothing here asserts on timing.
+        (fake_bin / "sleep").write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+        for stub in ("python3", "uvicorn", "sleep"):
+            (fake_bin / stub).chmod(0o755)
+
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["LLM_PROVIDER"] = "local"
+
+        completed = subprocess.run(
+            ["bash", str(ENTRYPOINT)],
+            capture_output=True,
+            text=True,
+            cwd=fixture,
+            env=env,
+            timeout=120,
+        )
+        attempts = int(attempts_file.read_text(encoding="utf-8").strip())
+        return completed, attempts
+
+
+class IndexerExitStatusTests(unittest.TestCase):
+    """The indexer's exit status has to distinguish failure from success."""
+
+    def test_successful_indexing_exits_zero(self):
+        completed, upserted = run_indexer("none")
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"successful indexing should exit 0\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+        # Vacuity guard: the stubs were reached and the real indexing path ran,
+        # so a zero here is a success rather than an import that never got going.
+        self.assertEqual(upserted, {"ids": ["p1", "p2"]})
+
+    def test_database_failure_exits_nonzero(self):
+        completed, _ = run_indexer("connect")
+        output = completed.stdout + completed.stderr
+        # Named message first: every way this fixture can break also exits
+        # nonzero -- a mistyped STUB_FAIL_AT, a syntax error in a stub, a wrong
+        # INDEXER path -- so the exit status alone would pass while proving
+        # nothing about the path this test is named for.
+        self.assertIn("stub: database is still starting up", output)
+        self.assertEqual(
+            completed.returncode,
+            1,
+            f"a database failure must not report success\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_chroma_failure_exits_nonzero(self):
+        completed, _ = run_indexer("upsert")
+        output = completed.stdout + completed.stderr
+        self.assertIn("stub: chroma rejected the upsert", output)
+        self.assertEqual(
+            completed.returncode,
+            1,
+            f"a chroma failure must not report success\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+    def test_failure_is_still_reported(self):
+        completed, _ = run_indexer("find_many")
+        output = completed.stdout + completed.stderr
+        self.assertIn("stub: database read failed", output)
+
+
+class IndexerDeliveryTests(unittest.TestCase):
+    """The entrypoint's relative path and the Dockerfile's COPY have to agree.
+
+    The entrypoint invokes the indexer as `infrastructure/scripts/...` relative
+    to the image's WORKDIR, which resolves only because the Dockerfile copies it
+    to that exact destination. Two files, one contract, and nothing compared
+    them -- so either side could be renamed and every unit test would stay green
+    while the container failed at startup.
+
+    This compares the two declarations. It does not prove the COPY landed in the
+    built image; only inspecting the image does that.
+    """
+
+    def invoked_path(self):
+        entrypoint = ENTRYPOINT.read_text(encoding="utf-8")
+        invocations = re.findall(r"python3\s+(\S*index_products_local\.py)", entrypoint)
+        self.assertEqual(
+            len(invocations),
+            1,
+            f"expected exactly one indexer invocation in {ENTRYPOINT.name}, found {invocations}",
+        )
+        return invocations[0]
+
+    def copy_destinations(self):
+        dockerfile = CHAT_DOCKERFILE.read_text(encoding="utf-8")
+        return re.findall(
+            r"^COPY\s+(?:--\S+\s+)*\S*index_products_local\.py\s+(\S+)\s*$",
+            dockerfile,
+            re.MULTILINE,
+        )
+
+    def test_the_image_copies_the_indexer_where_the_entrypoint_looks_for_it(self):
+        destinations = self.copy_destinations()
+        self.assertEqual(
+            len(destinations),
+            1,
+            f"expected exactly one indexer COPY in {CHAT_DOCKERFILE.name}, found {destinations}",
+        )
+        self.assertEqual(
+            destinations[0],
+            self.invoked_path(),
+            "the Dockerfile copies the indexer somewhere the entrypoint does not run it",
+        )
+
+    def test_the_copied_indexer_exists_in_the_repository(self):
+        source = re.search(
+            r"^COPY\s+(?:--\S+\s+)*(\S*index_products_local\.py)\s+\S+\s*$",
+            CHAT_DOCKERFILE.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(source, "no indexer COPY found to check")
+        self.assertTrue(
+            (REPO_ROOT / source.group(1)).is_file(),
+            f"the Dockerfile copies {source.group(1)}, which is not in the repository",
+        )
+
+
+class EntrypointRetryTests(unittest.TestCase):
+    """The retry loop has to react to that exit status."""
+
+    def test_a_failing_attempt_is_retried_until_it_succeeds(self):
+        completed, attempts = run_entrypoint(failures_before_success=2)
+        self.assertEqual(
+            attempts,
+            3,
+            f"expected two failures then a success\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+        self.assertIn("uvicorn started", completed.stdout)
+
+    def test_retrying_stops_at_the_first_success(self):
+        completed, attempts = run_entrypoint(failures_before_success=0)
+        self.assertEqual(attempts, 1, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+        self.assertIn("uvicorn started", completed.stdout)
+
+    def test_a_permanently_failing_indexer_gives_up_and_still_serves(self):
+        completed, attempts = run_entrypoint(failures_before_success=99)
+        self.assertEqual(attempts, 5, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+        self.assertIn("uvicorn started", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #323.

## What was wrong

`services/chat/src/api/chat-entrypoint.sh` retries the local product indexer **while it exits nonzero**:

```bash
for i in {1..5}; do
    if python3 infrastructure/scripts/index_products_local.py; then
        break
    fi
    echo "Indexing attempt ${i} failed; retrying in 5s..."
    sleep 5
done
```

`index_products_local.py` caught every indexing exception, logged it, and returned normally. So a failed index exited 0, the loop broke on attempt 1, and the retry policy was dead code. The chat service came up serving an empty vector collection, with the logs showing an error and then a normal startup.

The loop is **not** changed here. It was already correct; it only looked broken because nothing could make it iterate.

## The removed comment

The old code carried `# Don't exit with error to avoid breaking the master seed script`. That was true when written and is not any more — #321 and #325 removed this script from the GCP seeding path. The only remaining references are `services/chat/Dockerfile:58` (COPY) and `chat-entrypoint.sh:20` (the retry loop). `code-review` re-derived this independently rather than taking my word for it.

## Coverage

`tests/scripts/test_local_indexing_retry.py` runs the real script and the real entrypoint rather than reading them. The existing entrypoint coverage in `test_chat_profile_wiring.py` is `assertIn` over the script text, which cannot see an exit status.

- The indexer runs as a subprocess with `prisma` and `chromadb` shadowed via `PYTHONPATH`. That picks the failure point and keeps the guard runnable under the core setup profile, which does not install `chromadb`.
- The entrypoint runs under `bash` with `python3`, `uvicorn` and `sleep` shadowed on `PATH`, so the loop is driven by a chosen exit status rather than a real database.

**Red phase:** two assertions failed `0 == 0` on the exit status, with tracebacks showing the real script reaching the stubs at lines 16 and 61.

**The other seven guard behaviour that already worked, so each was demonstrated against a deliberate break:**

| Break | Assertion that caught it |
| --- | --- |
| always exit 1, even on success | `1 != 0` |
| drop the logging, keep the exit status | stub message not found |
| loop breaks unconditionally | `1 != 3` |
| retry budget 5 -> 3 | `3 != 5` |
| success never breaks the loop | `5 != 1` |
| Dockerfile COPY destination moved | `scripts/... != infrastructure/scripts/...` |
| COPY source not in the repository | `False is not true` |
| entrypoint invokes a different path | `0 != 3`, `0 != 5`, `0 != 1` |

## A deliberate scope call

`IndexerDeliveryTests` guards lines this change does not touch. The entrypoint invokes the indexer by a relative path that resolves only because the Dockerfile copies it to exactly that destination — that seam is what delivers this fix, and nothing compared the two declarations. Per AGENTS.md`s rule about treating a seam as one contract, it seemed wrong to fix the file without pinning how it arrives.

It does **not** prove the COPY landed in the built image, and says so in its own docstring.

## What green does not prove here

`verifier` established this directly rather than by inference: **no automated target in this repository executes this code path.** The entrypoint reaches it only under `LLM_PROVIDER=local`, and smoke runs the gcp branch:

```
$ docker compose logs chat | grep -i indexing
chat-1  | Starting Chat Service Entrypoint...
chat-1  | Skipping local product indexing: LLM_PROVIDER=gcp.
```

`make e2e-smoke-full` does not change that — it sets a Docker **build arg** (`CHAT_INSTALL_LOCAL_STACK`), not the provider, so it installs the local stack and then runs a container that never uses it. Filed as #333, since AGENTS.md documents that target as "full local-provider integration confidence".

What was verified against the real artifact: the chat image was rebuilt from this branch and the changed code was run **from the bytes inside the image** against stubs, exiting 1. Before the rebuild the warm image still had the old catch-and-return code, which confirms the layers were genuinely stale rather than the check being a no-op.

## Verification

`make test-scripts` (206 tests, run twice, no flakes), `make -C services/chat ci`, `make -C apps/web ci`, `make toolchain-doctor`, `make env-contract-check`, and `LLM_PROVIDER=gcp make e2e-smoke` all pass. Rendered UI review is not applicable: the diff moves no component, no style, and no rendering dependency.

`code-review` returned **no defects and three refinements**, all applied — the two failure-path tests now assert the stub`s own message before the exit status (every way the fixture can break also exits nonzero, so the status alone proved nothing); the fake `python3` requires its target to exist, making the fixture files load-bearing; and a dead parameter was removed. No findings were disputed.

## Issues filed from this work

Findings recorded rather than folded in, per AGENTS.md:

- #332 — an unseeded database also exits 0 and is not retried. Whether "empty" is a failure is a policy call.
- #333 — `e2e-smoke-full` never selects the local provider, so the documented coverage does not exist.
- #335 — the loop sleeps 5s and announces a retry after its *final* attempt. This change makes that path reachable for the first time.
- #336 — `disconnect()` is not in a `finally`, so a mid-read failure leaves the client connected.

Also closed #327 as a duplicate of #286 during triage.