### PR TITLE
fix(tooling): unquote the paths git C-quotes before classifying

### DIFF
--- a/scripts/detect_changed_surfaces.py
+++ b/scripts/detect_changed_surfaces.py
@@ -125,13 +125,111 @@ def matches_any(path: str, patterns: Iterable[str]) -> bool:
     return any(path_matches(pattern, path) for pattern in patterns)
 
 
+# git renders a path it considers unsafe as a C-quoted string: wrapped in
+# double quotes, with backslash escapes and non-ASCII bytes as three-digit
+# octal. `git status --porcelain` does that for any name containing a space,
+# and both readers do it for non-ASCII. Taken literally, `"apps/web/a b.tsx"`
+# matches no pattern and classifies as `unknown` (#297).
+_C_ESCAPES = {
+    "a": 0x07,
+    "b": 0x08,
+    "f": 0x0C,
+    "n": 0x0A,
+    "r": 0x0D,
+    "t": 0x09,
+    "v": 0x0B,
+    '"': 0x22,
+    "\\": 0x5C,
+}
+
+
+def unquote_git_path(path: str) -> str:
+    """Undo git's C-quoting. Returns anything unquoted unchanged.
+
+    Not `core.quotePath=false`, which is the obvious fix and is a worse one.
+    That makes git emit the raw bytes, and a filename that is not valid UTF-8
+    then raises `UnicodeDecodeError` out of `subprocess.run(text=True)` --
+    measured, `git -c core.quotePath=false status --porcelain` on a name
+    containing byte 0xff dies where the default emits an ASCII-safe
+    `"apps/web/src/bad\\377.tsx"`. That would turn a misclassification into a
+    hard failure of `make quick-ci-changed`. The flag would also not be enough
+    on its own: `status --porcelain` quotes a name containing a space whether
+    it is set or not.
+
+    Decoding is via bytes rather than str because the escapes are bytes: a
+    single non-ASCII character arrives as several octal escapes, and only the
+    assembled sequence is decodable.
+    """
+    if len(path) < 2 or not path.startswith('"') or not path.endswith('"'):
+        return path
+
+    body = path[1:-1]
+    out = bytearray()
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char != "\\":
+            out.extend(char.encode("utf-8"))
+            index += 1
+            continue
+        index += 1
+        if index >= len(body):
+            break
+        escape = body[index]
+        if escape in "01234567":
+            out.append(int(body[index : index + 3], 8))
+            index += 3
+            continue
+        out.append(_C_ESCAPES.get(escape, ord(escape)))
+        index += 1
+    # surrogateescape so a name that is not valid UTF-8 survives as a distinct
+    # string rather than raising or collapsing into replacement characters.
+    return out.decode("utf-8", errors="surrogateescape")
+
+
+def _read_path_token(payload: str, index: int) -> tuple[str, int]:
+    """Read one porcelain path starting at `index`, quoted or not."""
+    if payload[index] == '"':
+        cursor = index + 1
+        while cursor < len(payload):
+            if payload[cursor] == "\\":
+                cursor += 2
+                continue
+            if payload[cursor] == '"':
+                return payload[index : cursor + 1], cursor + 1
+            cursor += 1
+        return payload[index:], len(payload)
+    separator = payload.find(" -> ", index)
+    if separator == -1:
+        return payload[index:], len(payload)
+    return payload[index:separator], separator
+
+
+def porcelain_destination(payload: str) -> str:
+    """The path a porcelain entry is about -- for a rename, where it now is.
+
+    Splitting the raw string on " -> " is not enough once quoting is in play,
+    because a quoted name can contain that sequence. Reading the first token to
+    its closing quote and looking for the separator after it cannot be fooled
+    that way.
+    """
+    if not payload:
+        return payload
+    token, index = _read_path_token(payload, 0)
+    if payload[index:].startswith(" -> "):
+        token, _ = _read_path_token(payload, index + 4)
+    return unquote_git_path(token)
+
+
 def changed_files_from_range(base: str, head: str) -> list[str]:
     # D is included: a deletion changes a surface just as much as an edit.
     # Without it a deletion-only change classified as "none" and CI skipped
     # every scoped check, so removing a referenced asset or source file would
     # have gone green without the web or chat suites ever running.
     raw = run_git(["diff", "--name-only", "--diff-filter=ACMRTD", f"{base}...{head}"])
