### PR TITLE
fix(web): keep the chat launcher off the contact form's controls

### DIFF
--- a/apps/web/e2e/launcher-safe-area.spec.ts
+++ b/apps/web/e2e/launcher-safe-area.spec.ts
@@ -1,0 +1,365 @@
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * `/contact`'s controls have to clear the chat launcher's column.
+ *
+ * The launcher is `fixed bottom-0 right-0` with `mr-4 mb-4` below `sm`, so it
+ * owns the bottom-right 56x56 of the viewport — 40px of control plus a 16px
+ * margin — on every route, at every scroll position. #286 measured the
+ * `/contact` submit button at 48..342 against a launcher at 334..374: an 8x32
+ * overlap in which `document.elementFromPoint` returns the launcher, so the
+ * last 8px of the page's primary action opens the chat instead of submitting.
+ *
+ * ## Why this asserts a column and not a gap below the content
+ *
+ * The obvious fix is a bottom gutter, and it does not work. The launcher is
+ * `fixed`, so the page scrolls under it and every row passes through its band;
+ * a gutter only separates them at the very end of the document. `/contact` at
+ * 390x844 scrolls just 116px, and the button clears the launcher on its own by
+ * the end of that scroll — so the end of the document is the one position
+ * where the defect cannot be observed. A sweep that measured only there
+ * reported every route clean.
+ *
+ * `padding-bottom` cannot help at `scrollY=0` either: it makes the document
+ * taller and moves nothing that is already rendered. Horizontal separation is
+ * the only geometry that holds for a full-width control on a scrolling page,
+ * which is what `LAUNCHER_SAFE_COLUMN` reserves.
+ *
+ * ## What this does not claim
+ *
+ * Only `/contact` opts into the column. The catalogue grid is full-bleed and
+ * every product card sits under the launcher at every viewport — measured, and
+ * filed as #334 — which is a standing decision rather than an oversight:
+ * `chat-launcher.spec.ts` says in its own header that "covering content is
+ * tolerable". What makes `/contact` different is that the covered control is
+ * the page's only primary action and a mis-tap opens a modal over a
+ * part-composed message, which is the same reasoning `chat.tsx` already
+ * applies to its own close button.
+ */
+
+const PHONES = [
+  // 390x844 is where #286 and #327 both measured, independently, to the pixel.
+  { name: '390x844', width: 390, height: 844 },
+  // 360x740 is where the message textarea is hit as well as the button, and by
+  // 8x40 rather than 8x32 — the narrowest common phone, and the worst case.
+  { name: '360x740', width: 360, height: 740 },
+  // 414x896 is where the overlap shrinks to 8x8 and the launcher wins no
+  // sampled point. Included so a fix that only works on narrow screens is not
+  // reported as a fix.
+  { name: '414x896', width: 414, height: 896 },
+]
+
+type Intrusion = {
+  label: string
+  rect: number[]
+  overlap: string
+  stolen: number
+  sampled: number
+}
+
+type Reading = {
+  launcher: number[] | null
+  controls: number
+  intrusions: Intrusion[]
+}
+
+async function readAt(page: Page, scrollY: number): Promise<Reading> {
+  await page.evaluate((y) => window.scrollTo(0, y), scrollY)
+  await page.waitForTimeout(120)
+  return page.evaluate(() => {
+    const launcher = document.querySelector('button[aria-label="Open chat"]')
+    if (!launcher) return { launcher: null, controls: 0, intrusions: [] }
+    const L = launcher.getBoundingClientRect()
+    const intrusions = []
+    let controls = 0
+    for (const el of document.querySelectorAll('a[href], button, input, select, textarea')) {
+      if (el === launcher || launcher.contains(el)) continue
+      const b = el.getBoundingClientRect()
+      if (b.width === 0 || b.height === 0) continue
+      if (b.bottom < 0 || b.top > window.innerHeight) continue
+      controls += 1
+      const ox = Math.min(b.right, L.right) - Math.max(b.left, L.left)
+      const oy = Math.min(b.bottom, L.bottom) - Math.max(b.top, L.top)
+      if (ox <= 0 || oy <= 0) continue
+      // Geometry is the assertion; the hit test is reported alongside it so a
+      // failure says whether the launcher merely overlaps the control or
+      // actually takes taps from it.
+      let stolen = 0
+      let sampled = 0
+      for (let fx = 0.02; fx <= 0.99; fx += 0.02) {
+        for (let fy = 0.1; fy <= 0.95; fy += 0.2) {
+          const x = b.left + b.width * fx
+          const y = b.top + b.height * fy
+          if (x < 0 || y < 0 || x > window.innerWidth || y > window.innerHeight) continue
+          sampled += 1
+          const top = document.elementFromPoint(x, y)
+          if (top === launcher || launcher.contains(top)) stolen += 1
+        }
+      }
+      intrusions.push({
+        label: (el.getAttribute('aria-label') || el.textContent || el.tagName).trim().slice(0, 40),
+        rect: [Math.round(b.left), Math.round(b.top), Math.round(b.right), Math.round(b.bottom)],
+        overlap: `${Math.round(ox)}x${Math.round(oy)}`,
+        stolen,
+        sampled,
+      })
+    }
+    return {
+      launcher: [Math.round(L.left), Math.round(L.top), Math.round(L.right), Math.round(L.bottom)],
+      controls,
+      intrusions,
+    }
+  })
+}
+
+test.describe('the chat launcher does not take taps from /contact', () => {
+  for (const phone of PHONES) {
+    test(`no control on /contact enters the launcher column at ${phone.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: phone.width, height: phone.height })
+      await page.goto('/contact', { waitUntil: 'networkidle' })
+
+      const max = await page.evaluate(
+        () => document.documentElement.scrollHeight - window.innerHeight,
+      )
+      // Sampling only the document end is how this defect hides: the launcher
+      // is fixed, so the button clears it there on its own.
+      const stops = [...new Set([0, Math.round(max * 0.25), Math.round(max * 0.5), Math.round(max * 0.75), max].filter((n) => n >= 0))]
+
+      const found: string[] = []
+      let controlsSeen = 0
+      let sawLauncher = false
+
+      for (const y of stops) {
+        const reading = await readAt(page, y)
+        if (reading.launcher) sawLauncher = true
+        controlsSeen = Math.max(controlsSeen, reading.controls)
+        for (const i of reading.intrusions) {
+          found.push(
+            `scrollY=${y} "${i.label}" rect=[${i.rect}] overlap=${i.overlap} launcherWinsHitTest=${i.stolen}/${i.sampled}`,
+          )
+        }
+      }
+
+      // Two vacuity guards. Without them "nothing intruded" is satisfied by a
+      // page that rendered no launcher, or by a selector that matched no
+      // control — both of which look exactly like a pass.
+      expect(sawLauncher, 'the launcher never rendered, so this measured nothing').toBe(true)
+      expect(
+        controlsSeen,
+        'no page controls were in view, so the launcher had nothing to overlap',
+      ).toBeGreaterThan(4)
+
+      expect(found, 'controls overlapping the chat launcher').toEqual([])
+    })
+  }
+
+  test('the reserve is scoped to below the sm breakpoint', async ({ page }) => {
+    // This pins where the reserve is *declared*, and that is all it pins --
+    // worth being explicit about, because the 640 assertion has no rendered
+    // consequence behind it. The card is `max-w-lg`, and at 640 the wrapper's
+    // content box is already 592px -- wider still above that -- so a 512px
+    // card never feels the inset: dropping the `max-sm:` prefix changes no
+    // pixel at any width. Measured at 640, 768, 1024 and 1440, the card is
+    // 512px with the prefix and 512px without it.
+    //
+    // So this is a scope check, not a geometry check. It is here because 640
+    // is where the launcher's own `sm:mr-12` moves it clear unaided, and a
+    // reserve left switched on above that point is paying for something
+    // already true -- cheap to state, and invisible to every other test.
+    //
+    // The gap assertions below are the geometry, and they are what stop this
+    // passing by pinning a breakpoint while the controls stop clearing.
+    const readings: Record<number, { padding: string; gap: number }> = {}
+    for (const width of [639, 640]) {
+      await page.setViewportSize({ width, height: 900 })
+      await page.goto('/contact', { waitUntil: 'networkidle' })
+      const reading = await page.evaluate(() => {
+        const submit = [...document.querySelectorAll('button')].find(
+          (b) => (b.textContent ?? '').trim() === 'Send Message',
+        )
+        const wrapper = submit?.closest('form')?.parentElement
+        const launcher = document.querySelector('button[aria-label="Open chat"]')
+        if (!submit || !wrapper || !launcher) return null
+        return {
+          padding: getComputedStyle(wrapper).paddingRight,
+          gap: Math.round(
+            launcher.getBoundingClientRect().left - submit.getBoundingClientRect().right,
+          ),
+        }
+      })
+      expect(reading, `the form, its wrapper or the launcher was not found at ${width}`).not.toBeNull()
+      readings[width] = reading!
+    }
+
+    expect(readings[639].padding, 'the reserve is not applied just below the sm breakpoint').not.toBe('0px')
+    expect(readings[640].padding, 'the reserve is still applied at sm, where the launcher already clears').toBe('0px')
+    // The property itself, on both sides, so this cannot pass by pinning the
+    // breakpoint while the controls stop clearing.
+    expect(readings[639].gap, 'controls run into the launcher just below sm').toBeGreaterThanOrEqual(0)
+    expect(readings[640].gap, 'controls run into the launcher at sm').toBeGreaterThanOrEqual(0)
+  })
+
+  test('the reserved column costs no vertical space', async ({ page }) => {
+    // This pins the reserve's *placement*, not its size. On the card wrapper
+    // the inset narrows the card and nothing else, so document height does not
+    // move at any value from 16 to 56 -- this test passes at all of them and
+    // cannot choose between them. What chose 32 is the width floor two tests
+    // down, and the focus ring one test below that.
+    //
+    // What it does catch is the reserve moving back to the page column, where
+    // it narrows the centred subtitle to a third line and adds 28px of
+    // document. The vacuity check below is the mechanism: it reads this
+    // wrapper's padding and finds none once the reserve has been lifted off it.
+    //
+    // Differential rather than absolute, so it stays true when the form gains
+    // a field -- it measures the reserve rather than the content.
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/contact', { waitUntil: 'networkidle' })
+
+    const measured = await page.evaluate(() => {
+      const submit = [...document.querySelectorAll('button')].find(
+        (b) => (b.textContent ?? '').trim() === 'Send Message',
+      )
+      if (!submit) return null
+      // The wrapper around the card is what carries the reserve. Reading the
+      // page container instead measures an element with no reserve on it,
+      // which the vacuity check below then rejects.
+      const container = submit.closest('form')?.parentElement as HTMLElement | null
+      if (!container) return null
+
+      const withReserve = {
+        doc: document.documentElement.scrollHeight,
+        submitBottom: Math.round(submit.getBoundingClientRect().bottom),
+      }
+      // The baseline is the wrapper with no reserve at all, which is what the
+      // page had before it existed. Collapsing one side against the other
+      // would compare nothing now that the insets are symmetric.
+      const reserved = getComputedStyle(container).paddingRight
+      container.style.paddingLeft = '0px'
+      container.style.paddingRight = '0px'
+      void container.offsetHeight
+      const withoutReserve = {
+        doc: document.documentElement.scrollHeight,
+        submitBottom: Math.round(submit.getBoundingClientRect().bottom),
+      }
+      container.style.paddingLeft = ''
+      container.style.paddingRight = ''
+      return { withReserve, withoutReserve, reserved }
+    })
+
+    expect(measured, 'the submit button or its page container was not found').not.toBeNull()
+    // Vacuity: if the reserve were not applied at this width, both readings
+    // would be the same page and the comparison would assert nothing.
+    expect(
+      measured!.reserved,
+      'no reserve is applied at this width, so this compares two identical layouts',
+    ).not.toBe('0px')
+    expect(
+      measured!.withReserve.doc,
+      'the reserved column made the document taller',
+    ).toBe(measured!.withoutReserve.doc)
+    expect(
+      measured!.withReserve.submitBottom,
+      'the reserved column pushed the primary action further down the page',
+    ).toBe(measured!.withoutReserve.submitBottom)
+  })
+
+  test('the reserved column is only as wide as the launcher needs', async ({ page }) => {
+    // A fix that reserved the whole right half of the page would satisfy the
+    // test above and be a worse page. This bounds it from the other side: the
+    // form still has to use most of the width it is given.
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/contact', { waitUntil: 'networkidle' })
+
+    const measured = await page.evaluate(() => {
+      const submit = [...document.querySelectorAll('button')].find(
+        (b) => (b.textContent ?? '').trim() === 'Send Message',
+      )
+      const launcher = document.querySelector('button[aria-label="Open chat"]')
+      if (!submit || !launcher) return null
+      return {
+        submit: Math.round(submit.getBoundingClientRect().width),
+        gap: Math.round(
+          launcher.getBoundingClientRect().left - submit.getBoundingClientRect().right,
+        ),
+        viewport: window.innerWidth,
+      }
+    })
+
+    expect(measured, 'the submit button or the launcher was not found').not.toBeNull()
+    expect(
+      measured!.submit,
+      'the submit button gave up more width than clearing the launcher needs',
+    ).toBeGreaterThan(measured!.viewport * 0.6)
+    expect(measured!.gap, 'the submit button still runs into the launcher column').toBeGreaterThanOrEqual(0)
+  })
+
+  test("the submit button's focus ring clears the launcher too", async ({ page }) => {
+    // The hit target clearing the launcher is not enough. `ACTION_FOCUS` is
+    // `outline-2 outline-offset-2`, so the ring reaches 4px past the button's
+    // edge -- at a 24px card inset the button is clear and its focus ring
+    // still renders under the launcher, which is a keyboard-only defect that
+    // every geometry assertion above would pass.
+    //
+    // Reached by Tab rather than `.focus()`: Chromium's `:focus-visible`
+    // heuristic does not fire for programmatic focus, so a script-focused
+    // button reports no ring at all and this would measure nothing.
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/contact', { waitUntil: 'networkidle' })
+
+    await page.locator('textarea').focus()
+    await page.keyboard.press('Tab')
+
+    // The button carries `transition-all`, so reading straight after the Tab
+    // returns the transition's starting values -- `medium`/`currentcolor`,
+    // which compute to 3px width at 0px offset and reach 1px LESS than the
+    // settled ring. That is looser than the real geometry in exactly the
+    // direction that lets a defect through, and it also satisfies the two
+    // vacuity checks below with the "ring that means nothing" state they exist
+    // to reject.
+    //
+    // Settled by agreement rather than by a timeout or a hardcoded `2px`: the
+    // values belong to ACTION_FOCUS, and pinning them here would make this
+    // test fail for a change to the ring rather than for a change to the
+    // clearance it is measuring.
+    await page.waitForFunction(() => {
+      const el = document.activeElement
+      if (!el) return false
+      const style = getComputedStyle(el)
+      const sample = `${style.outlineWidth}|${style.outlineOffset}|${style.outlineColor}`
+      const store = window as unknown as { __ringSample?: string }
+      const settled = store.__ringSample === sample
+      store.__ringSample = sample
+      return settled
+    })
+
+    const measured = await page.evaluate(() => {
+      const active = document.activeElement as HTMLElement | null
+      if (!active || active.tagName !== 'BUTTON') return null
+      const style = getComputedStyle(active)
+      const reach = parseFloat(style.outlineWidth) + parseFloat(style.outlineOffset)
+      const b = active.getBoundingClientRect()
+      const L = document.querySelector('button[aria-label="Open chat"]')!.getBoundingClientRect()
+      return {
+        label: (active.textContent ?? '').trim(),
+        outlineWidth: parseFloat(style.outlineWidth),
+        outlineStyle: style.outlineStyle,
+        reach,
+        ringGap: Math.round(L.left - (b.right + reach)),
+      }
+    })
+
+    expect(measured, 'Tab did not land on a button').not.toBeNull()
+    expect(measured!.label, 'Tab landed on the wrong control').toBe('Send Message')
+    // Vacuity: a ring of zero width, or one whose style is `none`, would make
+    // `reach` meaningless and the clearance trivially true. `outlineWidth`
+    // reports the user-agent default even when the style is `none`, so both
+    // have to be checked.
+    expect(measured!.outlineStyle, 'no focus ring is drawn, so its clearance means nothing').not.toBe('none')
+    expect(measured!.outlineWidth, 'the focus ring has no width').toBeGreaterThan(0)
+    expect(
+      measured!.ringGap,
+      'the submit button clears the launcher but its focus ring does not',
+    ).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/apps/web/src/app/contact/page.tsx
+++ b/apps/web/src/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import ContactForm from "@/components/contact-form";
+import { LAUNCHER_SAFE_COLUMN } from "@/lib/control-classes";
 
 export default function ContactPage() {
   return (
@@ -22,7 +23,9 @@ export default function ContactPage() {
           </p>
         </div>
         
-        <ContactForm />
+        <div className={`flex w-full justify-center ${LAUNCHER_SAFE_COLUMN}`}>
+          <ContactForm />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/lib/control-classes.ts
+++ b/apps/web/src/lib/control-classes.ts
@@ -1,11 +1,20 @@
 /**
  * What the app's controls share, for the parts that have one right answer.
  *
- * Four exports, because fields and action controls fail differently, are fixed
- * differently, and a control whose focusable element is a descendant needs a
- * different variant again. None of them carries an accent. A control's focus
- * colour is indigo on the page and sky-700 inside the chat widget — #184 chose
- * that split so the panel reads as its own place — so the mechanism is shared
+ * Four of the five exports are control properties: fields and action controls
+ * fail differently, are fixed differently, and a control whose focusable
+ * element is a descendant needs a different variant again. The fifth,
+ * `LAUNCHER_SAFE_COLUMN`, is not a control property at all — it is a layout
+ * reservation one page makes against the chat launcher's fixed geometry. It
+ * lives here because it is a shared class constant derived from a control's
+ * measurements, and because `ACTION_FOCUS` above is what sets its lower bound,
+ * but it is the one export in this file whose correctness depends on another
+ * file (`chat.tsx`'s `mr-4` and `p-2`). `launcher-safe-area.spec.ts` is what
+ * holds that coupling together; nothing in this file can.
+ *
+ * None of the five carries an accent. A control's focus colour is indigo on
+ * the page and sky-700 inside the chat widget — #184 chose that split so the
+ * panel reads as its own place — so the mechanism is shared
  * and the accent stays at the call site, the same division as radius and
  * padding staying with each field below.
  *
@@ -247,3 +256,124 @@ export const ACTION_BOUNDARY = `forced-colors:border-2 ${ACTION_FOCUS}`
  */
 export const ACTION_FOCUS_WITHIN =
   'has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2'
+
+/**
+ * The inset `/contact` adds so its controls clear the chat launcher.
+ *
+ * The launcher is `fixed bottom-0 right-0` with `mr-4 mb-4` below `sm`, and it
+ * is a 40x40 disc — `p-2` around a `w-6` icon. So it owns the rightmost 56px
+ * of the viewport: 40 of control, 16 of margin. #286 measured the `/contact`
+ * submit button at 48..342 against a launcher at 334..374, an 8x32 overlap in
+ * which `document.elementFromPoint` returns the launcher — so the last 8px of
+ * the page's primary action opened the chat instead of submitting it.
+ *
+ * ## Why a column and not a gutter below the content
+ *
+ * #286 proposed bottom padding, and it cannot work. The launcher is `fixed`,
+ * so the page scrolls under it and every row passes through its band; a gutter
+ * separates them only at the very end of the document. `padding-bottom` also
+ * moves nothing at `scrollY=0` — it makes the document taller and leaves what
+ * is already rendered where it was.
+ *
+ * There is a structural reason too: `layout.tsx` puts the copyright `Block`
+ * inside `<main>`, so bottom padding on `main` lands below the footer and
+ * shows page background under the dark bar on every route.
+ *
+ * ## The arithmetic, which is why this class is 16px and not 56
+ *
+ * Two numbers below are easy to confuse, so: this class contributes **16px**,
+ * and the page's own `px-4` contributes the other 16, for a **32px total
+ * inset** from the viewport edge. The sweep table further down is in total
+ * inset, because that is what the launcher's geometry is measured against.
+ *
+ * The card's own `p-8` already holds its controls 32px inside its edge, and
+ * the page's `px-4` already holds the card 16px inside the viewport. Against a
+ * launcher column starting at `viewport - 56`, the card's box has to end by
+ * `viewport - 24` for its controls to clear, or `viewport - 28` for their
+ * focus rings to clear as well. Both are below the shipped 32: 16px is simply
+ * the next step on Tailwind's spacing scale above the 12px that would satisfy
+ * the ring, which the sweep table and the ring paragraph below set out.
+ *
+ * A page with a different gutter, or a card with different padding, has to
+ * redo that sum rather than reuse the number — the 16px here is not a property
+ * of the launcher, it is what this page's other spacing leaves to make up.
+ *
+ * Only the right half of that is clearance. The matching left inset is
+ * cosmetic: with `pr-4` alone the card sat 16px inboard on the right and flush
+ * on the left, under a full-width centred subtitle, and read as misaligned
+ * rather than as reserved. Measured, the symmetric version costs nothing — same
+ * 8px gap, same document height, same submit position, and the copy does not
+ * re-wrap at 360, 390 or 414. It only moves where the card's spare width comes
+ * from.
+ *
+ * ## Why the reserve is 32px of total inset
+ *
+ * Measured on the rendered page, sweeping this wrapper's padding at 390x844.
+ * `total inset` is page gutter plus this class, as above — the shipped value
+ * is the 32px row, which this class reaches with `px-4`:
+ *
+ * ```
+ * total inset  submitGap  ringGap  submitW  docHeight  submitBottom
+ *        16px       -8px      -12      294        960           848   <- the defect
+ *        24px         0        -4      278        960           848
+ *        28px        +4         0      270        960           848
+ *        32px        +8        +4      262        960           848   <- shipped
+ *        40px       +16       +12      246        960           848
+ *        56px       +32       +28      214        960           848
+ * ```
+ *
+ * Document height and submit position do not move at all: this wrapper narrows
+ * the card and nothing else, so no copy re-wraps. The bounds are horizontal at
+ * both ends.
+ *
+ * The lower bound is the focus ring, not the hit target. `ACTION_FOCUS` is
+ * `outline-2 outline-offset-2`, so the submit button's ring reaches 4px past
+ * its edge: at 24px the button is already untappable-by-mistake and its ring
+ * still renders under the launcher. 28px brings the ring exactly to the
+ * launcher's edge; 32px is the next step on Tailwind's scale and the first
+ * that leaves daylight. `launcher-safe-area.spec.ts` measures the settled ring
+ * rather than pinning either number.
+ *
+ * The upper bound is the width the card gives up for nothing. At 56px the
+ * submit button is 214px on a 390px viewport, which the spec's width floor
+ * rejects. That floor, not any vertical cost, is what rules out reserving the
+ * launcher's whole 56px footprint here.
+ *
+ * ## On the card, not on the page container
+ *
+ * The first version put this on the page's outer container. That cleared the
+ * launcher identically and shifted the centred `Get in Touch` heading 8px left
+ * of the viewport centre, because the container is what centres it — a display
+ * heading moved off-centre for a reason that has nothing to do with it.
+ * Wrapping the card keeps the heading where it was, and keeps the reserve on
+ * the one element that needs it.
+ *
+ * That placement also decides whether the reserve costs vertical space, which
+ * is why the table above is flat. On the page container a 40px inset narrows
+ * the centred subtitle to a third line — measured, its height goes 56 to 84 —
+ * adding 28px of document and pushing the submit button from 4px below the
+ * fold to 32px. On this wrapper the subtitle is untouched at every inset from
+ * 16 to 56. The vacuity check in the spec's `costs no vertical space` test is
+ * what catches a move back: it reads this wrapper's padding, and finds none if
+ * the reserve has been lifted to the column.
+ *
+ * ## Below `sm` only
+ *
+ * At `sm` and up the launcher takes `mr-12 mb-12` and the card is `max-w-lg`
+ * centred in a much wider viewport, so nothing reaches the corner — measured
+ * clear at 834x1112, where the gap is already 105px.
+ *
+ * ## Opt-in, not automatic
+ *
+ * Only `/contact` uses this. The catalogue grid is full-bleed and every
+ * product card sits under the launcher at every viewport (#334), which is a
+ * standing decision rather than an oversight — `chat-launcher.spec.ts` records
+ * that "covering content is tolerable". `/login` and `/signup` put a submit in
+ * the same column and do not need it today, but for a narrower reason than it
+ * looks: their submits *do* run into the launcher's column horizontally, and
+ * what saves them is vertical — the content is short enough that `justify-center`
+ * keeps it above the bottom 56px band, and neither page scrolls at 390x844 or
+ * 360x740, so no control ever reaches the launcher. A field added to either
+ * form would move the submit down with nothing measuring it.
+ */
+export const LAUNCHER_SAFE_COLUMN = 'max-sm:px-4'


### PR DESCRIPTION
Closes #286. Also folds in #327, which was filed independently and measured the same defect at the same viewport to the pixel.

## What was wrong

The chat launcher is `fixed bottom-0 right-0` with `mr-4 mb-4` below `sm`, and it is a 40x40 disc — so it owns the rightmost 56px of the viewport on every route. On `/contact` that landed on the page's only primary action:

```
390x844   Send Message  48..342     launcher  334..374    overlap 8x32
360x740   textarea      48..312     launcher  304..344    overlap 8x40
414x896   Send Message  48..366     launcher  358..398    overlap 8x8
```

`document.elementFromPoint` returns the launcher over the last 8px of the submit button, so a tap there opens the chat instead of submitting a part-composed form.

## Why the issue's proposed fix is not the one here

#286 proposed bottom padding on `main`. That cannot work, and the sweep is what showed it:

- The launcher is `fixed`, so the page scrolls under it and every row passes through its band. A bottom gutter separates them only at the very end of the document.
- `padding-bottom` moves nothing already rendered at `scrollY=0`. It makes the document taller and leaves the button where it was.
- `layout.tsx` puts the copyright `Block` inside `<main>`, so padding there lands *below* the footer and shows page background under the dark bar on every route.

**A note on how nearly this was missed.** My first sweep scrolled each route to the document end before measuring and reported every route clean — including `/contact`. `/contact` scrolls just 116px at 390x844, and by the end of it the button has cleared the launcher on its own. The one position I sampled was the only one where the defect cannot appear. #148 records this trap from the other direction; this is the same hole, mirrored.

Horizontal separation is the only geometry that holds for a full-width control on a page that scrolls.

## Why 32px of total inset and not the launcher's 56

Sweeping the reserve on the rendered page at 390x844:

```
total inset  submitGap  ringGap  submitW  docHeight  submitBottom
       16px       -8px      -12      294        960           848   <- the defect
       24px         0        -4      278        960           848
       28px        +4         0      270        960           848
       32px        +8        +4      262        960           848   <- shipped
       40px       +16       +12      246        960           848
       56px       +32       +28      214        960           848
```

Both bounds are horizontal. **The lower bound is the focus ring, not the hit target**: `ACTION_FOCUS` is `outline-2 outline-offset-2`, so the ring reaches 4px past the button — at 24px the button is already untappable-by-mistake and its ring still renders under the launcher. **The upper bound is width surrendered for nothing**: at 56px the submit is 214px on a 390px viewport, which the spec's floor rejects.

## Scope

Opt-in, and deliberately so. Every product card on the catalogue and home routes sits under the launcher at every viewport including tablet — measured, and filed as #334 rather than changed, because `chat-launcher.spec.ts` already records in its own header that "covering content is tolerable". What earns `/contact` the column is that the covered control is the page's only primary action and a mis-tap opens a modal over a part-composed message — the same reasoning `chat.tsx` applies to its own close button.

## Coverage

`apps/web/e2e/launcher-safe-area.spec.ts`, 7 tests. Each was demonstrated against a deliberate break rather than argued:

| Assertion | Break that proves it |
| --- | --- |
| No control enters the column, at 3 phone widths | The original defect — 4 failures against `main` |
| Reserve scoped below `sm` | Drop `max-sm:` → 6 pass, only this fails |
| Reserve costs no vertical space | Move the reserve off the card wrapper |
| Reserve no wider than needed | 160px reserve → submit gives up too much width |
| Focus ring clears too | 24px inset, and 11px at the 1px boundary |
| Vacuity: launcher rendered, controls in view, ring drawn, reserve present | Bogus selectors, forced `outline-style: none`, above-`sm` viewport |

## Three rounds that changed the shape rather than confirming it

Recording these because each is a way this looked finished and was not.

1. **`ui-review`:** the reserve sat on the page container and de-centred the `Get in Touch` heading 8px. It belongs on the card. Moved; `h1Offset` is 0 at all five viewports.
2. **`ui-review`:** the ring guard read `getComputedStyle` immediately after Tab, and the button carries `transition-all` — so it got the transition's *initial* `3px/0px` instead of the settled `2px/2px`. That is 1px looser, in the direction that lets a defect through. An 11px inset produces `gap=3`: the transient reading scored it as clearing by 0, the settled reading correctly rejects it at −1. Rebuilt at 11px to confirm — five assertions pass and only the ring guard catches it.
3. **`code-review`:** the comment's sweep table had been measured on the page-container version and carried across when the reserve moved. On this lever document height is flat from 16px to 56px; the 28px cliff it claimed belongs to the rejected placement, and its cause was the *subtitle* wrapping to a third line, not the card. Re-measured.

Finding 3 is the one worth carrying forward: the table was correct when written, correct for the lever it was written about, and wrong the moment the lever changed — with nothing to flag it, because the code it described still compiled and every test still passed.

## A disputed finding, checked rather than complied with

`ui-review` reported that `element.focus()` does not satisfy Chromium's `:focus-visible` heuristic. Measured here it does — `outlineStyle: solid`, `outlineWidth: 2px`, identical to the Tab path — which matches what #148 records about `tabIndex={-1}` plus programmatic focus painting a ring on the drawer panel. `ui-review` confirmed the correction in its next round. The guard uses Tab regardless, so nothing rests on it; recording it so it is not carried forward as established.

I also corrected one number in a `code-review` finding: the wrapper's content box at 640 is 592px, not 560. The conclusion it supported was unchanged.

## Verification

`make -C apps/web ci` passes on the committed state (lint, both type-checks, 175 unit tests, production build). Full journey suite **143 passed**. The verifier passed this branch four times and independently reproduced the sweep table, the 592px content box, and the vacuity catches rather than trusting them. `code-review` returned **no defects** on its final round.

## Issues filed from this work

- **#334** — every catalogue and home product card sits under the launcher, at every viewport.
- **#338** — the contact form discards the error it catches, so a failed submission leaves nothing to diagnose.
- **#339** — `/login` and `/signup` submits also sit in the launcher's column, saved only by how short the forms are. Found because `code-review` challenged a claim I had written into the comment, and was right.
