### PR TITLE
fix(web): announce a failed contact submission and keep focus

### DIFF
--- a/apps/web/e2e/contact-error.spec.ts
+++ b/apps/web/e2e/contact-error.spec.ts
@@ -1,0 +1,296 @@
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * A failed contact submission has to reach the person who made it.
+ *
+ * Measured on the build before this guard, at 390x844 with `/api/contact`
+ * forced to 500: the error rendered as a plain `<p>`, the page contained
+ * **zero** elements with `role="alert"`, and `document.activeElement` was
+ * `BODY`. So the failure was neither announced nor reachable — a screen reader
+ * was told nothing, and a keyboard user was returned to the top of the document
+ * at the moment the form reported a problem (#326).
+ *
+ * Every query for the region is scoped to the `<form>`, because there are two
+ * alerts on this page and only one of them is visible to an in-page audit.
+ * Next renders `<next-route-announcer>` with a **shadow root** containing
+ * `<div role="alert" aria-live="assertive" id="__next-route-announcer__">`.
+ * `document.querySelectorAll('[role="alert"]')` reports 1 — it does not pierce
+ * shadow DOM — while Playwright's role engine does, reports 2, and fails an
+ * unscoped `getByRole('alert')` on strict mode. Both counts are correct; they
+ * are answers to different questions, which is worth knowing before concluding
+ * from a console one-liner that the scoping is unnecessary.
+ *
+ * That is the ambiguity `chat.tsx` avoids by not adding a second
+ * `role="status"`. Here the second element is Next's rather than ours, so
+ * scoping is the answer rather than dropping the role.
+ *
+ * The focus half of that is guarded here rather than in `contact-form.test.tsx`
+ * for a concrete reason: a jsdom version of it passed with the fix removed
+ * entirely, because disabling the focused button does not blur it under jsdom.
+ * The defect cannot occur there, so the assertion measured nothing. A real
+ * browser blurs, which is the only place this can be checked.
+ */
+
+const PHONE = { width: 390, height: 844 }
+const SERVER_ERROR = 'Measured server error'
+
+async function fillAndFail(page: Page) {
+  await page.route('**/api/contact', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: SERVER_ERROR }),
+    }),
+  )
+  await page.setViewportSize(PHONE)
+  await page.goto('/contact', { waitUntil: 'networkidle' })
+  await page.getByLabel('Name').fill('Ada')
+  await page.getByLabel('Email').fill('ada@example.test')
+  await page.getByLabel('Subject').fill('Support')
+  await page.getByLabel(/message/i).fill('The order never arrived.')
+}
+
+test.describe('a failed contact submission', () => {
+  test('is announced through a region that was already there', async ({ page }) => {
+    await fillAndFail(page)
+
+    // The region has to exist before the content arrives. A live region that
+    // appears at the same moment as its text is not reliably announced, so an
+    // alert that only renders on failure is a fix that does not work.
+    const alert = page.locator('form').getByRole('alert')
+    await expect(alert).toBeAttached()
+    expect(
+      (await alert.textContent())?.trim(),
+      'the region should be empty before a submission fails',
+    ).toBe('')
+
+    await page.getByRole('button', { name: /send message/i }).click()
+
+    await expect(alert).toHaveText(SERVER_ERROR)
+
+    // The announced node and the visible node are the same element, so they
+    // cannot drift apart the way an sr-only copy beside a visible one can.
+    const sameNode = await page.evaluate((message) => {
+      const region = document.querySelector('form [role="alert"]')
+      const visible = [...document.querySelectorAll('p')].find(
+        (p) => p.textContent?.trim() === message,
+      )
+      return region !== null && region === visible
+    }, SERVER_ERROR)
+    expect(sameNode, 'the visible error is a different node from the announced one').toBe(true)
+  })
+
+  test('leaves focus on the control that was pressed', async ({ page }) => {
+    await fillAndFail(page)
+
+    const submit = page.getByRole('button', { name: /send message/i })
+    await submit.focus()
+    await submit.click()
+    await expect(page.locator('form').getByRole('alert')).toHaveText(SERVER_ERROR)
+
+    const landed = await page.evaluate(() => {
+      const active = document.activeElement as HTMLElement | null
+      return {
+        tag: active?.tagName ?? 'none',
+        label: (active?.textContent ?? '').trim().slice(0, 20),
+        isBody: active === document.body,
+      }
+    })
+
+    expect(
+      landed.isBody,
+      'focus was dumped to the document body when the submission failed',
+    ).toBe(false)
+    expect(landed.tag).toBe('BUTTON')
+    expect(landed.label).toContain('Send Message')
+  })
+
+  test('leaves focus alone when submitting from a field, where it was never lost', async ({ page }) => {
+    // Only the submit button is disabled while a request is in flight, so an
+    // implicit submit -- Enter from a text field -- never loses focus. Moving
+    // it to the button anyway would take someone out of the field they were
+    // typing in, and would put a focus change in the same tick as an assertive
+    // announcement for no gain. This is the path the click test cannot see.
+    await fillAndFail(page)
+
+    await page.getByLabel('Subject').focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('form').getByRole('alert')).toHaveText(SERVER_ERROR)
+
+    const landed = await page.evaluate(() => {
+      const active = document.activeElement as HTMLElement | null
+      return { tag: active?.tagName ?? 'none', id: active?.id ?? '' }
+    })
+
+    expect(landed.tag, 'the failure moved focus off the field being typed in').toBe('INPUT')
+    expect(landed.id).toBe('subject')
+  })
+
+  test('announces a second identical failure as well as the first', async ({ page }) => {
+    // A live region announces a *change*. Submitting twice and failing the same
+    // way both times produces the same string, so without the `setError("")`
+    // reset at the top of the handler the second failure writes an identical
+    // value, mutates nothing, and is never spoken. That reset reads like
+    // redundant tidying; this is what makes removing it fail.
+    await fillAndFail(page)
+    const alert = page.locator('form').getByRole('alert')
+    const submit = page.getByRole('button', { name: /send message/i })
+
+    await page.evaluate(() => {
+      const region = document.querySelector('form [role="alert"]')!
+      const seen: string[] = []
+      ;(window as unknown as { __alertLog: string[] }).__alertLog = seen
+      new MutationObserver(() => seen.push((region.textContent ?? '').trim())).observe(region, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      })
+    })
+
+    await submit.click()
+    await expect(alert).toHaveText(SERVER_ERROR)
+    await submit.click()
+    await expect(alert).toHaveText(SERVER_ERROR)
+
+    const log = await page.evaluate(
+      () => (window as unknown as { __alertLog: string[] }).__alertLog,
+    )
+    // The empty string between the two identical messages is the whole point:
+    // it is the transition the second announcement depends on.
+    expect(log.filter((entry) => entry === SERVER_ERROR).length).toBeGreaterThanOrEqual(2)
+    expect(log, 'no empty state between the two failures, so the second is silent').toContain('')
+  })
+
+  test('the error text meets AA against the card it is printed on', async ({ page }) => {
+    // The card is `bg-white/90` over a photograph, so its computed
+    // `backgroundColor` is not what is on screen -- the effective surface is
+    // about rgb(234,234,233). `text-red-600` measures 4.77:1 on white and
+    // 3.96-4.02:1 there, failing AA for 14px text. Nothing else in this file
+    // would notice that token changing back.
+    //
+    // Pixels rather than the class, following `e2e/support/boundary.ts`: this
+    // repository has a written history of colour assertions that credited what
+    // CSS was asked for rather than what was painted.
+    await fillAndFail(page)
+    await page.getByRole('button', { name: /send message/i }).click()
+    const alert = page.locator('form').getByRole('alert')
+    await expect(alert).toHaveText(SERVER_ERROR)
+
+    const shot = (await alert.screenshot()).toString('base64')
+    const measured = await page.evaluate(async (encoded) => {
+      const image = new Image()
+      image.src = `data:image/png;base64,${encoded}`
+      await image.decode()
+      const canvas = document.createElement('canvas')
+      canvas.width = image.width
+      canvas.height = image.height
+      const context = canvas.getContext('2d')!
+      context.drawImage(image, 0, 0)
+      const data = context.getImageData(0, 0, canvas.width, canvas.height).data
+
+      const counts = new Map<string, number>()
+      for (let i = 0; i < data.length; i += 4) {
+        const key = `${data[i]},${data[i + 1]},${data[i + 2]}`
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+      const luminance = ([r, g, b]: number[]) => {
+        const channel = (value: number) => {
+          const v = value / 255
+          return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+      }
+      // Frequency alone picks the wrong pixel: where the message wraps to three
+      // lines the glyph colour is the most common one in the crop. Take the
+      // darkest and lightest colours that appear often enough to be real.
+      const frequent = [...counts.entries()]
+        .map(([key, n]) => [key.split(',').map(Number), n] as [number[], number])
+        .filter(([, n]) => n > 20)
+        .sort((a, b) => luminance(a[0]) - luminance(b[0]))
+      if (frequent.length < 2) return null
+      const glyph = frequent[0][0]
+      const background = frequent[frequent.length - 1][0]
+      const [high, low] = [luminance(glyph), luminance(background)].sort((a, b) => b - a)
+      return {
+        glyph,
+        background,
+        ratio: (high + 0.05) / (low + 0.05),
+        distinctColours: frequent.length,
+      }
+    }, shot)
+
+    expect(measured, 'the rendered error produced too few distinct colours to sample').not.toBeNull()
+    // Vacuity: an empty or single-colour crop would give a ratio of 1 and no
+    // glyph to measure, which is a broken sample rather than a failing colour.
+    expect(measured!.distinctColours).toBeGreaterThan(2)
+    expect(
+      measured!.ratio,
+      `error text ${measured!.glyph} on ${measured!.background} is below WCAG AA for 14px text`,
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('the always-present region costs no layout while it is empty', async ({ page }) => {
+    // The region is rendered even when idle, which is what makes the
+    // announcement work, and that has to cost nothing -- anything growing here
+    // pushes the page's primary action further below the fold (#286, #339).
+    //
+    // What this pins is the invariance, not a mechanism. The invariance comes
+    // from margin collapsing through a zero-height block; an earlier version of
+    // the component carried an `empty:mt-0` to force it, and this test passed
+    // identically with that class present and absent, because the class was
+    // inert -- Tailwind v4's `space-y-6` sets `margin-bottom`, not
+    // `margin-top`. The mutation is what established that; the assertion below
+    // cannot tell the two apart and is not meant to.
+    //
+    // Differential rather than absolute: it removes the region and re-measures,
+    // so it stays true when the form gains a field.
+    await page.setViewportSize(PHONE)
+    await page.goto('/contact', { waitUntil: 'networkidle' })
+
+    const measured = await page.evaluate(() => {
+      const submit = [...document.querySelectorAll('button')].find(
+        (b) => (b.textContent ?? '').trim() === 'Send Message',
+      )
+      const region = document.querySelector('form [role="alert"]') as HTMLElement | null
+      if (!submit || !region) return null
+
+      // Read before detaching. A computed style read from a removed element
+      // returns empty strings, which would pass a `toBe("0px")` check for the
+      // wrong reason if the assertion were written the other way round.
+      const marginTop = getComputedStyle(region).marginTop
+      const height = Math.round(region.getBoundingClientRect().height)
+      const text = (region.textContent ?? '').trim()
+
+      const withRegion = {
+        submitTop: Math.round(submit.getBoundingClientRect().top),
+        doc: document.documentElement.scrollHeight,
+      }
+      region.remove()
+      void document.body.offsetHeight
+      const withoutRegion = {
+        submitTop: Math.round(submit.getBoundingClientRect().top),
+        doc: document.documentElement.scrollHeight,
+      }
+      return { withRegion, withoutRegion, height, marginTop, text }
+    })
+
+    expect(measured, 'the submit button or the alert region was not found').not.toBeNull()
+    // Vacuity: with text in it the region is supposed to take space, so this
+    // only means anything while it is empty.
+    expect(measured!.text, 'the region already had content, so this measured a filled one').toBe('')
+    // Height, not margin. Tailwind v4's `space-y-6` sets `margin-block-end`,
+    // so `margin-top` reads 0px for every non-last child of this form whatever
+    // the region contains -- an assertion on it passes identically on a filled
+    // region taking 20px of content, which is the state it claims to reject.
+    // Zero height is what makes the margins collapse, and it fails the moment
+    // someone adds a `min-h-5` like `avatar-upload.tsx` carries.
+    expect(measured!.height, 'the empty region occupies vertical space').toBe(0)
+    expect(
+      measured!.withRegion.submitTop,
+      'the empty region pushed the submit button down',
+    ).toBe(measured!.withoutRegion.submitTop)
+    expect(measured!.withRegion.doc, 'the empty region made the document taller').toBe(
+      measured!.withoutRegion.doc,
+    )
+  })
+})

--- a/apps/web/src/components/contact-form.test.tsx
+++ b/apps/web/src/components/contact-form.test.tsx
@@ -16,6 +16,15 @@ describe('ContactForm', () => {
     global.fetch = vi.fn()
   })
 
+  // Required fields have to be filled or the submit never reaches the handler,
+  // and every assertion below would read an empty region for the wrong reason.
+  const fillRequiredFields = () => {
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'John Doe' } })
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'john@example.com' } })
+    fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'Support' } })
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Help me!' } })
+  }
+
   it('renders all form fields', () => {
     render(<ContactForm />)
     expect(screen.getByLabelText(/name/i)).toBeDefined()
@@ -41,6 +50,110 @@ describe('ContactForm', () => {
     // HTML5 validation would prevent this in a real browser, 
     // but we can check if fetch was NOT called
     expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('keeps the error region in the document before there is an error to put in it', () => {
+    render(<ContactForm />)
+
+    // A live region that appears at the same moment as its content is not
+    // reliably announced -- the region has to be there first for the change to
+    // be a change. `avatar-upload.tsx` records the same reasoning.
+    const region = screen.getByRole('alert')
+    expect(region.textContent).toBe('')
+  })
+
+  it('announces a failed submission through that region', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'Failed to submit contact inquiry.' }),
+    } as any)
+
+    render(<ContactForm />)
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('Failed to submit contact inquiry.')
+    })
+    // The visible text and the announced text are the same node, so they cannot
+    // drift apart -- not an sr-only copy alongside a separate visible one.
+    expect(screen.getByText('Failed to submit contact inquiry.')).toBe(screen.getByRole('alert'))
+  })
+
+  it('reports an HTTP error response with a JSON body', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: 'Failed to submit contact inquiry.' }),
+    } as any)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<ContactForm />)
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).not.toBe('')
+    })
+    // `response.ok === false` takes the else branch, so a log placed only in
+    // `catch` covers network and parse failures and silently misses every 5xx
+    // -- which is the one failure an operator is most likely to be asked about.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Contact form'),
+      expect.objectContaining({ status: 500 }),
+    )
+    consoleError.mockRestore()
+  })
+
+  it('still reports the status when the error body is not JSON', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON')
+      },
+    } as any)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<ContactForm />)
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).not.toBe('')
+    })
+    // An infrastructure error page is the likeliest production 5xx, and its
+    // body does not parse. Logging after the parse loses the status for
+    // exactly that case, leaving an operator with a SyntaxError and no code.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Contact form'),
+      expect.objectContaining({ status: 502 }),
+    )
+    consoleError.mockRestore()
+  })
+
+  // Focus after a failed submission is guarded in `e2e/contact-error.spec.ts`,
+  // not here. A jsdom version of it passed with the fix removed entirely:
+  // disabling the focused button does not blur it under jsdom, so the defect
+  // this is about cannot occur and the assertion measures nothing. The real
+  // browser does blur, which is where the guard belongs.
+
+  it('reports the error it caught rather than discarding it', async () => {
+    const thrown = new Error('network is down')
+    vi.mocked(global.fetch).mockRejectedValue(thrown)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<ContactForm />)
+    fillRequiredFields()
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).not.toBe('')
+    })
+    // The user-facing string is a constant, so without this the difference
+    // between a network failure, a parse failure and a 500 is unrecoverable.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Contact form'), thrown)
+    consoleError.mockRestore()
   })
 
   it('submits correctly and redirects on success', async () => {

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ACTION_BOUNDARY, FIELD_BOUNDARY } from "@/lib/control-classes";
 
@@ -14,7 +14,22 @@ export default function ContactForm() {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const submitRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
+
+  // `isSubmitting` disables the submit button, and disabling the focused
+  // element blurs it -- so after a click-submit the person is on `<body>` at
+  // the top of the document when the failure lands. This puts them back.
+  //
+  // Guarded on the loss having happened, not on the failure. Only the button is
+  // disabled, so submitting with Enter from a text field never loses focus, and
+  // moving it there would take someone out of the field they were typing in --
+  // a focus change racing an assertive announcement for no gain.
+  useEffect(() => {
+    if (error && !isSubmitting && document.activeElement === document.body) {
+      submitRef.current?.focus();
+    }
+  }, [error, isSubmitting]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -26,6 +41,10 @@ export default function ContactForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
+    // Load-bearing beyond clearing stale text: a live region only announces
+    // a *change*, so two consecutive failures with the same message need the
+    // empty state between them or the second one is silent. Removing this as
+    // redundant would break re-announcement without failing anything obvious.
     setError("");
 
     try {
@@ -40,10 +59,23 @@ export default function ContactForm() {
       if (response.ok) {
         router.push("/contact/thanks");
       } else {
-        const data = await response.json();
-        setError(data.message || "Failed to send message. Please try again.");
+        // Before the parse: an error body that is not JSON -- an
+        // infrastructure error page, the likeliest production 5xx -- makes
+        // `response.json()` throw into the catch below, and the status is the
+        // one thing an operator needs. Logging after the parse loses it for
+        // exactly that case.
+        console.error("Contact form submission failed", { status: response.status });
+        const data = await response.json().catch(() => null);
+        setError(data?.message || "Failed to send message. Please try again.");
       }
     } catch (err) {
+      // Network failures, and any error whose body is unreadable. An HTTP
+      // error response is reported by the `else` above, which now runs before
+      // the parse, so a 502 serving HTML is logged with its status there and
+      // arrives here only as the parse failure. The user-facing string is a
+      // constant, so between them these two logs are the only record of which
+      // failure actually happened.
+      console.error("Contact form submission failed", err);
       setError("An unexpected error occurred. Please try again later.");
     } finally {
       setIsSubmitting(false);
@@ -152,11 +184,52 @@ export default function ContactForm() {
         ></textarea>
       </div>
 
-      {error && <p className="text-red-600 text-sm font-medium">{error}</p>}
+      {/*
+        Always rendered, empty when idle. A live region that appears at the same
+        moment as its content is not reliably announced -- the region has to be
+        there first for the change to be a change, which is the same reasoning
+        `avatar-upload.tsx` records for its status line.
+
+        `role="alert"` rather than `aria-live` alone: a failed submission is the
+        assertive case. It is not the only alert on the page, though -- Next
+        renders a route announcer with `role="alert"` inside a shadow root, so
+        `getByRole('alert')` finds two and tests have to scope to the form.
+        `e2e/contact-error.spec.ts` records the measurement.
+
+        Also referenced by the submit button's `aria-describedby`. Some screen
+        readers flush the speech queue on a focus change, which can clip an
+        assertive announcement -- and this component moves focus in the same
+        tick. The description does not depend on the live region surviving
+        that: whoever lands on the button hears why it failed either way.
+
+        Costs no layout while empty, which matters because anything that grows
+        here pushes the page's primary action further below the fold (#286,
+        #339). That is margin collapsing rather than anything declared: the
+        node is `display: block` with `height: 0`, so its margins collapse
+        through it and with its neighbour's. Measured at 390x844, the submit
+        button sits at y=796 whether this node is present or removed.
+
+        `text-red-700`, not `red-600`. The card is `bg-white/90` over a
+        photograph, so the effective background is about rgb(234,234,233)
+        rather than white -- and red-600, which measures 4.77:1 on white,
+        drops to 3.96-4.02:1 there and fails AA for 14px text. red-700
+        measures 5.33:1 against the same sampled pixels.
+
+        An earlier version carried `empty:mt-0` to force that. It was inert --
+        Tailwind v4's `space-y-6` sets `margin-bottom` on non-last children,
+        not `margin-top`, so the class targeted a margin nothing had ever set.
+        Removing it changes no measurement. `e2e/contact-error.spec.ts` pins
+        the invariance itself rather than the mechanism.
+      */}
+      <p id="contact-form-error" role="alert" className="text-red-700 text-sm font-medium">
+        {error}
+      </p>
 
       <button
+        ref={submitRef}
         type="submit"
         disabled={isSubmitting}
+        aria-describedby={error ? "contact-form-error" : undefined}
         className={`w-full flex justify-center rounded-lg bg-indigo-600 px-4 py-4 text-sm font-bold text-white shadow-lg hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-indigo-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed ${ACTION_BOUNDARY}`}
       >
         {isSubmitting ? "Sending..." : "Send Message"}


### PR DESCRIPTION
Closes #326 and #338.

## What was wrong

Measured on `main`'s build at 390x844 with `/api/contact` forced to 500:

```
error node    <p class="text-red-600 ...">   role: null, aria-live: null
alerts in form  0
activeElement   BODY
```

So a failed submission was neither announced to assistive technology nor left focus anywhere useful. `isSubmitting` disables the submit button, and disabling the focused element blurs it — a keyboard user was returned to the top of the document at the moment the form reported a problem.

## The fix

- The error paragraph is **always rendered, empty when idle**, with `role="alert"`. It has to exist before its content — a live region that appears at the same moment as its text is not reliably announced, which is the reasoning `avatar-upload.tsx` already records.
- The submit button gains `aria-describedby` onto that region while an error shows. `ui-review` raised a risk neither of us could test here: some screen readers flush the speech queue on a focus change, and this component moves focus in the same tick. The description does not depend on the live region surviving that.
- Focus returns to the submit button, **gated on the loss having happened** (`document.activeElement === document.body`). Only the button is disabled, so an implicit submit — Enter from a text field — never loses focus, and restoring unconditionally took people out of the field they were typing in. Measured after the gate: click-submit lands on the button, Enter-in-Subject stays on `INPUT#subject`.
- `setError("")` at the top of the handler is load-bearing and now says so: a live region announces a *change*, so two consecutive failures with the same message need the empty state between them or the second is silent.
- **#338**: the caught error was discarded. Both branches now log, and the HTTP branch logs **before** parsing — a 502 serving an HTML error page makes `response.json()` throw, and the status is the one thing an operator needs for exactly that case.
- `text-red-600` -> `text-red-700`.

## On including the colour change

The card is `bg-white/90` over a photograph, so the effective background is about rgb(234,234,233), not white. `text-red-600` measures 4.77:1 on white and **3.96–4.02:1** there — failing AA for 14px text. `text-red-700` measures **5.30–5.36:1**, sampled from rendered pixels at 390, 834 and 1440.

It is a colour change in a change about announcements, and it belongs here: an announcement whose visible text fails AA is half a fix. `code-review` agreed with the scope call, and with #338 riding along, since it is one line inside the block #326 rewrites.

## Three guards exist because a mutation showed the obvious version measured nothing

This is the part worth reading.

1. **An inert class, shipped with a comment explaining why it was essential.** The region carried `empty:mt-0` to stop `space-y-6` adding 24px above the submit button. Mutating it away changed nothing: Tailwind v4's `space-y-6` sets `margin-bottom` on non-last children, not `margin-top`, so the class targeted a margin nothing had set. The zero layout cost is margins collapsing through a zero-height block. The spec now asserts `height === 0` — the `marginTop === '0px'` assertion it replaced passed identically on a *filled* region taking 20px of content, which is the state its own failure message claimed to reject.

2. **A jsdom test that could not fail.** A focus assertion in `contact-form.test.tsx` passed with the focus restoration removed entirely, because jsdom does not blur a disabled element — so the defect cannot occur there. Deleted, with the reason kept in the unit file, and guarded in the browser instead. The verifier confirmed jsdom's behaviour independently.

3. **The colour had no guard at all.** Reverting the token left every check in this change green. There is now a pixel-sampled AA assertion, following `e2e/support/boundary.ts` rather than reading a class; reverting the token fails it with `error text 231,0,11 on 243,240,240 is below WCAG AA`.

## A disputed finding, checked rather than complied with

`ui-review` reported that `#__next-route-announcer__` does not exist, that `/contact` has exactly one `role="alert"`, and that scoping the spec's queries to the `<form>` was unnecessary defensiveness.

It lives in a **shadow root**:

```
document.querySelectorAll('[role="alert"]')  -> 1   (does not pierce shadow DOM)
page.getByRole('alert').count()              -> 2   (Playwright's engine does)
unscoped getByRole('alert')                  -> strict mode violation, today
page.locator('form').getByRole('alert')      -> 1
```

Both original measurements were correct; they answer different questions. The verifier reproduced this and confirmed the spec's comment is accurate. Recorded because a maintainer checking with a console one-liner would find one element and reasonably conclude the scoping is dead code.

## Coverage

6 rendered tests in `apps/web/e2e/contact-error.spec.ts`, 5 unit tests in `contact-form.test.tsx`.

Red phase: all 6 rendered tests fail against `main`'s component, rebuilt and served. Mutations demonstrated for the colour token, the region height, the focus gate, the `setError("")` reset, the role, and both log branches — each rebuilt and confirmed served by a marker that distinguishes the mutation from the original.

That last detail is not incidental. One earlier mutation appeared to leave everything passing and had simply never been served, because the readiness poll waited on a string present in *both* builds.

## Verification

`make -C apps/web ci` passes (lint, both type-checks, 180 unit tests, production build). Full journey suite **149 passed**. Merges cleanly onto `origin/main`. `code-review` returned **no defects**.

## Filed rather than fixed

- **#343** — the submit button blurs to `<body>` for the whole in-flight window. This change repairs the end of that window, not the window. The suggested fix (`aria-disabled` plus a guard) would remove the need for the focus effect entirely.
- **#344** — `POST /api/contact` accepts an empty body and an invalid email and reports success. That bounds what this guard proves: the error path renders and announces correctly, not that any real submission can reach it. Every failure here is injected.
- **#235** — added a measurement: the focus ring animates through CSS initial values (`3px`/`currentcolor`), which is 1px looser than the settled ring and in the direction that lets a defect through.