-    return sorted({line.strip() for line in raw.splitlines() if line.strip()})
+    return sorted(
+        {unquote_git_path(line.strip()) for line in raw.splitlines() if line.strip()}
+    )
 
 
 def changed_files_from_worktree() -> list[str]:
@@ -140,9 +238,7 @@ def changed_files_from_worktree() -> list[str]:
     for line in raw.splitlines():
         if len(line) < 4:
             continue
-        payload = line[3:].strip()
-        if " -> " in payload:
-            payload = payload.split(" -> ", 1)[1].strip()
+        payload = porcelain_destination(line[3:].strip())
         if payload:
             files.add(payload)
     return sorted(files)

--- a/tests/scripts/AGENTS.md
+++ b/tests/scripts/AGENTS.md
@@ -45,6 +45,32 @@ constant the demonstrated assertion reaches:
   `stale_port_keys` tests take their inputs as arguments and reach no path at all,
   which is the reason they are shaped that way.
 
+## Mutation demonstrations and stale bytecode
+
+`load_script_module` reaches these scripts through `spec_from_file_location`, so
+they compile into `scripts/__pycache__` like any import. Python treats a cached
+`.pyc` as current when the source's **mtime and size** both match, and a mutation
+demonstration defeats exactly that check: flipping a constant (`0x5C` to `0x58`)
+leaves the file the same size, and restoring it from a backup seconds later
+leaves the recorded mtime unchanged to the second.
+
+Measured here: after restoring the source, `grep` showed the original constant
+and the suite still failed, decoding through the mutated table. The source was
+never wrong; the bytecode was. It reads exactly like a mutation that would not
+revert.
+
+So clear the cache between a mutation and its restore, or check the restore by
+running the suite rather than by reading the file:
+
+```bash
+find . -name __pycache__ -type d -not -path './node_modules/*' -not -path './.venv/*' -exec rm -rf {} +
+```
+
+The same shape bites in the other direction. A mutation that never applied —
+a `sed` whose pattern did not match — leaves every test passing, which is
+indistinguishable from an assertion that catches nothing. Confirm the mutation
+landed before believing its result, the same way you confirm the restore did.
+
 Confirm the run opened the fixture with a failure that names a fixture path or a
 vacuity guard whose count matches what the fixture contains. The count is the
 evidence: a vacuity guard also fires when a fixture path is mistyped, while every

--- a/tests/scripts/test_detect_changed_surfaces.py
+++ b/tests/scripts/test_detect_changed_surfaces.py
@@ -1,4 +1,8 @@
+import contextlib
 import importlib.util
+import os
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -293,6 +297,223 @@ class DetectChangedSurfacesTests(unittest.TestCase):
                 "scripts/new_path.py",
                 "tests/scripts/test_new.py",
             ],
+        )
+
+
+# Names git renders differently from how they sit on disk. `SPACED` is the one
+# that matters most: `git status --porcelain` quotes it even under
+# `core.quotePath=false`, while `git diff --name-only` never quotes it at all,
+# so the two readers need different handling and only one of them is fixed by
+# the config flag.
+SPACED = "apps/web/src/a b.tsx"
+NON_ASCII = "apps/web/src/na\u00efve.tsx"
+PLAIN = "apps/web/src/plain.tsx"
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+class QuotedPathFixture:
+    """A real repository containing names git C-quotes.
+
+    Patching `run_git` cannot exercise this: the defect is in what git emits,
+    so the fixture has to be a repository git actually reads. `tests/scripts/
+    AGENTS.md` asks for the owning tool's own output where practical, and this
+    is the case it is describing.
+    """
+
+    def __init__(self, stack):
+        self.root = Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        git(self.root, "init", "--quiet", ".")
+        git(self.root, "config", "user.email", "guard@example.test")
+        git(self.root, "config", "user.name", "Guard")
+        git(self.root, "config", "commit.gpgsign", "false")
+        (self.root / "README.md").write_text("base\n", encoding="utf-8")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", "base")
+
+    def write(self, *relative: str) -> None:
+        for name in relative:
+            path = self.root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("contents\n", encoding="utf-8")
+
+    def commit(self, message: str) -> None:
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "--quiet", "-m", message)
+
+    def raw_status(self) -> str:
+        return git(self.root, "status", "--porcelain")
+
+    def raw_diff(self, base: str, head: str) -> str:
+        return git(self.root, "diff", "--name-only", "--diff-filter=ACMRTD", f"{base}...{head}")
+
+
+class QuotedPathTests(unittest.TestCase):
+    """Paths git quotes must still classify as the surface they belong to.
+
+    Routing fails safe today -- an unrecognised path sets `unknown`, which
+    forces the full runtime recommendation -- so nothing is under-gated and the
+    defect has never been visible in CI. The cost is to the flag: `unknown` is
+    meant to mean "no pattern claims this path", and #253 narrowed it for
+    exactly that reason. A renamed component with a space in its name reads, to
+    that flag, as unclassified.
+    """
+
+    def setUp(self):
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        self.fixture = QuotedPathFixture(stack)
+        # Every assertion below reaches git through this constant, so the
+        # fixture is only isolated once it is rebound -- otherwise `run_git`
+        # reads the checkout this guard is meant to protect.
+        stack.enter_context(patch.object(detect_changed, "ROOT", self.fixture.root))
+
+    def test_the_fixture_actually_produces_quoted_output(self):
+        """Without this, the tests below could pass on a fixture git never quotes."""
+        self.fixture.write(SPACED, NON_ASCII, PLAIN)
+        self.fixture.commit("add awkward names")
+        self.fixture.write(SPACED, NON_ASCII, PLAIN)
+        for path in (self.fixture.root / SPACED, self.fixture.root / NON_ASCII):
+            path.write_text("modified\n", encoding="utf-8")
+
+        status = self.fixture.raw_status()
+        self.assertIn('"apps/web/src/a b.tsx"', status)
+        self.assertIn("\\303\\257", status)
+
+    def test_worktree_reader_unquotes_the_names_git_quoted(self):
+        self.fixture.write(SPACED, NON_ASCII, PLAIN)
+        self.fixture.commit("add awkward names")
+        for name in (SPACED, NON_ASCII, PLAIN):
+            (self.fixture.root / name).write_text("modified\n", encoding="utf-8")
+
+        files = detect_changed.changed_files_from_worktree()
+
+        self.assertEqual(files, sorted([SPACED, NON_ASCII, PLAIN]))
+
+    def test_worktree_quoted_names_classify_as_web(self):
+        self.fixture.write(SPACED, NON_ASCII)
+        self.fixture.commit("add awkward names")
+        for name in (SPACED, NON_ASCII):
+            (self.fixture.root / name).write_text("modified\n", encoding="utf-8")
+
+        flags = detect_changed.classify(detect_changed.changed_files_from_worktree())
+
+        self.assertTrue(flags["web"], "a web source file must classify as web")
+        self.assertFalse(
+            flags["unknown"],
+            "a tracked source file must not shelter under the unknown fallback",
+        )
+
+    def test_range_reader_unquotes_the_names_git_quoted(self):
+        self.fixture.write(SPACED, NON_ASCII, PLAIN)
+        self.fixture.commit("add awkward names")
+
+        files = detect_changed.changed_files_from_range(base="HEAD~1", head="HEAD")
+
+        self.assertEqual(files, sorted([SPACED, NON_ASCII, PLAIN]))
+
+    def test_range_quoted_names_classify_as_web(self):
+        self.fixture.write(SPACED, NON_ASCII)
+        self.fixture.commit("add awkward names")
+
+        flags = detect_changed.classify(
+            detect_changed.changed_files_from_range(base="HEAD~1", head="HEAD"),
+        )
+
+        self.assertTrue(flags["web"])
+        self.assertFalse(flags["unknown"])
+
+    def test_a_quoted_name_containing_the_rename_separator_is_not_split_on_it(self):
+        """The separator git puts between a rename's two paths is also legal in a name.
+
+        `status --porcelain` quotes any name with a space in it, so this one
+        arrives as a single quoted token. Splitting the raw payload on " -> "
+        cuts it in half and reports `b.tsx"` as the changed file.
+        """
+        awkward = "apps/web/src/a -> b.tsx"
+        self.fixture.write(awkward)
+        self.fixture.commit("add a name containing the separator")
+        (self.fixture.root / awkward).write_text("modified\n", encoding="utf-8")
+
+        files = detect_changed.changed_files_from_worktree()
+
+        self.assertEqual(files, [awkward])
+
+    def test_names_using_the_named_escapes_round_trip(self):
+        """The escape table for quotes, backslashes and control characters.
+
+        Nothing else in this class reaches it. A space produces quoting with no
+        escape at all, and non-ASCII goes through the octal branch, so the
+        named-escape table was free to be wrong: dropping it entirely leaves
+        every other test here green while `\t` decodes to `t` and
+        `apps/web/src/ta\tb.tsx` silently becomes `apps/web/src/tatb.tsx` -- a
+        rewritten path in the file that routes every check CI runs.
+        """
+        awkward = 'apps/web/src/qu"o\tte\\back.tsx'
+        self.fixture.write(awkward)
+        self.fixture.commit("add a name needing named escapes")
+        (self.fixture.root / awkward).write_text("modified\n", encoding="utf-8")
+
+        # Vacuity: this is only a test of the escape table if git actually
+        # emitted those escapes. A fixture git chose to quote some other way
+        # would leave the assertion below passing for the wrong reason.
+        status = self.fixture.raw_status()
+        self.assertIn('\\"', status, "git did not escape the quote character")
+        self.assertIn("\\t", status, "git did not escape the tab character")
+
+        files = detect_changed.changed_files_from_worktree()
+
+        self.assertEqual(files, [awkward])
+
+    def test_a_filename_that_is_not_utf8_does_not_crash_the_reader(self):
+        """This is why the fix does not use `core.quotePath=false`.
+
+        With that flag git emits the raw bytes and `subprocess.run(text=True)`
+        raises `UnicodeDecodeError`, so a single such file would take down
+        `make quick-ci-changed` entirely rather than misclassify one path.
+        Git's default quoting keeps the stream ASCII, which is what the
+        unquoter is built to read.
+        """
+        directory = self.fixture.root / "apps/web/src"
+        directory.mkdir(parents=True, exist_ok=True)
+        raw_name = os.path.join(os.fsencode(directory), b"bad\xff.tsx")
+        with open(raw_name, "wb") as handle:
+            handle.write(b"contents\n")
+        self.fixture.commit("add a name that is not utf-8")
+        with open(raw_name, "wb") as handle:
+            handle.write(b"modified\n")
+
+        # Vacuity: if git had not quoted this, the reader would be getting an
+        # ordinary ASCII path and the decode path under test never runs.
+        self.assertIn("\\377", self.fixture.raw_status())
+
+        files = detect_changed.changed_files_from_worktree()
+
+        self.assertEqual(len(files), 1, f"expected one changed file, got {files!r}")
+        flags = detect_changed.classify(files)
+        self.assertTrue(flags["web"])
+        self.assertFalse(flags["unknown"])
+
+    def test_worktree_rename_into_a_quoted_name_reports_the_destination(self):
+        self.fixture.write(PLAIN)
+        self.fixture.commit("add plain")
+        git(self.fixture.root, "mv", PLAIN, SPACED)
+
+        files = detect_changed.changed_files_from_worktree()
+
+        self.assertEqual(
+            files,
+            [SPACED],
+            "a rename reports where the file now is, not where it was",
         )
 
 


### PR DESCRIPTION
Closes #297.

## What was wrong

Git renders a path it considers unsafe as a C-quoted string — wrapped in double quotes, backslash escapes, non-ASCII as three-digit octal. Both readers in `detect_changed_surfaces.py` took that literally, so `apps/web/src/a b.tsx` arrived as `"apps/web/src/a b.tsx"`, matched no pattern, and classified as `unknown`.

Routing fails safe — `unknown` forces the full runtime recommendation — so nothing was ever under-gated and this has never been visible in CI. The cost is to the flag: #253 had just narrowed `unknown` so it could mean "no pattern claims this path", and every classified file sheltering under it makes that harder to tighten again.

## The issue's recommended fix is the wrong one, and measurably so

#297 recommends `core.quotePath=false`. Measured:

```
default          text=True OK     -> 'M "apps/web/src/bad\377.tsx"'
quotePath=false  text=True RAISES -> UnicodeDecodeError: byte 0xff in position 19
```

With the flag, git emits raw bytes and `subprocess.run(text=True)` raises. One non-UTF-8 filename anywhere in the worktree would take down `make quick-ci-changed` **entirely**, rather than misclassify a single path — trading a silent, fail-safe misrouting for a hard crash.

It is also not sufficient on its own. The issue assumes both readers quote the same inputs; they do not:

| reader | space | non-ASCII | with `quotePath=false` |
| --- | --- | --- | --- |
| `git status --porcelain` | **quoted** | quoted | space **still quoted**, non-ASCII literal |
| `git diff --name-only` | **not quoted** | quoted | both literal |

So an implementation following the issue body would have added the flag, skipped the unquoter where it looked unnecessary, and left the worktree reader — the one feeding `make quick-ci-changed`, which the issue itself calls the most degraded path — still broken for the commonest case of all, a filename with a space.

The fix therefore keeps git's default quoting, which is ASCII-safe by construction, and unquotes properly: octal escapes decoded to bytes, then UTF-8 with `surrogateescape`. Both the verifier and `code-review` reproduced all three measurements independently on their own scratch repositories.

`code-review` raised one alternative worth recording: `run_git` could pass `errors="surrogateescape"` to `subprocess.run`, which would defuse the crash and make the flag survivable. It still would not fix space quoting, so it only adds a second code path.

## Rename parsing

Splitting the raw payload on `" -> "` cuts a quoted name *containing* that sequence in half — `"apps/web/src/a -> b.tsx"` becomes `b.tsx"`. Reading the first token to its closing quote and looking for the separator after it cannot be fooled that way. The parse is unambiguous because `status --porcelain` quotes any path containing a space, so an unquoted token cannot contain the separator; `code-review` verified that property rather than assuming it, including both mixed quoted/unquoted rename shapes.

## Ordinary routing is unchanged

This file decides what CI runs for every change in the repository, so that was the check that mattered most. Verified byte-identical `--print-targets` and file lists against `main` over ranges up to the full ~340-commit history, plus an exhaustive cross-product of 15 realistic paths × 9 status codes × simple and rename forms — 0 mismatches.

## Coverage

`QuotedPathTests`, 9 tests, driving a **real temporary git repository** with `ROOT` rebound to it rather than patching `run_git`. The defect is in what git emits, so a fixture that fakes the output cannot exercise it — `tests/scripts/AGENTS.md` asks for the owning tool's own output where practical, and this is the case it describes.

**7 of the 9 fail against the unfixed script.** The two that do not were written after the fix, in response to review, and are demonstrated by mutation instead. (My first account of this said 5 of 8; the verifier built an isolated red-phase harness and corrected it.)

Mutations demonstrated: naive `" -> "` split, `core.quotePath=false`, octal decoded as decimal, and all four `_C_ESCAPES` mutations `code-review` found were invisible.

## A guard that was measuring nothing

`code-review` found the `_C_ESCAPES` table entirely unexercised — no fixture name contained a quote, a backslash or a control character, so four separate mutations to it left all 27 tests green. The one that bites: dropping the table decodes `"apps/web/src/ta\tb.tsx"` to `apps/web/src/tatb.tsx`, silently rewriting a path in the file that routes all of CI. Closed with a fixture named `apps/web/src/qu"o\tte\back.tsx`; all four mutations now fail, verified independently.

It also caught that `\377` in a *non-raw* docstring is a valid octal escape, so the rendered `__doc__` contained a literal `ÿ` — a sentence arguing that git's default keeps the stream ASCII-safe, demonstrating the opposite. No `SyntaxWarning` fires precisely because the escape is valid.

## Why a runbook change is in this diff

`tests/scripts/AGENTS.md` gains a section on how mutation demonstrations lie in this suite. It is here rather than in its own change because this change's entire evidence *is* mutation demonstrations, and both failure modes bit while producing it:

- A constant-flip mutation changes neither mtime nor size, so restoring from a backup within the same second leaves the stale `.pyc` considered current. `grep` showed the original constant while the suite failed decoding through the mutated table — indistinguishable from a mutation that will not revert.
- A `sed` whose pattern never matched leaves every test green, which is indistinguishable from an assertion that catches nothing.

The verifier hit the second one independently while checking this change, before reading the note, and caught it the way the note recommends. It also judged the inclusion in scope rather than creep.

## Verification

`make test-scripts` 215/215 and `make docs-check`, each run twice with stable results. `code-review` returned **no defects**.

## Filed rather than fixed

- **#341** — `changed_files_from_range` strips whitespace from paths. Since `git diff --name-only` does not quote spaces, a file named `docker-compose.yml ` classifies as `docker-compose.yml` — failing toward a real surface's routing, where the rest of this module deliberately fails toward `unknown`.
- Untracked-directory collapse: `git status --porcelain` reports `?? apps/` for a new directory, so files under it never reach `classify` individually. Exposing them needs `-uall` and would reclassify things, so it is its own decision — recorded on #297 and confirmed fail-safe by `code-review`.
